### PR TITLE
chore: engine-tailored .claude/rules (105 PR-C)

### DIFF
--- a/.claude/rules/dependencies.md
+++ b/.claude/rules/dependencies.md
@@ -1,0 +1,57 @@
+# Dependency Rules
+
+Applies to: `mpi_design_system.gemspec`, `Gemfile`, `package.json`, `yarn.lock`, `.yarnrc.yml`
+
+## This Repo Is a Gem — Runtime Dependencies Propagate
+
+- Runtime dependencies live in `mpi_design_system.gemspec` and are forced into the bundle
+  of **every consuming app** (Markaz, SFA, Garden, Harvest). The current runtime set is
+  deliberately tiny: `rails >= 8.1`, `view_component >= 3.0`, `stimulus-rails`,
+  `bootstrap ~> 5.3`, with `required_ruby_version >= 3.4`
+- Adding or tightening a gemspec dependency is an ecosystem-wide decision — it constrains
+  every consumer's resolution. Keep constraints as loose as safely possible, and never add
+  a runtime dependency for something only used in development or test
+- Development/test-only gems (puma, propshaft, jsbundling-rails, cssbundling-rails,
+  lookbook, foreman, rspec-rails, capybara, rubocop-rails-omakase) belong in the
+  `Gemfile`, never in the gemspec
+
+## Lockfiles
+
+- `Gemfile.lock` is **deliberately gitignored** — engines don't commit lockfiles, so the
+  engine resolves fresh within its constraints the same way it will inside each consuming
+  app. Do not commit it and do not "fix" its absence
+- `yarn.lock` **is** committed, and `package.json` pins JS dependencies to exact versions.
+  CI installs with `yarn install --immutable`, so a `package.json` change without a
+  matching lockfile update fails the build
+
+## Release-Age Cooldown (Supply-Chain Guardrail)
+
+MPI treats freshly published releases as elevated supply-chain risk — a compromised
+release is most dangerous in its first days.
+
+- Unlike the MPI app repos, this engine does **not** currently configure resolver-level
+  gates (no `cooldown:` in the `Gemfile`, no `npmMinimalAgeGate` in `.yarnrc.yml`), so
+  the cooldown is applied at **review time** instead
+- When authoring or reviewing a version bump, check the release date; prefer releases at
+  least a week old. Adopting a younger release requires a stated reason in the PR — a
+  security advisory is the standard one, noted with its CVE/advisory ID
+- If resolver-level gates are added later, mirror the app-repo convention rather than
+  inventing a new one
+
+## Dependabot and Actions Pinning
+
+- Dependabot PRs (npm and GitHub Actions bumps arrive regularly) go through `/dep-review`
+  (`.claude/commands/dep-review.md`): identify the dependency and version delta, check the
+  changelog for breaking changes, assess usage in the engine, and run the full suite
+  against the PR branch before recommending merge
+- GitHub Actions in `.github/workflows/ci.yml` are pinned to full commit SHAs with a
+  trailing `# vN` comment so Dependabot can still bump them — keep any new action
+  SHA-pinned the same way
+
+## Anti-Patterns
+
+- Never add a runtime dependency to the gemspec that consumers don't strictly need
+- Never move a dev/test gem from the `Gemfile` into the gemspec to "fix" a load error
+- Never commit `Gemfile.lock`
+- Never merge a dependency PR without `/dep-review` and green CI
+- Never replace a SHA-pinned action with a floating tag

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,0 +1,70 @@
+# Frontend Rules
+
+Applies to: `app/components/**`, `app/javascript/**`, `app/assets/**`
+
+## Framework
+
+- This repo is a Rails engine gem — everything under `app/` ships to every consuming app (Markaz, SFA, Garden, Harvest)
+- Hotwire only (Turbo + Stimulus) — never React, Vue, or other JS frameworks
+- ViewComponent for all UI components
+- Bootstrap 5.3 for all styling — never Tailwind CSS
+
+## ViewComponent Conventions
+
+- Components follow the `Admin::Name::Component` pattern:
+  `app/components/admin/<name>/component.rb` + `component.html.erb`
+- Components inherit directly from `ViewComponent::Base`. There is **no**
+  `ApplicationComponent` base class in this engine — do not reference or invent one
+- Every component ships with a spec (`spec/components/admin/<name>/component_spec.rb`)
+  and a Lookbook preview (`spec/components/previews/admin/<name>/component_preview.rb`)
+- Validate params in the component and fall back to safe defaults (e.g. `Admin::Badge::Component`
+  maps an unknown color to `primary`) — never let bad input render broken markup
+
+## Component Catalog First
+
+Before creating a new component, check the catalog for an existing spec:
+
+- `catalog/elements/` — buttons, badges, inputs, chips (Atoms)
+- `catalog/components/` — cards, tables, pagination, navbars (Molecules)
+- `catalog/patterns/` — forms, search, filters (Organisms)
+- `catalog/layouts/` — app shell, dashboard, detail/list views (Templates)
+
+If a catalog entry exists, implement to that spec. If not, raise it with the HC before building.
+
+## Styling and Tokens
+
+- Use Bootstrap utility and component classes — no arbitrary hex values, sizes, or spacing
+- Design tokens live in `app/assets/stylesheets/mpi_design_system/_tokens.scss` and override
+  Bootstrap variables before Bootstrap is imported (`$mpi-primary: #2E75B6`,
+  `$mpi-brand-navy: #1B2A4A`, `$mpi-brand-accent: #4EA8DE`)
+- Token documentation lives in `tokens/*.md` (colors, typography, spacing, components,
+  navigation, bootstrap-overrides) — consult it before choosing values
+- Custom SCSS only when Bootstrap genuinely cannot express the design; keep it in a
+  dedicated partial under `app/assets/stylesheets/mpi_design_system/` (existing example:
+  `_nav_bar.scss`) and import it from `application.scss`
+
+## Stimulus Controllers
+
+- Controllers live in `app/javascript/mpi_design_system/controllers/`
+- Every controller must be registered in `controllers/index.js` inside
+  `registerMpiControllers(application)` (e.g. `application.register("tag-input", TagInputController)`)
+  and exported from that file — consuming apps call `registerMpiControllers` to wire up
+  all engine controllers at once
+- The top-level `app/javascript/mpi_design_system/index.js` re-exports
+  `registerMpiControllers` and the individual controllers — keep it in sync when adding one
+- No inline JavaScript in ERB templates — attach behavior via `data-controller` attributes
+
+## Accessibility (WCAG 2.1 AA minimum)
+
+- All interactive elements keyboard-accessible
+- Appropriate ARIA roles and labels (e.g. Badge adds `aria-label` for its count)
+- Contrast: 4.5:1 for normal text, 3:1 for large text — pair light backgrounds with dark
+  text classes (e.g. `bg-warning` with `text-dark`)
+- Visible focus indicators on every focusable element
+
+## Anti-Patterns
+
+- Never add CSS frameworks beyond Bootstrap 5.3 (no Tailwind)
+- Never invent colors, sizes, or spacing outside the tokens and Bootstrap's scale
+- Never add a Stimulus controller without registering it in `registerMpiControllers`
+- Never subclass a nonexistent `ApplicationComponent`

