### PR TITLE
chore: add DB-free CI (rubocop, rspec, js-build) + .tool-versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+# Bespoke, DB-free CI for the mpi_design_system engine.
+#
+# The engine is an ActiveRecord-disabled Rails engine (no DB, no Postgres),
+# so it deliberately does NOT use the shared `mpi-application-workflows`
+# `ci-rails.yml`: that reusable workflow's `test` job unconditionally
+# provisions Postgres and runs `db:create db:schema:load`, which fail against
+# the dummy app's disabled ActiveRecord with no toggle to skip.
+#
+# Marketplace actions are pinned to a full commit SHA (immutable / supply-chain
+# safe); the trailing `# vN` comment records the tag the SHA resolves to and
+# lets Dependabot bump it.
+
+on:
+  push:
+    branches: ["**"]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Lint (RuboCop)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Set up Ruby
+        # ruby-version omitted: setup-ruby reads the version from .tool-versions
+        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1
+        with:
+          bundler-cache: true
+      - name: RuboCop
+        run: bin/rubocop -f github
+
+  test:
+    name: Test (RSpec, eager-load)
+    runs-on: ubuntu-latest
+    env:
+      # The dummy app sets `config.eager_load = ENV["CI"].present?`, so CI=true
+      # eager-loads every component and preview constant — the structural safety
+      # net that catches a broken constant/path anywhere in the engine.
+      CI: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@0dafeac902942906541bc140009cdbf32665b601 # v1
+        with:
+          bundler-cache: true
+      - name: RSpec
+        run: bundle exec rspec
+
+  js-build:
+    name: JS build (esbuild)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: ".tool-versions"
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build JS bundle
+        run: yarn build

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+ruby 3.4.2
+nodejs 22
+yarn 4.14.1


### PR DESCRIPTION
## Summary

**PR1 of the four-PR sequence for #103** (Option B, ratified). The `mpi_design_system` engine has **no `.github/workflows/`**, so nothing enforces its mandatory `rubocop`/`rspec` pre-commit gate on push. This adds a bespoke, DB-free CI workflow **first**, so the large namespace rename (PR2) lands against an automated gate rather than a local-only one.

No behavioral/library code changes — CI config + version pins only.

## Changes Made

- **`.github/workflows/ci.yml`** (new) — three DB-free jobs, triggered on `push: ["**"]` + `workflow_dispatch`:
  - **lint** — `bin/rubocop -f github`
  - **test** — `bundle exec rspec` with `env: CI: "true"` so the dummy app's `config.eager_load = ENV["CI"].present?` **eager-loads every component + preview constant** (the structural safety net for PR2's rename)
  - **js-build** — `corepack enable` → `yarn install --immutable` → `yarn build` (catches esbuild breakage in the Stimulus controller PR2 edits)
- **`.tool-versions`** (new, root) — `ruby 3.4.2`, `nodejs 22`, `yarn 4.14.1`.

## Technical Approach

- **Bespoke, not the shared `ci-rails.yml`.** The org's reusable `mpi-application-workflows/ci-rails.yml` `test` job unconditionally provisions Postgres and runs `db:create db:schema:load`, which fail against this engine's **ActiveRecord-disabled** dummy app, with no toggle to skip. A DB-free bespoke workflow is the correct fit. (A follow-up could add an upstream `database: false` toggle so the engine can adopt the reusable workflow later — deferred, non-blocking.)
- **SHA-pinned marketplace actions.** `actions/checkout`, `ruby/setup-ruby`, `actions/setup-node` are pinned to a full commit SHA (immutable / supply-chain safe) with a `# vN` comment recording the tag (and enabling Dependabot bumps). The SHAs resolve to the same major versions the org's shared workflows use (checkout v6, setup-ruby v1, setup-node v6).
- **Single source of truth for versions.** `setup-ruby` and `setup-node` read `.tool-versions` (ruby auto-detected; `node-version-file: .tool-versions`), so the pin lives in one place.
- **No untrusted input** in any `run:` step — no workflow-injection surface.

### ⚠️ Version-pin decision to confirm

The plan picked `ruby 3.4.2 / nodejs 22 / yarn 4.14.1`, and I kept those because they are the correct picks **for a library**:
- **ruby 3.4.2** honors the gemspec floor (`required_ruby_version >= 3.4`) and the engine's existing `spec/dummy/.ruby-version` — CI testing the *minimum supported* Ruby is what protects consumers still on 3.4.
- **nodejs 22** matches the org's shared `update-packages.yml` (`node-version: '22'`).
- **yarn 4.14.1** matches the engine's own `package.json` `packageManager` + `.yarnrc.yml` `yarnPath` (non-negotiable — corepack resolves this).

**Heads-up:** the sibling *app* `.tool-versions` (optimus/garden/harvest/markaz) have since moved to `ruby 4.0.5 / nodejs 26.4.0 / yarn 4.15.0`. I deliberately did **not** match those — this is a gem, not an app, and should test its declared floor — but flagging it so you can veto in review if you'd rather the engine track the app suite's versions.

## Testing

CI is the deliverable; verified all three jobs' local equivalents are green (Ruby 4.0.5 locally; CI runs 3.4.2 as the authoritative confirmation):

- `bundle exec rubocop` → **132 files, no offenses**
- `CI=true bundle exec rspec` → **496 examples, 0 failures** (eager-load path exercised)
- `yarn install --immutable` + `yarn build` → **Build complete**
- `.github/workflows/ci.yml` validates as YAML

No new specs — the workflow *is* the deliverable, and `rspec` was already green.

## Checklist

- [x] `bundle exec rubocop -a` — 0 offenses
- [x] `bundle exec rspec` — 0 failures (`CI=true` eager-load)
- [x] `yarn install --immutable` + `yarn build` succeed
- [x] Marketplace actions SHA-pinned with version comments
- [x] No DB/Postgres dependency (bespoke, not `ci-rails.yml`)
- [x] `Part of #103` (no closing keyword — PR4 closes the umbrella)
- [ ] CI green on this PR (confirm via `gh pr checks`)

Part of #103

— Claude Code (Opus 4.8)
