### PR TITLE
chore: add Claude branch protection hook

### DIFF
--- a/.claude/hooks/enforce-branch-creation.sh
+++ b/.claude/hooks/enforce-branch-creation.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+CURRENT_BRANCH=$(cd "$CLAUDE_PROJECT_DIR" && git rev-parse --abbrev-ref HEAD)
+PROTECTED_BRANCHES=("main" "master" "develop")
+
+for branch in "${PROTECTED_BRANCHES[@]}"; do
+  if [ "$CURRENT_BRANCH" = "$branch" ]; then
+    echo "Cannot make changes on '$CURRENT_BRANCH' branch. Please create a new branch first." >&2
+    exit 2
+  fi
+done
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-branch-creation.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds the org-standard Claude hook that blocks file edits on protected branches (main, master, develop)
- Matches the existing hook in `mpimedia/.github`

## Changes Made

- **`.claude/hooks/enforce-branch-creation.sh`** — Pre-tool-use hook that checks current branch and blocks Write/Edit on protected branches
- **`.claude/settings.json`** — Hook configuration matching the org standard

## Test plan

- [ ] Verify Claude is blocked from editing files when on `main`
- [ ] Verify Claude can edit files on feature branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)