--- a/.claude/rules/self-review.md
+++ b/.claude/rules/self-review.md
@@ -1,0 +1,45 @@
+# Self-Review Rules
+
+Applies to: `app/**`, `spec/**`, `lib/**`
+
+## Before Declaring Work Done
+
+Every time you finish writing or modifying code, run this checklist before telling the
+HC the work is complete:
+
+- [ ] **Plan alignment** — does the change match the issue/plan? Any scope creep, and any
+      planned item silently dropped?
+- [ ] **Spec + preview per component** — does every component change have a corresponding
+      spec update and Lookbook preview update?
+- [ ] **Test quality** — are assertions meaningful? For each test: "If this test passed
+      but the component was broken, would I know?" A spec that only checks the component
+      renders is a false green
+- [ ] **Edge cases** — invalid params, nil values, empty content, fallback defaults
+- [ ] **No debug leftovers** — no `puts`, `console.log`, `binding.irb`, commented-out
+      code, or "TODO" / "needs manual testing" comments. Remove them and write the test
+- [ ] **Catalog and token compliance** — does the component match its `catalog/` spec?
+      Are all values Bootstrap classes or tokens from `_tokens.scss` / `tokens/*.md`
+      (no invented colors, sizes, or spacing)?
+- [ ] **Accessibility pass** — keyboard access, ARIA roles/labels, 4.5:1 / 3:1 contrast,
+      visible focus indicators
+- [ ] **Both required checks green** — the engine has exactly two, and both must pass
+      before any commit or push (no Brakeman or bundler-audit here):
+      - `bundle exec rubocop -a` — zero offenses
+      - `bundle exec rspec` — zero failures
+
+## Never Deflect Work
+
+- Never say "needs manual testing" without proving `render_inline` + Capybara matchers
+  can't cover it
+- Never produce minimal assertions and declare the work complete
+- Never cut corners on the last 20% — edge cases, fallback behavior, and accessibility
+  are where a design system earns its keep, because every consuming app inherits them
+
+## Quality Bar
+
+Think like a senior engineer whose component will render in four applications:
+
+- Would you be comfortable if a critical reviewer examined every line?
+- Did you test the component's behavior, or that the code runs without errors?
+  Those are different things.
+- Are you done, or just at the point where it's tempting to stop?

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,80 @@
+# Testing Rules
+
+Applies to: `spec/**`
+
+## Stack
+
+- RSpec (`rspec-rails`) with ViewComponent test helpers and Capybara matchers —
+  `spec/spec_helper.rb` includes `ViewComponent::TestHelpers` and `Capybara::RSpecMatchers`
+  for `type: :component` specs
+- Render with `render_inline(described_class.new(...))`, assert with Capybara matchers
+  (`expect(page).to have_css(...)`, `have_text`, `have_link`)
+- The engine has no database and no models — the dummy app (`spec/dummy/`) boots without
+  ActiveRecord, so there is no FactoryBot, no fixtures, and no model/request specs
+- There is **no Selenium or system-spec infrastructure in this repo** — the test Gemfile
+  group contains only `rspec-rails` and `capybara` (rack-only matchers). Do not write
+  `js: true` or `type: :system` specs, and do not reference browser drivers that are not
+  in the Gemfile. Stimulus behavior is verified by asserting the rendered `data-controller`
+  / `data-*-target` / `data-action` attributes
+
+## Layout
+
+- Specs mirror components exactly: `spec/components/admin/<name>/component_spec.rb`
+  for `app/components/admin/<name>/component.rb`
+- Lookbook previews live at `spec/components/previews/admin/<name>/component_preview.rb`
+  and inherit `ApplicationComponentPreview` (base class at
+  `spec/components/previews/application_component_preview.rb`, which inherits
+  `ViewComponent::Preview`). Use Lookbook annotations (`@label`, `@display`) and
+  `render_with_template` for multi-example previews
+- `spec/dummy/` is the integration harness: it mounts the engine and serves Lookbook at
+  `/lookbook` in development (`spec/dummy/config/initializers/lookbook.rb` points preview
+  paths at `spec/components/previews`)
+- CI runs with `CI=true`, which makes the dummy app eager-load every component and preview
+  constant — a spec suite that passes locally can still fail CI if a constant or file path
+  is broken, so keep names and paths exact
+
+## Definition of Done for a Component Spec
+
+No component is complete until its spec covers:
+
+1. **Default render** — renders with only the required params
+2. **Every option exercised** — each variant, size, state, and color the component accepts
+   has at least one example
+3. **Meaningful assertions** — assert the classes, text, and attributes that make the
+   component correct, not merely that it renders. Ask: "If this test passed but the
+   component was broken, would I know?"
+4. **Edge cases** — missing/invalid params (e.g. an invalid color falls back to the
+   default), empty or nil content, empty collections
+5. **Accessibility assertions where relevant** — `aria-label`s, roles, and
+   contrast-pairing classes (e.g. `bg-warning` renders with `text-dark`)
+6. **A matching Lookbook preview** exists and its constants load (CI eager-load will
+   catch a broken preview)
+
+## Naming Convention
+
+Follow the `describe` / `context` / `it` structure:
+
+```ruby
+RSpec.describe Admin::Badge::Component, type: :component do
+  context "with an invalid color" do
+    it "falls back to the primary color" do
+      render_inline(described_class.new(label: "Test", color: :invalid))
+
+      expect(page).to have_css("span.badge.bg-primary")
+    end
+  end
+end
+```
+
+- `context` — specific scenario or state (`when`, `with`, `without`)
+- `it` — one outcome, with a description that states the expected behavior
+- Use `let` for setup, not instance variables
+
+## Anti-Patterns
+
+- Never assert only that a component "renders without error" — that is a false green
+- Never test private methods — test through the rendered output
+- Never reference models, the database, or request/feature specs — the engine has none
+- Never claim a behavior "needs manual testing" without first attempting it with
+  `render_inline` and Capybara matchers
+- Never skip edge cases because "they're unlikely"


