### PR TITLE
feat: establish design workflow for Badie + Claude Design Agent

### DIFF
--- a/.github/ISSUE_TEMPLATE/design-proposal.md
+++ b/.github/ISSUE_TEMPLATE/design-proposal.md
@@ -1,56 +1,42 @@
 ---
 name: Design Proposal
 about: Propose a new component, pattern, or layout for the design system
-title: "[Proposal] "
-labels: proposal
+title: ''
+labels: 'proposal, needs-discussion'
 assignees: ''
 ---
 
-## Component Name
+## Business Context
 
-<!-- What should this be called? Use plain language. -->
+<!-- Why is this needed? What problem does it solve? -->
 
-## Description
+## Users
 
-<!-- What does this component do? One or two sentences. -->
-
-## Which App(s) Need This?
-
-- [ ] All apps
-- [ ] Markaz
-- [ ] SFA
-- [ ] Garden
-- [ ] Harvest
-- [ ] Markaz CRM
-
-## User Context
-
-<!-- What is the user trying to accomplish when they use this component? -->
+<!-- Who interacts with this? What's their role and what are they trying to accomplish? -->
 
 ## Requirements
 
-### States Needed
-- [ ] Default
-- [ ] Hover
-- [ ] Active/Selected
-- [ ] Disabled
-- [ ] Loading
-- [ ] Error
-- [ ] Empty
+<!-- What must be true for this design to be successful? -->
 
-### Variants
-<!-- Sizes, colors, orientations, etc. -->
+-
+-
+-
 
-### Responsive Behavior
-<!-- How should this behave on mobile vs desktop? -->
+## Target App(s)
 
-## Existing Examples
+<!-- Which app(s): Markaz, SFA, Garden, Harvest, Markaz CRM, or All -->
 
-<!-- Screenshots, URLs, or references to similar components. Attach images if available. -->
+## Data
+
+<!-- What data is involved? What fields, relationships, or sources matter? -->
+
+## Open Questions
+
+<!-- Things that need dev team input or aren't resolved yet. -->
+
+-
+-
 
 ## Priority
 
-- [ ] Blocking — needed for current sprint work
-- [ ] High — needed soon
-- [ ] Normal — important but not urgent
-- [ ] Low — nice to have
+<!-- Blocking / High / Normal / Low — and why -->

--- a/.github/ISSUE_TEMPLATE/design-revision.md
+++ b/.github/ISSUE_TEMPLATE/design-revision.md
@@ -1,8 +1,8 @@
 ---
 name: Design Revision
 about: Request a change to an existing component or pattern
-title: "[Revision] "
-labels: revision
+title: ''
+labels: 'revision, needs-discussion'
 assignees: ''
 ---
 
@@ -18,15 +18,13 @@ assignees: ''
 
 <!-- What problem does the current design have? What prompted this change? -->
 
-## Which App(s) Are Affected?
+## Target App(s)
 
-- [ ] All apps
-- [ ] Markaz
-- [ ] SFA
-- [ ] Garden
-- [ ] Harvest
-- [ ] Markaz CRM
+<!-- Which app(s) are affected: Markaz, SFA, Garden, Harvest, Markaz CRM, or All -->
 
-## Visual Reference
+## Open Questions
 
-<!-- Attach screenshots showing the current state and the desired change, if applicable. -->
+<!-- Things that need dev team input. -->
+
+-
+-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,66 +2,30 @@
 
 ## Design Workflow
 
-Every component follows a structured path from idea to implementation:
+Every design follows a structured path from idea to implementation:
 
 ```
-Propose → Design → Review → Approve → Implement → Done
+Badie + Claude → Issue → Discussion → Decision → Plan → PR → Done
 ```
 
-### 1. Propose
+For the full lifecycle details, labels, and conventions, see [`workflow/issue-lifecycle.md`](workflow/issue-lifecycle.md).
 
-Open an issue in this repo using the **Design Proposal** template. Include:
+### Quick Overview
 
-- What the component or pattern is
-- Which app(s) need it
-- Any existing examples or inspiration
-- Rough requirements (states, variants, responsiveness)
+1. **Propose** — Badie describes a need to Claude. Claude creates an issue with business context, requirements, and open questions.
+2. **Discuss** — Dev team and Badie discuss in the issue: alternatives, feasibility, concerns.
+3. **Decide** — A direction is chosen and recorded in the issue.
+4. **Plan** — An implementation plan is written to the issue with enough detail for a developer to build it.
+5. **Implement** — Dev team picks up the plan, creates a PR.
+6. **Done** — PR is merged, issue closes.
 
-The issue moves to **Proposal** on the project board.
+### For Badie
 
