### PR TITLE
docs: add session handoff report for design system setup

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,0 +1,161 @@
+# Session Handoff Report
+
+**Session ID:** `session_017UKdvB9s6XhYBtsQLvkw6w`
+**Date:** 2026-03-01
+**Environment:** Claude Code Web (claude.ai/code)
+**Repo context:** `mpimedia/.github` (org-wide config repo — this was the only repo accessible in the web session)
+**Branch:** `claude/design-system-setup-QpJSm`
+
+---
+
+## Conversation Transcript (Summarized)
+
+### 1. User asked: "Does it make sense to create a GH Project for building this out?"
+
+Context: The user shared `https://github.com/mpimedia/mpi-design-system` and asked whether a GitHub Project board is the right tool for managing the design system buildout.
+
+**Claude's answer: Yes.** Rationale given:
+- It's an ongoing body of work, not a single deliverable
+- Multiple contributors with different roles
+- The design workflow maps naturally to kanban columns
+- GitHub Projects support cross-repo visibility (issues from multiple repos on one board)
+
+### 2. Claude proposed a board structure:
+
+| Column | Purpose |
+|---|---|
+| **Backlog** | Design needs identified but not yet started |
+| **Proposal** | Issue filed with requirements, waiting for design work |
+| **In Design** | Actively being worked on |
+| **In Review** | Design shared, awaiting stakeholder feedback |
+| **Approved** | Design accepted, ready for implementation |
+| **Implementing** | Being built in a Rails app |
+| **Done** | Implemented, merged, and live |
+
+**Status: PROPOSED, not explicitly approved.** The user did not review or confirm these specific columns.
+
+### 3. Claude asked about scope (org-wide vs mpi-design-system only vs manual setup)
+
+**The user dismissed this question without answering.** Scope was never confirmed.
+
+### 4. User said: "you create project"
+
+The user wants Claude to create the GitHub Project — not do it manually himself.
+
+### 5. Claude attempted to create the project but could not
+
+The web environment had no `gh` CLI auth. After installing `gh`, there was no API token available to authenticate. The project was **not created**.
+
+### 6. User asked how to open this session in the TUI
+
+Claude explained that web sessions cannot be resumed in the local TUI — they are separate environments. Advised starting a fresh local session.
+
+### 7. User confirmed their TUI attempt froze, asked for a handoff report
+
+This report was created.
+
+---
+
+## What Was Confirmed
+
+- A GitHub Project board **should** be created for the design system
+- **Claude should create it** (user does not want to do it manually)
+- The repo is `mpimedia/mpi-design-system`
+
+## What Was NOT Confirmed (Needs User Input)
+
+- **Board columns** — The 7-column structure above was proposed but never explicitly approved. Ask the user to confirm or adjust before creating.
+- **Project scope** — Org-wide (cross-repo) vs scoped to `mpi-design-system` only. The user was asked but did not answer.
+- **What the design system contains** — Not discussed in this session. No details about components, tokens, tooling, or architecture were covered.
+- **Who is involved** — No team members or roles were discussed in this session.
+- **What goes in the mpi-design-system repo** — Not discussed. No scaffolding decisions were made.
+
+---
+
+## Immediate Next Actions (for TUI session)
+
+### Action 1: Confirm open questions with the user
+
+Before creating anything, ask:
+1. "Should the project board be org-wide or scoped to mpi-design-system?"
+2. "Here are the proposed columns: [list]. Want to adjust any?"
+3. "What should the mpi-design-system repo contain? (e.g., Figma exports, design tokens, component specs, ViewComponent implementations?)"
+
+### Action 2: Create the GitHub Project
+
+Once confirmed, use `gh` CLI:
+
+```bash
+# Create org-level project (adjust --owner if scoped differently)
+gh project create --owner mpimedia --title "MPI Design System"
+
+# Then configure the Status field with custom columns.
+# Get project number from output above, then:
+PROJECT_NUM=<number>
+
+# Get project and field IDs
+PROJECT_ID=$(gh project list --owner mpimedia --format json | jq -r '.projects[] | select(.title=="MPI Design System") | .id')
+FIELD_ID=$(gh project field-list $PROJECT_NUM --owner mpimedia --format json | jq -r '.fields[] | select(.name=="Status") | .id')
+
+# Set custom status options (adjust names/colors based on user confirmation)
+gh api graphql -f query='
+mutation {
+  updateProjectV2Field(input: {
+    projectId: "'"$PROJECT_ID"'"
+    fieldId: "'"$FIELD_ID"'"
+    singleSelectOptions: [
+      {name: "Backlog", color: "GRAY"},
+      {name: "Proposal", color: "BLUE"},
+      {name: "In Design", color: "PURPLE"},
+      {name: "In Review", color: "YELLOW"},
+      {name: "Approved", color: "GREEN"},
+      {name: "Implementing", color: "ORANGE"},
+      {name: "Done", color: "GREEN"}
+    ]
+  }) {
+    projectV2Field { ... on ProjectV2SingleSelectField { name options { name } } }
+  }
+}'
+```
+
+### Action 3: Scaffold `mpi-design-system` repo (pending user direction)
+
+The repo exists at `https://github.com/mpimedia/mpi-design-system` but its contents and purpose were not discussed. Wait for user input before scaffolding.
+
+---
+
+## Org Context (from mpimedia/.github repo)
+
+This session ran inside the `mpimedia/.github` org-wide config repo. Relevant context for the design system work:
+
+### MPI Media Apps (potential consumers of the design system):
+- **Optimus, Avails, SFA, Garden, Harvest**
+
+### Tech Stack:
+- Ruby on Rails, PostgreSQL, Redis, Sidekiq
+- RSpec + FactoryBot for testing
+- GitHub Actions for CI/CD, Heroku for deployment
+
+### Org Standards:
+- **Branch protection:** Feature branches only, never commit to main/master/develop
+- **AI attribution:** Required `Co-Authored-By` trailer on all AI-generated commits
+- **Testing:** 80%+ coverage minimum
+- **Code style:** Rails conventions, RuboCop, 2-space indent, 120-char lines
+- **Security:** Brakeman scans, no secrets in code, input validation
+
+### Existing Org Infrastructure:
+- Issue templates (bug, feature, task, question)
+- PR template (standardized format)
+- Copilot instructions (org-wide + path-specific for tests and workflows)
+- CI workflow templates (Rails CI with RSpec, RuboCop, Brakeman)
+- Claude hooks (branch protection enforcement)
+
+---
+
+## What Was NOT Done
+
+- [ ] GitHub Project not created (no API auth in web environment)
+- [ ] `mpi-design-system` repo not accessed (web proxy only allows `.github` repo)
+- [ ] No design system scaffolding started
+- [ ] No issues created
+- [ ] No design system architecture discussed


### PR DESCRIPTION
## Summary

- Adds `SESSION_HANDOFF.md` documenting a Claude web session about setting up a GitHub Project board for the MPI Design System
- Moved from `mpimedia/.github` PR #12 — this file belongs in the design system repo, not the org config repo

## Context

This handoff report captures decisions, open questions, and next actions from a web session (`session_017UKdvB9s6XhYBtsQLvkw6w`) for continuation locally.

## Test plan

- [ ] Review handoff content for accuracy
- [ ] N/A — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)