### PR DESCRIPTION
## Summary

Creates `.claude/rules/` for the design-system engine (it did not exist before). The four files use the Optimus rules as structural templates (headers, `Applies to:` glob convention, tone, length) but every claim in them was verified against this repo's actual code before being written — per the #105 requirement to avoid the earlier class of error where docs referenced a nonexistent `ApplicationComponent` base class.

Part of #105

## Changes Made

- `.claude/rules/frontend.md` (70 lines) — applies to `app/components/**`, `app/javascript/**`, `app/assets/**`. ViewComponent conventions (`Admin::Name::Component`, `component.rb` + `component.html.erb`, inherits `ViewComponent::Base` directly — explicitly warns there is no `ApplicationComponent`), catalog-first workflow (`catalog/elements|components|patterns|layouts`), Bootstrap 5.3 + `_tokens.scss` / `tokens/*.md` token discipline, Stimulus registration via `registerMpiControllers` in `app/javascript/mpi_design_system/controllers/index.js`, WCAG 2.1 AA requirements
- `.claude/rules/testing.md` (80 lines) — applies to `spec/**`. `render_inline` + Capybara matchers (as configured in `spec/spec_helper.rb`), spec layout mirroring components (`spec/components/admin/<name>/component_spec.rb`), Lookbook previews at `spec/components/previews/admin/<name>/component_preview.rb` inheriting `ApplicationComponentPreview`, `spec/dummy/` as the DB-free integration harness, `CI=true` eager-load safety net, a definition of done for component specs, and an explicit statement that no Selenium/system-spec infrastructure exists in this repo
- `.claude/rules/self-review.md` (45 lines) — plan-alignment check, test-quality interrogation ("if this test passed but the component was broken, would I know?"), no debug leftovers/TODOs, catalog/token compliance, accessibility pass, and the engine's exactly-two required checks (`bundle exec rubocop -a`, `bundle exec rspec` — no Brakeman/bundler-audit)
- `.claude/rules/dependencies.md` (57 lines) — this repo IS a gem: runtime deps in `mpi_design_system.gemspec` (`rails >= 8.1`, `view_component >= 3.0`, `stimulus-rails`, `bootstrap ~> 5.3`) propagate to every consuming app; dev/test gems stay in the `Gemfile`; `Gemfile.lock` deliberately gitignored while `yarn.lock` is committed; release-age cooldown applied at review time (this repo has no resolver-level gates); Dependabot PRs go through `/dep-review`; CI actions stay SHA-pinned

