### PR TITLE
chore: restructure tokens for design-first workflow and add cross-app audit

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Project Board
-    url: https://github.com/orgs/mpimedia/projects/14
+    url: https://github.com/orgs/mpimedia/projects/15
     about: View the design system project board for current status

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full process.
 
 ## Project Board
 
-Track design system progress on the [MPI Design System project board](https://github.com/orgs/mpimedia/projects/14).
+Track design system progress on the [MPI Design System project board](https://github.com/orgs/mpimedia/projects/15).
 
 ## Related Repositories
 

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -32,4 +32,4 @@ Each spec includes a status badge:
 
 ## Finding Components
 
-Browse the directories above, or check the [project board](https://github.com/orgs/mpimedia/projects/14) for components currently in progress.
+Browse the directories above, or check the [project board](https://github.com/orgs/mpimedia/projects/15) for components currently in progress.

--- a/references/cross-app-audit.md
+++ b/references/cross-app-audit.md
@@ -1,0 +1,90 @@
+# Cross-App Component Audit
+
+> **Date:** 2026-03-02
+> **Purpose:** Inventory of existing UI components across MPI apps. Used for migration planning, not as the basis for the design system.
+
+## Component Counts
+
+| Repo | ViewComponents | Stimulus Controllers | Custom SCSS |
+|---|---|---|---|
+| markaz-crm | 38 | 0 | Minimal |
+| avails_server | 24 | 45 | Moderate |
+| wpa_film_library (SFA) | 20 | 29 | Heavy (28+ files) |
+| garden | 31 | 0 | Minimal |
+| harvest | 31 | 0 | Minimal |
+
+## Naming Conventions (Current State)
+
+| Pattern | Repos |
+|---|---|
+| `Admin::Name::Component` (folder-based) | markaz-crm, garden, harvest |
+| Flat (no namespace) | avails_server |
+| `Admin::NameComponent` (class-based) | wpa_film_library |
+
+**Target:** All apps will adopt `Admin::Name::Component` (folder-based) via shared gem.
+
+## Shared Admin Components
+
+These 28 components exist in markaz-crm, garden, and harvest with identical implementations (same file SHAs). avails_server and SFA have equivalents with different names.
+
+| Component | markaz-crm | avails_server | SFA | garden | harvest |
+|---|---|---|---|---|---|
+| ActionButton | `Admin::ActionButton` | `ActionButton` | — | `Admin::ActionButton` | `Admin::ActionButton` |
+| ArchivedBadge | `Admin::ArchivedBadge` | `ArchivedFlag` | — | `Admin::ArchivedBadge` | `Admin::ArchivedBadge` |
+| BatchActionButton | `Admin::BatchActionButton` | — | `Admin::BatchActionButtonComponent` | `Admin::BatchActionButton` | `Admin::BatchActionButton` |
+| BatchActionModalButton | `Admin::BatchActionModalButton` | — | `Admin::BatchActionModalButtonComponent` | `Admin::BatchActionModalButton` | `Admin::BatchActionModalButton` |
+| Brand | `Admin::Brand` | `Brand` | — | `Admin::Brand` | `Admin::Brand` |
+| DashboardCard | `Admin::DashboardCard` | — | `Admin::DashboardCardComponent` | `Admin::DashboardCard` | `Admin::DashboardCard` |
+| DashboardCardLink | `Admin::DashboardCardLink` | — | — | `Admin::DashboardCardLink` | `Admin::DashboardCardLink` |
+| DashboardContainer | `Admin::DashboardContainer` | — | — | `Admin::DashboardContainer` | `Admin::DashboardContainer` |
+| DashboardHeader | `Admin::DashboardHeader` | — | — | `Admin::DashboardHeader` | `Admin::DashboardHeader` |
+| DashboardHeaderLink | `Admin::DashboardHeaderLink` | — | — | `Admin::DashboardHeaderLink` | `Admin::DashboardHeaderLink` |
+| FilterCard | `Admin::FilterCard` | — | `Admin::FilterCardComponent` | `Admin::FilterCard` | `Admin::FilterCard` |
+| FormButton | `Admin::FormButton` | — | — | `Admin::FormButton` | `Admin::FormButton` |
+| HeaderForEdit | `Admin::HeaderForEdit` | `HeaderForEdit` | `Admin::HeaderComponent` | `Admin::HeaderForEdit` | `Admin::HeaderForEdit` |
+| HeaderForIndex | `Admin::HeaderForIndex` | `HeaderForIndex` | `Admin::HeaderComponent` | `Admin::HeaderForIndex` | `Admin::HeaderForIndex` |
+| HeaderForNew | `Admin::HeaderForNew` | `HeaderForNew` | `Admin::HeaderComponent` | `Admin::HeaderForNew` | `Admin::HeaderForNew` |
+| HeaderForShow | `Admin::HeaderForShow` | `HeaderForShow` | `Admin::HeaderComponent` | `Admin::HeaderForShow` | `Admin::HeaderForShow` |
+| HeaderForUpload | `Admin::HeaderForUpload` | `HeaderForUpload` | — | `Admin::HeaderForUpload` | `Admin::HeaderForUpload` |
+| IndexPager | `Admin::IndexPager` | `IndexPager` | — | `Admin::IndexPager` | `Admin::IndexPager` |
+| InterfaceNotification | `Admin::InterfaceNotification` | `InterfaceNotification` | — | `Admin::InterfaceNotification` | `Admin::InterfaceNotification` |
+| LinkButton | `Admin::LinkButton` | — | — | `Admin::LinkButton` | `Admin::LinkButton` |
+| NavBar | `Admin::NavBar` | `NavBar` | `Admin::NavBarComponent` | `Admin::NavBar` | `Admin::NavBar` |
+| NavDropdownItem | `Admin::NavDropdownItem` | `NavDropdownItem` | `Admin::NavDropdownItemComponent` | `Admin::NavDropdownItem` | `Admin::NavDropdownItem` |
+| NavItem | `Admin::NavItem` | `NavItem` | `Admin::NavItemComponent` | `Admin::NavItem` | `Admin::NavItem` |
+| PageContainer | `Admin::PageContainer` | `PageWrapper` | `Admin::ContainerComponent` | `Admin::PageContainer` | `Admin::PageContainer` |
+| TableForAssociations | `Admin::TableForAssociations` | (shared partials) | — | `Admin::TableForAssociations` | `Admin::TableForAssociations` |
+| TableForIndex | `Admin::TableForIndex` | (shared partials) | `Admin::TableComponent` | `Admin::TableForIndex` | `Admin::TableForIndex` |
+| TableForIndexColumn | `Admin::TableForIndexColumn` | — | — | `Admin::TableForIndexColumn` | `Admin::TableForIndexColumn` |
+| TableForShow | `Admin::TableForShow` | `ShowTable` | `Admin::TwoColumnTableComponent` | `Admin::TableForShow` | `Admin::TableForShow` |
+| TableForShowRow | `Admin::TableForShowRow` | — | — | `Admin::TableForShowRow` | `Admin::TableForShowRow` |
+| UserLogin | `Admin::UserLogin` | `UserLogin` | — | `Admin::UserLogin` | `Admin::UserLogin` |
+
+## App-Specific Components
+
+| App | Component | Purpose |
+|---|---|---|
+| markaz-crm | `Admin::DashboardActiveEngagements` | CRM active engagements widget |
+| markaz-crm | `Admin::DashboardFollowUps` | CRM follow-up reminders widget |
+| markaz-crm | `Admin::DashboardQuickActions` | CRM quick action buttons |
+| markaz-crm | `Admin::DashboardQuickStats` | CRM statistics widget |
+| markaz-crm | `Admin::DashboardRecentlyAdded` | CRM recent additions widget |
+| markaz-crm | `Admin::SavedFilterControls` | Saved filter management |
+| markaz-crm | `Favicon` | Favicon meta tags |
+| avails_server | `BooleanFlag` | Boolean status indicator |
+| avails_server | `CamaFlag` | CAMA status flag |
+| avails_server | `ExpiredFlag` | Expired status flag |
+| avails_server | `LabelFlag` | Label/tag flag |
+| avails_server | `PublicBrand` | Public-facing branding |
+| avails_server | `ScreenerRequestFormLink` | Screener request link |
+| avails_server | `AssociationsTable` | Associated records table |
+| SFA | `Clip::CardComponent` | Video clip card |
+| SFA | `Clip::DetailsComponent` | Clip details panel |
+| SFA | `Clipbin::CardComponent` | Clipbin collection card |
+| SFA | `Exhibit::CoverComponent` | Exhibit cover display |
+| SFA | `Exhibit::PageHeaderComponent` | Exhibit page header |
+| SFA | `HeroImageComponent` | Hero image banner |
+| SFA | `WelcomeHeaderComponent` | Welcome/landing header |
+| SFA | `Accordion::ItemComponent` | Accordion panel item |
+| garden | `Admin::PreviewBanner` | Content preview banner |
+| harvest | `StripeHeadTag` | Stripe payment meta tag |

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -2,20 +2,27 @@
 
 Design tokens are the foundational values that define MPI's visual language. They ensure consistency across all five applications.
 
+## Current Status
+
+Token values are **pending** — they will be derived from Badie's approved designs through a Q&A review process, not from legacy app code. The token files define the structure and categories; values will be filled in once designs are reviewed.
+
+## Process
+
+1. Badie provides designs (Figma, HTML artifacts, screenshots, PDFs)
+2. AC + HC conduct a Q&A session to decompose the designs
+3. Colors, typography, spacing, and component overrides are extracted
+4. Values are recorded in these token files as the canonical source
+5. A shared `_mpi_overrides.scss` partial is generated from the tokens
+6. Apps adopt the shared partial via the design system gem
+
 ## Token Files
 
-| File | Contents |
-|---|---|
-| [colors.md](colors.md) | Brand colors, semantic colors, neutral palette |
-| [typography.md](typography.md) | Font families, type scale, heading sizes |
-| [spacing.md](spacing.md) | Spacing scale, component spacing guidelines |
-| [bootstrap-overrides.md](bootstrap-overrides.md) | MPI customizations to Bootstrap 5 defaults |
-
-## How Tokens Are Used
-
-1. **Designers** reference tokens when creating components in Claude sessions
-2. **Developers** implement tokens as SCSS variables in Rails apps
-3. **Reviewers** verify that new designs use established tokens (not arbitrary values)
+| File | Contents | Status |
+|---|---|---|
+| [colors.md](colors.md) | Brand colors, semantic colors, neutral palette | Pending designs |
+| [typography.md](typography.md) | Font families, type scale, heading sizes | Partially confirmed (Bootstrap defaults) |
+| [spacing.md](spacing.md) | Spacing scale, component spacing guidelines | Baseline (Bootstrap defaults) |
+| [bootstrap-overrides.md](bootstrap-overrides.md) | MPI customizations to Bootstrap 5 defaults | Pending designs |
 
 ## Adding New Tokens
 
@@ -24,4 +31,4 @@ If a design requires a value not covered by existing tokens:
 1. Check if Bootstrap 5 already provides a suitable default
 2. If a custom value is needed, propose it via PR to this directory
 3. Document the token name, value, and intended usage
-4. Update the relevant token file
+4. Every override must trace back to an approved design decision

--- a/tokens/bootstrap-overrides.md
+++ b/tokens/bootstrap-overrides.md
@@ -2,7 +2,11 @@
 
 MPI-specific customizations to Bootstrap 5 defaults.
 
-> **Status:** Draft — to be populated as the design system matures.
+> **Status:** Pending — overrides will be derived from approved designs during Q&A review sessions.
+
+## Philosophy
+
+Start from Bootstrap 5 defaults. Only override when the approved designs explicitly require it. Every override must trace back to a design decision, not a developer preference.
 
 ## How Overrides Work
 
@@ -11,47 +15,62 @@ Each MPI Rails app uses Bootstrap 5 via the `bootstrap` gem. Customizations are 
 ```scss
 // app/assets/stylesheets/application.scss
 
-// 1. MPI overrides (import from design system tokens)
-@import "mpi_overrides";
+// 1. MPI overrides (from design system tokens)
+@use "mpi_overrides";
 
 // 2. Bootstrap
-@import "bootstrap";
+@use "bootstrap/scss/bootstrap";
 
 // 3. App-specific styles
-@import "custom";
-```
-
-## Current Overrides
-
-### Colors
-
-See [colors.md](colors.md) for the full palette. Key overrides:
-
-```scss
-$primary: $mpi-primary;
-$secondary: $mpi-secondary;
-// Additional overrides TBD
-```
-
-### Typography
-
-See [typography.md](typography.md). Key overrides:
-
-```scss
-$font-family-base: $mpi-font-primary;
-// Additional overrides TBD
-```
-
-### Components
-
-Document component-specific overrides here as they are established:
-
-```scss
-// Example: card customizations
-// $card-border-radius: 0.5rem;
-// $card-spacer-y: 1.25rem;
+@use "custom";
 ```
 
 ## Shared Override File
 
-Eventually, a shared SCSS partial (`_mpi_overrides.scss`) should be maintained in this repo and distributed to each app. For now, each app maintains its own overrides file, using the tokens documented here as the reference.
+The goal is a single `_mpi_overrides.scss` partial maintained in this repo and distributed to each app via a shared gem. This file will be generated from the token values once designs are approved.
+
+## Override Categories
+
+### Colors
+
+See [colors.md](colors.md). Overrides to be determined from designs:
+
+```scss
+// $primary: $mpi-primary;
+// $secondary: $mpi-secondary;
+```
+
+### Typography
+
+See [typography.md](typography.md). Overrides to be determined from designs:
+
+```scss
+// $font-family-base: $mpi-font-primary;
+```
+
+### Component Overrides
+
+_To be populated after Q&A review of approved designs._
+
+Open questions from legacy apps that designs should resolve:
+
+| Question | Legacy Context |
+|---|---|
+| Button border-radius | SFA uses `3.125rem` (pill buttons). Other apps use Bootstrap default. |
+| Button padding | SFA has custom padding values. Other apps use Bootstrap default. |
+| Link color | avails_server uses `#0a3d7e`. Others use Bootstrap default. |
+| Card border-radius | Unknown — pending designs. |
+| Navbar style | V2 (white topbar) confirmed as canonical direction in Issue #5. |
+
+## Legacy Reference
+
+Current override files in each app (for migration planning):
+
+| App | File | Scope |
+|---|---|---|
+| SFA | `app/assets/stylesheets/overrides/_variables.scss` | Extensive: 13 custom colors, pill buttons, accordion, carousel, form overrides |
+| SFA | `app/assets/stylesheets/overrides/_theme_colors.scss` | Merges 11 custom colors into Bootstrap theme map |
+| avails_server | `app/assets/stylesheets/customizations/admin.scss` | Moderate: link color, heading sizes, font family, table styling, accordion levels |
+| markaz-crm | `app/assets/stylesheets/admin.scss` | Minimal: one custom background color, readonly input styling, table headers, mobile responsive |
+| garden | `app/assets/stylesheets/admin.scss` | Minimal (similar to markaz-crm) |
+| harvest | `app/assets/stylesheets/admin.scss` | Minimal (similar to markaz-crm) |

--- a/tokens/colors.md
+++ b/tokens/colors.md
@@ -2,41 +2,48 @@
 
 Design tokens for the MPI color palette.
 
-> **Status:** Draft — values to be populated once brand colors are confirmed.
+> **Status:** Pending — values will be derived from approved designs during Q&A review sessions.
+
+## How This File Gets Populated
+
+1. Badie provides new designs (Figma, HTML artifacts, screenshots)
+2. AC + HC conduct a Q&A session to break down colors used in the designs
+3. Values are recorded here as the canonical palette
+4. Apps adopt these values via `_mpi_overrides.scss`
 
 ## Brand Colors
 
 | Token | Value | Usage |
 |---|---|---|
-| `$mpi-primary` | TBD | Primary actions, key UI elements |
-| `$mpi-secondary` | TBD | Secondary actions, supporting elements |
-| `$mpi-accent` | TBD | Highlights, active states |
+| `$mpi-primary` | _from designs_ | Primary actions, key UI elements |
+| `$mpi-secondary` | _from designs_ | Secondary actions, supporting elements |
+| `$mpi-accent` | _from designs_ | Highlights, active states |
 
 ## Semantic Colors
 
 | Token | Value | Usage |
 |---|---|---|
-| `$mpi-success` | TBD | Positive actions, confirmations |
-| `$mpi-warning` | TBD | Caution states, pending actions |
-| `$mpi-danger` | TBD | Destructive actions, errors |
-| `$mpi-info` | TBD | Informational messages |
+| `$mpi-success` | _from designs_ | Positive actions, confirmations |
+| `$mpi-warning` | _from designs_ | Caution states, pending actions |
+| `$mpi-danger` | _from designs_ | Destructive actions, errors |
+| `$mpi-info` | _from designs_ | Informational messages |
 
 ## Neutral Colors
 
 | Token | Value | Usage |
 |---|---|---|
-| `$mpi-text` | TBD | Primary text |
-| `$mpi-text-muted` | TBD | Secondary text, captions |
-| `$mpi-border` | TBD | Default borders |
-| `$mpi-background` | TBD | Page background |
-| `$mpi-surface` | TBD | Card/panel backgrounds |
+| `$mpi-text` | _from designs_ | Primary text |
+| `$mpi-text-muted` | _from designs_ | Secondary text, captions |
+| `$mpi-border` | _from designs_ | Default borders |
+| `$mpi-background` | _from designs_ | Page background |
+| `$mpi-surface` | _from designs_ | Card/panel backgrounds |
 
 ## Bootstrap 5 Mapping
 
 These tokens map to Bootstrap's color system via SCSS variable overrides:
 
 ```scss
-// In your app's Bootstrap override file
+// In each app's Bootstrap override file
 $primary: $mpi-primary;
 $secondary: $mpi-secondary;
 $success: $mpi-success;
@@ -48,3 +55,18 @@ $info: $mpi-info;
 ## App-Specific Overrides
 
 Individual apps may extend the palette for app-specific needs, but should never redefine the core tokens above. Document app-specific colors in the app's own codebase.
+
+## Legacy Reference
+
+These values exist in current apps but may not carry forward. Included for migration context only:
+
+| App | Variable | Value | Notes |
+|---|---|---|---|
+| SFA | `$primary-blue` | `#1C75BC` | Currently used as Bootstrap `$primary` |
+| SFA | `$dark-blue` | `#00447A` | |
+| SFA | `$turqoise` | `#00776d` | |
+| SFA | `$gold` | `#afa54b` | |
+| SFA | `$purple` | `#612574` | |
+| SFA | `$faint-gray` | `#f7f7f7` | |
+| avails_server | `$link-color` | `#0a3d7e` | |
+| markaz-crm | `.bg-custom-light-gray` | `#c2c2c2` | |

--- a/tokens/spacing.md
+++ b/tokens/spacing.md
@@ -2,11 +2,11 @@
 
 Design tokens for consistent spacing across MPI applications.
 
-> **Status:** Draft — using Bootstrap 5 defaults as baseline.
+> **Status:** Baseline — using Bootstrap 5 defaults. Custom overrides will be derived from approved designs if needed.
 
 ## Spacing Scale
 
-MPI uses Bootstrap 5's spacing scale as the foundation. Custom overrides are documented here.
+MPI uses Bootstrap 5's spacing scale as the foundation. Custom overrides are documented here only if the designs require them.
 
 | Token | Bootstrap Class | Default Value | Usage |
 |---|---|---|---|
@@ -27,10 +27,14 @@ MPI uses Bootstrap 5's spacing scale as the foundation. Custom overrides are doc
 | Inline element gaps | `$spacer-1` to `$spacer-2` |
 | Button padding | Bootstrap defaults (`btn` class) |
 
+## Design-Driven Overrides
+
+_To be populated after Q&A review of approved designs. Only add overrides here if Bootstrap defaults are insufficient._
+
 ## Bootstrap 5 Mapping
 
 ```scss
-// Override Bootstrap's spacer if needed
+// Override Bootstrap's spacer only if designs require it
 $spacer: 1rem;
 $spacers: (
   0: 0,

--- a/tokens/typography.md
+++ b/tokens/typography.md
@@ -2,36 +2,43 @@
 
 Design tokens for MPI typography.
 
-> **Status:** Draft — values to be populated once type scale is confirmed.
+> **Status:** Pending — values will be derived from approved designs during Q&A review sessions.
+
+## Confirmed Decisions
+
+These decisions were confirmed in [Issue #5](https://github.com/mpimedia/mpi-design-system/issues/5):
+
+- **Font family:** Bootstrap default system font stack (not DM Sans)
+- **Custom CSS:** Convert designs to use Bootstrap standards, only customize when needed
 
 ## Font Families
 
 | Token | Value | Usage |
 |---|---|---|
-| `$mpi-font-primary` | TBD | Body text, general UI |
-| `$mpi-font-heading` | TBD | Headings (may be same as primary) |
-| `$mpi-font-mono` | TBD | Code, data tables, technical content |
+| `$mpi-font-primary` | _Bootstrap default_ | Body text, general UI |
+| `$mpi-font-heading` | _from designs_ | Headings (may be same as primary) |
+| `$mpi-font-mono` | _Bootstrap default_ | Code, data tables, technical content |
 
 ## Type Scale
 
 | Token | Size | Weight | Line Height | Usage |
 |---|---|---|---|---|
-| `$mpi-text-xs` | TBD | 400 | TBD | Fine print, labels |
-| `$mpi-text-sm` | TBD | 400 | TBD | Secondary text, captions |
-| `$mpi-text-base` | TBD | 400 | TBD | Body text |
-| `$mpi-text-lg` | TBD | 400 | TBD | Lead paragraphs |
-| `$mpi-text-xl` | TBD | 600 | TBD | Section headers |
+| `$mpi-text-xs` | _from designs_ | _from designs_ | _from designs_ | Fine print, labels |
+| `$mpi-text-sm` | _from designs_ | _from designs_ | _from designs_ | Secondary text, captions |
+| `$mpi-text-base` | _from designs_ | _from designs_ | _from designs_ | Body text |
+| `$mpi-text-lg` | _from designs_ | _from designs_ | _from designs_ | Lead paragraphs |
+| `$mpi-text-xl` | _from designs_ | _from designs_ | _from designs_ | Section headers |
 
 ## Headings
 
 | Token | Size | Weight | Usage |
 |---|---|---|---|
-| `$mpi-h1` | TBD | 700 | Page titles |
-| `$mpi-h2` | TBD | 700 | Section headings |
-| `$mpi-h3` | TBD | 600 | Subsection headings |
-| `$mpi-h4` | TBD | 600 | Card titles, group labels |
-| `$mpi-h5` | TBD | 600 | Small headings |
-| `$mpi-h6` | TBD | 600 | Overlines, labels |
+| `$mpi-h1` | _from designs_ | _from designs_ | Page titles |
+| `$mpi-h2` | _from designs_ | _from designs_ | Section headings |
+| `$mpi-h3` | _from designs_ | _from designs_ | Subsection headings |
+| `$mpi-h4` | _from designs_ | _from designs_ | Card titles, group labels |
+| `$mpi-h5` | _from designs_ | _from designs_ | Small headings |
+| `$mpi-h6` | _from designs_ | _from designs_ | Overlines, labels |
 
 ## Bootstrap 5 Mapping
 
@@ -41,3 +48,15 @@ $headings-font-family: $mpi-font-heading;
 $font-family-monospace: $mpi-font-mono;
 $font-size-base: $mpi-text-base;
 ```
+
+## Legacy Reference
+
+These values exist in current apps but may not carry forward:
+
+| App | Override | Notes |
+|---|---|---|
+| avails_server | `font-family: "Helvetica Neue", Helvetica, Arial, sans-serif` | Admin section only — diverges from Bootstrap default |
+| SFA | No font override | Uses Bootstrap default |
+| markaz-crm | No font override | Uses Bootstrap default |
+| garden | No font override | Uses Bootstrap default |
+| harvest | No font override | Uses Bootstrap default |

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -40,7 +40,7 @@ Badie + Claude → Issue → Discussion → Decision → Plan → PR → Done
 
 ## Project Board
 
-All design work is tracked on the [MPI Design System project board](https://github.com/orgs/mpimedia/projects/14).
+All design work is tracked on the [MPI Design System project board](https://github.com/orgs/mpimedia/projects/15).
 
 | Board Column | What's here |
 |---|---|


### PR DESCRIPTION
## Summary

- Restructures all token files (`colors.md`, `typography.md`, `spacing.md`, `bootstrap-overrides.md`) to use a design-first approach — values will be derived from Badie's approved designs via Q&A sessions, not back-filled from legacy app code
- Adds `references/cross-app-audit.md` documenting all ViewComponents, Stimulus controllers, and custom styling across all 5 MPI apps (markaz-crm, avails_server, wpa_film_library, garden, harvest)
- Fixes project board URL from `projects/14` to `projects/15` in 4 files

## Context

The previous token files had "TBD" placeholders that implied values would come from existing app code. Since the design system should be built forward from new designs (not backward from legacy), the tokens now explicitly say "from designs" and include legacy values only as a migration reference section.

The cross-app audit serves as the migration map for:
- Moving all apps to `Admin::Name::Component` naming convention
- Identifying the 28 shared admin components that are currently copy-pasted between repos
- Planning the shared gem extraction

## Test plan

- [x] Verify token files render correctly in GitHub markdown
- [x] Verify project board links point to projects/15
- [ ] Review audit data for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)