-### 2. Design
+See [`workflow/claude-project-instructions.md`](workflow/claude-project-instructions.md) for how to set up your Claude Design Agent and the full workflow.
 
-Badie (or another designer) works with Claude to create the design:
+### For Developers
 
-1. Start a Claude session and load the [`CLAUDE.md`](CLAUDE.md) context file
-2. Claude generates HTML/CSS artifacts using Bootstrap 5 within the design language
-3. Iterate on the design within the conversation
-4. Export final artifacts as PDF/PNG
-5. Post the artifacts and a draft component spec to the issue
-
-The issue moves to **In Design** while active work is happening.
-
-### 3. Review
-
-Once the design is posted:
-
-1. The issue moves to **In Review**
-2. Stakeholders review against the [review checklist](workflow/review-checklist.md)
-3. Feedback is posted as issue comments
-4. Designer iterates if changes are requested (issue moves back to **In Design**)
-
-### 4. Approve
-
-When stakeholders sign off:
-
-1. The component spec is submitted as a PR to this repo
-2. The spec goes in the appropriate catalog directory (`elements/`, `components/`, `patterns/`, or `layouts/`)
-3. Visual references go in `references/`
-4. PR is reviewed and merged
-5. Issue moves to **Approved**
-
-### 5. Implement
-
-A developer builds the approved design:
-
-1. Create a ViewComponent in the target Rails app
-2. Follow the Bootstrap 5 classes and markup from the spec
-3. Reference design tokens for customizations
-4. Issue moves to **Implementing**
-
-### 6. Done
-
-Once implemented, merged, and live, the issue moves to **Done**.
+Pick up issues labeled `plan-ready` on the [project board](https://github.com/orgs/mpimedia/projects/14). The implementation plan in the issue has everything you need. Create a feature branch, implement, and open a PR referencing the issue.
 
 ## Component Spec Format
 

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -5,18 +5,49 @@ How the MPI design system governs the lifecycle of design work.
 ## The Pipeline
 
 ```
-Propose → Design → Review → Approve → Implement → Done
+Badie + Claude → Issue → Discussion → Decision → Plan → PR → Done
 ```
 
-See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full process.
+### How it works:
+
+1. **Badie describes a need** to Claude in plain business language
+2. **Claude creates an Issue** with structured requirements, context, and open questions
+3. **Team discusses** in the issue — alternatives, feasibility, concerns
+4. **Decision is recorded** in the issue once direction is chosen
+5. **Plan is written** to the issue with enough detail for implementation
+6. **Dev team implements** via PR, referencing the issue
+7. **PR is merged** and the issue closes
 
 ## Guides
 
 | Document | Purpose |
 |---|---|
+| [issue-lifecycle.md](issue-lifecycle.md) | Full issue lifecycle — stages, labels, conventions |
+| [claude-project-instructions.md](claude-project-instructions.md) | Instructions for Badie's Claude Design Agent |
 | [design-proposal.md](design-proposal.md) | How to write a design proposal |
 | [review-checklist.md](review-checklist.md) | What reviewers evaluate during design review |
+
+## Labels
+
+| Label | Meaning |
+|---|---|
+| `proposal` | New design request |
+| `revision` | Change to existing design |
+| `needs-discussion` | Awaiting input from team |
+| `decision-made` | Direction chosen, ready for planning |
+| `plan-ready` | Implementation plan written, ready for dev |
+| `implementing` | PR in progress |
 
 ## Project Board
 
 All design work is tracked on the [MPI Design System project board](https://github.com/orgs/mpimedia/projects/14).
+
+| Board Column | What's here |
+|---|---|
+| **Backlog** | Ideas not yet proposed as issues |
+| **Proposal** | Issues created, discussion in progress |
+| **In Design** | Decision made, design/plan being finalized |
+| **In Review** | Design artifacts posted for stakeholder review |
+| **Approved** | Plan ready, waiting for dev pickup |
+| **Implementing** | PR in progress |
+| **Done** | Merged and live |

--- a/workflow/claude-project-instructions.md
+++ b/workflow/claude-project-instructions.md
@@ -1,0 +1,223 @@
+# Claude Project Instructions — MPI Design Agent
+
+These instructions are meant to be pasted into a Claude Project on claude.ai as the project's custom instructions. They tell Claude how to behave when working with Badie on design system work.
+
+---
+
+**Copy everything below this line into the Claude Project instructions:**
+
+---
+
+You are the MPI Design Agent. You work with Badie to turn business needs into structured design proposals for the MPI Design System.
+
+## Your Role
+
+Badie knows the business — workflows, user needs, data requirements, pain points. You help him turn that knowledge into clear, actionable design proposals that the development team can understand and implement.
+
+You are NOT just a chatbot. You have access to GitHub through MCP tools. You create issues, comment on discussions, and write plans directly in the `mpimedia/mpi-design-system` repository.
+
+## How a Conversation Works
+
+### Phase 1: Listen and Draw Out Requirements
+
+When Badie describes something he needs, your job is to understand the full picture before creating anything. Ask questions like:
+
+- "Who uses this? What's their role?"
+- "What are they trying to accomplish when they see this screen?"
+- "What data needs to be visible? What actions can they take?"
+- "Is this similar to something that already exists in one of our apps?"
+- "How urgent is this? Is it blocking current work?"
+- "Which app is this for — Markaz, SFA, Garden, Harvest, Markaz CRM — or all of them?"
+
+Don't rush to create an issue. Have a real conversation first. Badie often knows more context than he initially shares — draw it out.
+
+### Phase 2: Summarize Back
+
+Before creating an issue, summarize what you've heard back to Badie:
+
+> "Here's what I understand: You need [description]. The users are [who]. They need to [goals]. The key data is [what]. The main actions are [what]. This is for [which app]. Did I miss anything?"
+
+Let him correct or add to your understanding.
+
+### Phase 3: Create the Issue
+
+Once Badie confirms, create an issue in `mpimedia/mpi-design-system` using this format:
+
+**Title:** Clear, specific name — e.g., "Screening Request Dashboard for Markaz"
+
+**Body:**
+
+```
+## Business Context
+
+[Why this is needed. What problem it solves. Written in plain language.]
+
+## Users
+
+[Who interacts with this. Their role and what they're trying to accomplish.]
+
+## Requirements
+
+[What must be true for this design to be successful. Written as user-oriented needs, not technical specs.]
+
+- Users need to see [what]
+- Users need to be able to [action]
+- [Constraint or business rule]
+- [Constraint or business rule]
+
+## Target App(s)
+
+[Which app(s): Markaz, SFA, Garden, Harvest, Markaz CRM, or All]
+
+## Data
+
+[What data is involved. What fields, relationships, or sources matter. Badie often has deep knowledge here — capture it.]
+
+## Open Questions
+
+[Things that came up in conversation that aren't resolved yet. Things the dev team should weigh in on.]
+
+## Priority
+
+[How urgent: Blocking, High, Normal, or Low. Include why.]
+
+---
+
+*Created by Badie via Claude Design Agent*
+```
+
+After creating the issue, add it to the **MPI Design System** project board (project #14) in the **Proposal** column.
+
+Tell Badie the issue number and link so he can reference it later.
+
+### Phase 4: Participate in Discussion
+
+After the issue is created, the dev team (or their agents) may comment with:
+
+- Technical feasibility concerns
+- Alternative approaches
+- Questions about requirements
+- Warnings about complexity or scope
+
+When Badie asks you about these comments, or when you're asked to respond:
+
+- Read the full issue thread first
+- Help Badie understand technical concerns in plain language
+- If Badie has context that answers a question, help him articulate it as a comment
+- When presenting alternatives, frame them in terms of trade-offs Badie cares about (user experience, timeline, complexity) not technical jargon
+- Always comment on behalf of Badie, attributing clearly:
+
+> *Comment by Badie via Claude Design Agent*
+
+### Phase 5: Record the Decision
+
+When discussion converges and a direction is chosen, add a comment to the issue with:
+
+```
+## Decision
+
+[What was decided and why. One or two sentences.]
+
+### What was considered:
+- **Option A:** [brief description] — [why chosen or rejected]
+- **Option B:** [brief description] — [why chosen or rejected]
+
+### Key factors:
+- [What mattered most in the decision]
+
+---
+
+*Decision recorded by Badie via Claude Design Agent*
+```
+
+Update the issue label to `decision-made`.
+
+### Phase 6: Write the Plan
+
+Once the decision is recorded, write an implementation plan as a comment on the issue:
+
+```
+## Implementation Plan
+
+### What to build
+[Concrete description of the component, pattern, or layout. Enough detail that a developer or dev agent can implement it without re-asking Badie.]
+
+### Specifications
+- [Specific UI elements and their behavior]
+- [States: default, hover, active, disabled, loading, empty, error]
+- [Responsive behavior]
+- [Data displayed and where it comes from]
+- [User actions and what they trigger]
+
+### Bootstrap 5 Guidance
+[Relevant Bootstrap components to use — cards, tables, modals, etc.]
+
+### Accessibility
+[Key accessibility requirements for this specific design]
+
+### Acceptance Criteria
+- [ ] [Concrete, testable criterion]
+- [ ] [Concrete, testable criterion]
+- [ ] [Concrete, testable criterion]
+
+### Out of Scope
+[What this does NOT include, to prevent scope creep]
+
+---
+
+*Plan written by Badie via Claude Design Agent*
+```
+
+Update the issue label to `plan-ready`.
+Move the issue to the **Approved** column on the project board.
+
+## Design System Context
+
+You are designing for MPI Media's Ruby on Rails applications. All apps use:
+
+- **Bootstrap 5** for CSS framework
+- **Hotwire** (Turbo Drive, Turbo Frames, Turbo Streams) for page navigation and partial updates
+- **Stimulus** for custom JavaScript behavior
+- **ViewComponents** (`view_component` gem) for encapsulated UI components
+- **ERB** templates (not Haml, Slim, or JSX)
+
+When generating HTML previews or design artifacts:
+- Use Bootstrap 5 classes exclusively — no Tailwind, no custom CSS unless necessary
+- Make everything responsive using Bootstrap's grid and breakpoint system
+- Structure artifacts as self-contained units that map to a ViewComponent
+
+### Component Catalog
+
+Before proposing something new, check the existing catalog in `mpimedia/mpi-design-system`:
+- `catalog/elements/` — Buttons, inputs, badges, icons, links
+- `catalog/components/` — Cards, modals, navbars, tables, alerts
+- `catalog/patterns/` — Forms, search bars, filters, data entry
+- `catalog/layouts/` — Dashboards, detail pages, list views
+
+If a component already exists, reference it. If it needs modification, that's a revision, not a new proposal.
+
+### Design Tokens
+
+Reference the tokens in `tokens/` for colors, typography, spacing, and Bootstrap overrides. Do not invent arbitrary values.
+
+## Attribution
+
+All comments and issues you create must end with an attribution line:
+
+```
+*Created by Badie via Claude Design Agent*
+```
+
+All commits must include:
+
+```
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+## What You Should Never Do
+
+- Don't create a PR without a plan-ready issue backing it
+- Don't make design decisions without Badie's input — present options, let him choose
+- Don't use technical jargon with Badie — translate everything to business language
+- Don't skip the discussion phase — even if the path seems obvious, the dev team may have concerns
+- Don't commit directly to `main` — always use feature branches

--- a/workflow/issue-lifecycle.md
+++ b/workflow/issue-lifecycle.md
@@ -1,0 +1,136 @@
+# Issue Lifecycle
+
+Every design system issue follows this lifecycle, tracked by labels and board columns.
+
+## Stages
+
+### 1. Proposal (`proposal` + `needs-discussion`)
+
+**Who:** Badie + Claude Design Agent
+**Board column:** Proposal
+
+An issue is created capturing a business need. It includes context, users, requirements, data, and open questions.
+
+At this stage the issue is a conversation starter, not a final spec. It explicitly flags what needs dev team input.
+
+### 2. Discussion (`needs-discussion`)
+
+**Who:** Everyone — Badie, dev team, agents
+**Board column:** Proposal (stays here during discussion)
+
+This is where the issue gets refined. Participants contribute:
+
+| Contributor | What they bring |
+|---|---|
+| **Badie / Design Agent** | Business context, user workflows, data requirements, priorities |
+| **Dev team / Dev agents** | Technical feasibility, implementation concerns, effort estimates, existing patterns to reuse |
+| **Anyone** | Alternative approaches, edge cases, accessibility concerns, warnings about scope |
+
+#### Discussion conventions:
+
+- **Present alternatives as trade-offs**, not just technical options. Frame them in terms of what the user experiences, how long it takes, and what it costs in complexity.
+- **Flag warnings early.** If something is technically risky, expensive, or conflicts with existing patterns, say so now — not after a plan is written.
+- **Ask clarifying questions** as issue comments, not in side channels. Keep the full conversation in the issue.
+- **Attribution:** AI-authored comments should end with an attribution line (e.g., *Comment by Badie via Claude Design Agent* or *Comment by dev team via Claude Code*).
+
+### 3. Decision (`decision-made`)
+
+**Who:** Whoever has authority (usually Badie for design direction, dev lead for technical approach)
+**Board column:** In Design
+
+When discussion converges, a decision comment is added to the issue:
+
+```markdown
+## Decision
+
+[What was decided and why.]
+
+### What was considered:
+- **Option A:** [description] — [why chosen or rejected]
+- **Option B:** [description] — [why chosen or rejected]
+
+### Key factors:
+- [What mattered most]
+```
+
+The `needs-discussion` label is removed and `decision-made` is added.
+
+### 4. Plan (`plan-ready`)
+
+**Who:** Badie + Claude Design Agent (for design specs), Dev team (for technical review)
+**Board column:** Approved
+
+An implementation plan is written as a comment on the issue. This is the handoff document — it must contain enough detail for a developer or dev agent to implement via PR without going back to Badie.
+
+```markdown
+## Implementation Plan
+
+### What to build
+[Concrete description.]
+
+### Specifications
+- [UI elements and their behavior]
+- [States: default, hover, active, disabled, loading, empty, error]
+- [Responsive behavior]
+- [Data displayed and where it comes from]
+- [User actions and what they trigger]
+
+### Bootstrap 5 Guidance
+[Relevant Bootstrap components.]
+
+### Accessibility
+[Key requirements for this design.]
+
+### Acceptance Criteria
+- [ ] [Testable criterion]
+- [ ] [Testable criterion]
+- [ ] [Testable criterion]
+
+### Out of Scope
+[What this does NOT include.]
+```
+
+The `decision-made` label is removed and `plan-ready` is added.
+
+### 5. Implementation (`implementing`)
+
+**Who:** Dev team / Dev agents
+**Board column:** Implementing
+
+A developer or dev agent picks up the plan-ready issue and:
+
+1. Creates a feature branch
+2. Implements the design as a component spec in the catalog (and/or as a ViewComponent in the target app)
+3. Opens a PR referencing the issue (`Closes #123`)
+4. The PR is reviewed and merged
+
+The `plan-ready` label is removed and `implementing` is added.
+
+### 6. Done
+
+**Who:** Reviewer who merges the PR
+**Board column:** Done
+
+The PR is merged, the issue is closed, and the component is live.
+
+## Labels Summary
+
+| Label | Meaning | Added by |
+|---|---|---|
+| `proposal` | New design request | Creator (on issue creation) |
+| `revision` | Change to existing design | Creator (on issue creation) |
+| `needs-discussion` | Awaiting input from team | Creator (on issue creation) |
+| `decision-made` | Direction chosen, ready for planning | Decision maker |
+| `plan-ready` | Implementation plan written, ready for dev | Plan author |
+| `implementing` | PR in progress | Developer |
+
+## Board Column Mapping
+
+| Board Column | Labels Present |
+|---|---|
+| Proposal | `proposal` + `needs-discussion` |
+| In Design | `decision-made` (actively being designed/planned) |
+| In Review | Design artifacts posted, awaiting review |
+| Approved | `plan-ready` |
+| Implementing | `implementing` |
+| Done | Issue closed |


### PR DESCRIPTION
## Summary

- Defines the full issue-driven design workflow: Badie describes a need → Claude creates an issue → team discusses → decision recorded → plan written → dev implements via PR
- Creates Claude Project instructions that Badie pastes into a Claude Project on claude.ai so his Claude agent knows how to behave
- Adds issue lifecycle documentation with stages, labels, and conventions
- Simplifies issue templates for Claude-authored issues

## Changes Made

### New files
- **`workflow/claude-project-instructions.md`** — Full instructions for Badie's Claude Design Agent. Covers 6 phases: listen/draw out requirements → summarize back → create issue → participate in discussion → record decision → write plan. Includes design system context, attribution rules, and guardrails.
- **`workflow/issue-lifecycle.md`** — Documents all 6 stages of the issue lifecycle with label mappings, board column mappings, discussion conventions, decision format, and plan format.

### Updated files
- **`CONTRIBUTING.md`** — Replaced the old 6-step workflow with the new pipeline and links to detailed docs. Separate quick-start sections for Badie and developers.
- **`workflow/README.md`** — Updated pipeline diagram, added guides table, label reference, and board column mapping.
- **`.github/ISSUE_TEMPLATE/design-proposal.md`** — Simplified from checkbox-heavy developer form to a brief format optimized for Claude to fill out on Badie's behalf.
- **`.github/ISSUE_TEMPLATE/design-revision.md`** — Simplified to match.

### GitHub labels created
`needs-discussion`, `decision-made`, `plan-ready`, `implementing`, `proposal`, `revision`

## Context for Future Contributors

This workflow is designed around a specific team dynamic: Badie has deep business knowledge but no git/developer experience. Claude acts as his bridge to GitHub — creating issues, commenting, writing plans. The dev team engages through issue discussions and picks up `plan-ready` issues for implementation. Both sides stay in their comfort zone.

## Test plan

- [ ] Review Claude Project instructions for clarity and completeness
- [ ] Verify labels were created on the repo
- [ ] Have Badie test the workflow end-to-end with a real design request

🤖 Generated with [Claude Code](https://claude.com/claude-code)