Deliberately omitted: `backend.md`, `migrations.md`, `security.md` — the engine has no models/controllers/jobs, no database, and no app credentials.

## Technical Approach

- Read the seven Optimus rule files first, then verified every engine fact by reading the corresponding source (component classes, JS entry points, `spec_helper.rb`, sample specs/previews, the gemspec, `Gemfile`, `.gitignore`, `.yarnrc.yml`, `package.json`, `spec/dummy` config, `.github/workflows/ci.yml`) before asserting it
- Where Optimus rules describe infrastructure this repo lacks (Selenium feature specs, FactoryBot, resolver cooldown gates, Brakeman), the engine rules either state the absence explicitly or reframe the policy honestly (e.g. cooldown as a review-time discipline) instead of copying claims that would be false here
- Verified every `Applies to:` glob resolves to real paths

## Testing

- Grep gate: `grep -rEi 'searchkick|kamal|pundit|goodjob|devise|db/migrate' .claude/rules/` returns nothing
- `bundle exec rubocop -a` — 132 files inspected, no offenses detected
- `bundle exec rspec` — 496 examples, 0 failures (suite untouched, as expected for a docs-only change)

## Checklist

- [x] Tests pass (496 examples, 0 failures)
- [x] Linting passes (no offenses)
- [x] Every `Applies to:` glob matches real paths
- [x] All factual claims verified against engine source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude Code (Fable 5)