### PR TITLE
chore: remove Markaz CRM from design-system docs and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/design-proposal.md
+++ b/.github/ISSUE_TEMPLATE/design-proposal.md
@@ -24,7 +24,7 @@ assignees: ''
 
 ## Target App(s)
 
-<!-- Which app(s): Markaz, SFA, Garden, Harvest, Markaz CRM, or All -->
+<!-- Which app(s): Markaz, SFA, Garden, Harvest, or All -->
 
 ## Data
 

--- a/.github/ISSUE_TEMPLATE/design-revision.md
+++ b/.github/ISSUE_TEMPLATE/design-revision.md
@@ -20,7 +20,7 @@ assignees: ''
 
 ## Target App(s)
 
-<!-- Which app(s) are affected: Markaz, SFA, Garden, Harvest, Markaz CRM, or All -->
+<!-- Which app(s) are affected: Markaz, SFA, Garden, Harvest, or All -->
 
 ## Open Questions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## About This Project
 
-MPI Design System is a Rails engine gem that provides shared ViewComponents, design tokens, and Stimulus controllers for all MPI Media applications (Markaz, SFA, Garden, Harvest, Markaz CRM). It defines the visual language and reusable UI components used across the ecosystem.
+MPI Design System is a Rails engine gem that provides shared ViewComponents, design tokens, and Stimulus controllers for all MPI Media applications (Markaz, SFA, Garden, Harvest). It defines the visual language and reusable UI components used across the ecosystem.
 
 ## Tech Stack
 
@@ -23,7 +23,6 @@ MPI Design System is a Rails engine gem that provides shared ViewComponents, des
 - **SFA** — Video clip hosting and search
 - **Garden** — Static site generator
 - **Harvest** — Ecommerce platform
-- **Markaz CRM** — Customer relationship management
 
 All apps share a common visual language defined by this design system.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ The design system serves these MPI Media applications:
 | **SFA** | Video clip hosting and search |
 | **Garden** | Static site generator |
 | **Harvest** | Ecommerce platform |
-| **Markaz CRM** | Customer relationship management (replacing Dynamics BCC) |
 
 ## Repo Structure
 

--- a/workflow/claude-project-instructions.md
+++ b/workflow/claude-project-instructions.md
@@ -27,7 +27,7 @@ When Badie describes something he needs, your job is to understand the full pict
 - "What data needs to be visible? What actions can they take?"
 - "Is this similar to something that already exists in one of our apps?"
 - "How urgent is this? Is it blocking current work?"
-- "Which app is this for — Markaz, SFA, Garden, Harvest, Markaz CRM — or all of them?"
+- "Which app is this for — Markaz, SFA, Garden, Harvest — or all of them?"
 
 Don't rush to create an issue. Have a real conversation first. Badie often knows more context than he initially shares — draw it out.
 
@@ -67,7 +67,7 @@ Once Badie confirms, create an issue in `mpimedia/mpi-design-system` using this 
 
 ## Target App(s)
 
-[Which app(s): Markaz, SFA, Garden, Harvest, Markaz CRM, or All]
+[Which app(s): Markaz, SFA, Garden, Harvest, or All]
 
 ## Data
 

--- a/workflow/design-proposal.md
+++ b/workflow/design-proposal.md
@@ -17,7 +17,7 @@ Use the **Design Proposal** issue template in this repo. It covers:
 
 - **Component name** — What to call it (plain language)
 - **Description** — What it does, in one or two sentences
-- **Which app(s) need it** — Markaz, SFA, Garden, Harvest, Markaz CRM, or all
+- **Which app(s) need it** — Markaz, SFA, Garden, Harvest, or all
 - **User context** — What is the user trying to accomplish when they encounter this component?
 
 ### Helpful to Include


### PR DESCRIPTION
## Summary

Markaz CRM is sunsetted; `mpimedia/markaz-crm` was archived on GitHub on **2026-05-13**. This PR removes the "Markaz CRM" entry from user-facing app lists and issue-template options across this repo's documentation and templates.

## Changes Made

| File | Change |
|------|--------|
| `CLAUDE.md` | Drop "Markaz CRM" from the app-list sentence in "About This Project"; drop the "Markaz CRM — Customer relationship management" bullet from "MPI Applications Using This Engine" |
| `README.md` | Drop "Markaz CRM" row from the "Applications" table |
| `workflow/design-proposal.md` | Drop "Markaz CRM" from the "Which app(s) need it" options under Required Information |
| `workflow/claude-project-instructions.md` | Drop "Markaz CRM" from the example conversation prompt (Phase 1) and from the issue-body template's `## Target App(s)` line (Phase 3) |
| `.github/ISSUE_TEMPLATE/design-proposal.md` | Drop "Markaz CRM" from the `## Target App(s)` hint comment |
| `.github/ISSUE_TEMPLATE/design-revision.md` | Same as design-proposal |

All six references were menu/list options. None of the workflow files named an in-progress design effort targeted at Markaz CRM, so nothing was preserved as a historical note.

## What's NOT in this PR

Per the task scope, only the 6 files above were edited. The following files in this repo still contain "Markaz CRM" / `markaz_crm` references and should be cleaned up in follow-up PRs:

- `AGENTS.md`
- `.claude/projects.json` (registry entry)
- `mpi_design_system.gemspec`
- `references/qa-session-001-crm-designs.md` (likely a historical QA record — review before removing)
- `references/cross-app-audit.md`
- `references/markaz_tag_system_v2.html`
- `tokens/colors.md`, `tokens/typography.md`, `tokens/bootstrap-overrides.md`
- `spec/components/admin/nav_bar/component_spec.rb`
- `spec/components/previews/admin/nav_bar/component_preview.rb`
- `spec/components/previews/admin/app_shell/component_preview.rb`

## Testing

Doc/template-only change. No application code touched.

- Verified target files contain no remaining `markaz.crm` / `markaz_crm` / `markez` matches (case-insensitive)
- `git diff` shows 6 files / +6 / -8

## Checklist

- [x] All six listed files edited
- [x] Re-grep on target files clean
- [x] Other files containing references documented as follow-ups
- [x] Markaz CRM GitHub repo archive verified (2026-05-13)

— Claude Code (Opus 4.7)