### PR TITLE
docs: standards core + cross-repo sync (105 PR-D)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+# GitHub Copilot Instructions for MPI Design System
+
+**`AGENTS.md` at the repository root is the source of truth for all AI coding agents in this repo — read it first and follow it.**
+
+Quick orientation:
+
+- This is a Rails engine gem providing shared ViewComponents, design tokens, and Stimulus controllers for the MPI Media apps (Markaz, SFA, Garden, Harvest).
+- Pre-commit requirements (no exceptions): `bundle exec rubocop -a` (zero offenses) and `bundle exec rspec` (zero failures).
+- Never commit directly to `main` — create a feature branch first.
+- Agent attribution is required on every commit, PR, and comment — see "Agent Attribution" in `AGENTS.md`.
+- Review severity levels (P0/P1/P2) are summarized in `AGENTS.md` and expanded in `docs/standards/code-review.md`.
+
+For lifecycle and process standards, see `docs/standards/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,8 @@ Before creating a new component, check the existing catalog:
 - `catalog/patterns/` — Forms, search bars, filters, data entry (Organisms)
 - `catalog/layouts/` — Dashboards, detail pages, list views (Templates)
 
+Machine-readable component inventory and token reference work is tracked in issue #96 — do not expand catalog metadata here without checking that issue first.
+
 ## Design Tokens
 
 Reference these tokens when choosing values. Do not invent arbitrary colors, sizes, or spacing.
@@ -178,6 +180,26 @@ Reference these tokens when choosing values. Do not invent arbitrary colors, siz
 - Maintain 4.5:1 contrast ratio for normal text, 3:1 for large text
 - Provide visible focus indicators
 
+## Domain-Triggered Rules
+
+Detailed conventions live in `.claude/rules/` — consult the matching rule when working in its area:
+
+| Rule | What It Covers | Applies When |
+|------|----------------|--------------|
+| `.claude/rules/frontend.md` | ViewComponent, Stimulus, and Bootstrap 5 patterns | Working in `app/components/`, `app/javascript/`, or `app/assets/` |
+| `.claude/rules/testing.md` | Component spec, Lookbook preview, and dummy-app coverage requirements | Writing or changing anything under `spec/` |
+| `.claude/rules/self-review.md` | Pre-PR self-review checklist | Before creating or updating any PR |
+| `.claude/rules/dependencies.md` | Dependency update policy for a published gem | Touching `Gemfile`, `*.gemspec`, `package.json`, or reviewing dependency PRs |
+
+## Standards Documentation
+
+Process standards live in `docs/standards/`:
+
+- `docs/standards/development-lifecycle.md` — the five-stage lifecycle behind `/assess`, `/cplan`, `/impl`, `/verify`, `/final`
+- `docs/standards/code-review.md` — review checklists and the P0/P1/P2 Severity Priority framework
+- `docs/standards/memory-management.md` — auto-memory structure, budgets, and maintenance (`/memory-review`)
+- `docs/standards/cross-repo-sync.md` — how this engine stays in sync with the Optimus template (`/compare`)
+
 ## Commit and PR Standards
 
 **All commits and PRs must have verbose, detailed documentation.**
@@ -192,7 +214,7 @@ Detailed explanation of changes:
 - Technical approach taken
 - Any architectural decisions made
 
-Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
 ```
 
 ### PR Description Format
@@ -221,7 +243,7 @@ Detailed overview of what this PR accomplishes and why it was needed.
 
 Every AI agent **must** include attribution on every piece of work:
 
-- **Commits**: `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+- **Commits**: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` (the active model — kept current via `docs/standards/cross-repo-sync.md`)
 - **PRs**: Agent name in description footer
 - **Comments**: Attribution line
 

--- a/docs/standards/code-review.md
+++ b/docs/standards/code-review.md
@@ -1,0 +1,104 @@
+# MPI Design System Code Review Standards
+
+These standards apply to all reviewers: Human Contributors (HC), AI Contributors (AC), and external Reviewers. The severity framework below is the canonical expansion of the "Review Guidelines" summary in `AGENTS.md` — keep the two consistent (see `docs/standards/cross-repo-sync.md`).
+
+## Automated Checks (Must Pass)
+
+Before any review begins, both required checks must pass:
+
+- `bundle exec rubocop -a` — zero offenses
+- `bundle exec rspec` — zero failures
+
+These two are the engine's complete required-check set. App repos in the MPI suite run additional app-only checks; their absence here is deliberate — see `docs/standards/cross-repo-sync.md`.
+
+## ViewComponents
+
+- [ ] Components follow the `Admin::Name::Component` pattern at `app/components/admin/`
+- [ ] Each component is a `component.rb` (Ruby logic) + `component.html.erb` (template) pair
+- [ ] Slots use `renders_one` / `renders_many`
+- [ ] Conditional logic lives in the Ruby class, not the template
+- [ ] Lookbook preview added or updated in `spec/components/previews/`
+
+## Styling and Tokens
+
+- [ ] Bootstrap 5 classes for all styling — no custom CSS unless absolutely necessary
+- [ ] Values come from design tokens (`_tokens.scss`, `tokens/` docs) — no arbitrary colors, sizes, or spacing
+- [ ] Semantic color classes (`btn-primary`, `text-danger`) over custom hex values
+- [ ] Responsive by default — Bootstrap grid and responsive utilities
+
+## Stimulus / JavaScript
+
+- [ ] Interactive behavior uses Stimulus controllers in `app/javascript/mpi_design_system/controllers/`
+- [ ] New controllers are registered in `controllers/index.js` so `registerMpiControllers` picks them up
+- [ ] Hotwire stack only — no other client-side frameworks
+
+## Security
+
+- [ ] User-supplied content is escaped in ERB templates — no `raw` / `html_safe` without sanitization
+- [ ] External links pair `target: "_blank"` with `rel: "noopener noreferrer"`
+- [ ] No secrets or credentials in code, specs, or fixtures
+
+## Accessibility
+
+- [ ] WCAG 2.1 AA compliance minimum
+- [ ] All interactive elements keyboard-accessible
+- [ ] Appropriate ARIA roles and labels
+- [ ] Contrast: 4.5:1 for normal text, 3:1 for large text
+- [ ] Visible focus indicators
+
+## Gem Packaging and Consuming Apps
+
+- [ ] Changes to what ships in the gem are checked against the gemspec `files` glob (`{app,config,lib}/**/*`)
+- [ ] Breaking component API changes are flagged — they affect all consuming apps (Markaz, SFA, Garden, Harvest)
+
+## Tests
+
+- [ ] Component specs cover every variant, size, and state with assertions on rendered output (`render_inline` + Capybara matchers) — not just "it renders"
+- [ ] Edge cases: invalid/missing params, empty collections, boundary values
+- [ ] Interactive behavior exercised through the dummy app (`spec/dummy/`)
+- [ ] Accessibility assertions (ARIA attributes, keyboard access) where relevant
+- [ ] See `.claude/rules/testing.md` for the full definition of done
+
+## Documentation
+
+- [ ] Catalog (`catalog/`) and token docs (`tokens/`) updated when the visual language changes
+- [ ] `CLAUDE.md` updated if new patterns or commands are introduced
+- [ ] Commit messages follow the format in `CLAUDE.md`
+
+## Agent Attribution
+
+- [ ] Every commit has a `Co-Authored-By` trailer for the agent that wrote it
+- [ ] PR description includes agent attribution footer
+- [ ] Issue/PR comments include an attribution line
+
+## Severity Priority
+
+When triaging review findings, classify each issue by severity. These definitions match the "Review Guidelines" in `AGENTS.md`.
+
+### P0 — Must Fix (blocks merge)
+
+- Security vulnerabilities (XSS in component templates, missing escaping)
+- Broken tests or tests that don't test what they claim
+- Accessibility violations (missing ARIA attributes, poor contrast)
+
+### P1 — Should Fix (request changes; merge after fix)
+
+- Pattern violations (components not following the `Admin::Name::Component` convention)
+- Missing tests for new components
+- Incorrect Bootstrap class usage
+- Missing responsive behavior
+
+### P2 — Consider (suggest; fix or explain why not — HC decides)
+
+- Naming improvements
+- Code organization suggestions
+- Additional component variants or states
+
+### Discussion
+
+- Architectural questions, alternative approaches, clarification requests — not defects; resolve in conversation before or alongside the fix cycle
+
+### Resolution Rules
+
+- All P0 and P1 findings must be resolved before the SOW is generated (Stage 5 of `docs/standards/development-lifecycle.md`)
+- Do not argue with Reviewer findings unless factually incorrect — if the Reviewer flags it, it's a real gap

--- a/docs/standards/cross-repo-sync.md
+++ b/docs/standards/cross-repo-sync.md
@@ -61,6 +61,14 @@ Run `/compare` (defaults to comparing this repo against Optimus):
 4. **Gates** — both required checks pass (`bundle exec rubocop -a`, `bundle exec rspec`); grep the changed docs/rules for imported app-isms and confirm none appear.
 5. **Upstream first** — if the better pattern originated in *this* repo, change Optimus first, then propagate back here. The template stays canonical.
 
+## Upstream Findings Log
+
+The standing record of findings *against the canonical template* that were deliberately **not** fixed locally — the local copy stays byte-identical and the fix belongs upstream in Optimus (per "Upstream first" above). Log each one here so drift checks and future ports don't re-discover or "helpfully" patch them.
+
+| Date | Finding | Disposition | Evidence | Status |
+|------|---------|-------------|----------|--------|
+| 2026-07-01 | `bin/guard-protected-branch` (byte-identical Optimus port) intends to exempt Human Contributors via TTY detection (`[[ ! -t 0 ]]` fallback), but git >= 2.36 runs hooks with stdin attached to `/dev/null` — so through the git layer (`.githooks/*`) **every** invocation, human or AI, is classified as an AC and blocked on protected branches. Verified empirically on git 2.55 (scratch repo, hooks installed, AC env vars unset, real PTY: commit and push on `main` both blocked). Practical impact low: the flow is PR-based and HCs retain `git commit/push --no-verify`. The alternative fix (probing `/dev/tty`) risks silently exempting ACs. Found during Stage-4 verification of PR #108. | Accept-and-document; byte-identity with Optimus preserved | [PR #108 comment](https://github.com/mpimedia/mpi-design-system/pull/108#issuecomment-4860931688) | To raise upstream in Optimus |
+
 ## Model Attribution Strings
 
 Attribution strings are hardcoded and go stale as models change: the commit trailer (`Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`) and comment/PR footer (`— Claude Code (Fable 5)`) appear in `CLAUDE.md`, `AGENTS.md`, the `attribution` block of `.claude/settings.json`, and the command templates. Keeping them current is part of this sync process:

--- a/docs/standards/cross-repo-sync.md
+++ b/docs/standards/cross-repo-sync.md
@@ -1,0 +1,98 @@
+# Cross-Repo Standards Synchronization
+
+How this engine's agent configuration stays in sync with the MPI application suite. **Optimus is the canonical template** — standards originate there and propagate outward. "In sync" is an ongoing obligation, not a one-time port: when Optimus's agent configuration evolves (a new lifecycle stage, a renamed command, a newly shared plugin), this repo tracks the change deliberately instead of re-diverging.
+
+This document is the backbone of that process; `/compare` is its drift-check command.
+
+## The Two-Layer Model
+
+The agent configuration splits into two layers that are treated **differently**. Machinery converges tightly on Optimus; domain content is tailored to engine scope. Knowing which layer a file belongs to tells you whether a difference from Optimus is drift (fix it) or tailoring (keep it).
+
+### Layer 1: Machinery — sync tightly with the suite
+
+Same names, same numbers, same structure as Optimus. Engine-scoped wording *inside* these files is expected; their shape is not allowed to drift.
+
+| Machinery | Files | Sync Rule |
+|-----------|-------|-----------|
+| Lifecycle commands | `.claude/commands/*.md` | Same command names, stage numbers, and document structure as Optimus. This repo's flat set: `assess`, `compare`, `cplan`, `dep-review`, `explore`, `final`, `impl`, `memory-review`, `orch`, `rtr`, `verify`. Step content is engine-scoped (components, previews, tokens — not app systems). |
+| `settings.json` structure | `.claude/settings.json` | The **attribution block** (commit trailer + PR footer strings), the **PreToolUse hook matcher** list (`Write\|Edit\|Bash(git commit:*)\|Bash(git push:*)\|Bash(git merge:*)\|Bash(git rebase:*)`), and the **enabledPlugins** scheme converge with Optimus. The plugin *list* is tailored to engine relevance: design/frontend-facing plugins kept, app/infra-only plugins dropped. |
+| Agent-layer branch hook | `.claude/hooks/enforce-branch-creation.sh` | Optimus's fail-closed variant. Logic changes sync from Optimus, not local edits. |
+| Git-layer branch guard | `.githooks/{pre-commit,pre-push,pre-merge-commit,pre-rebase}`, `bin/guard-protected-branch`, `bin/install-git-hooks` | Ported from Optimus; the AC-vs-HC detection logic must match the template. |
+| Project registry | `.claude/projects.json` | Matches Optimus's current registry — Optimus's copy is the source of truth for the ecosystem entry list. |
+| Standards doc structure | `docs/standards/*.md` | Stage definitions, gate structure, severity framework, and thresholds track Optimus's versions; the content inside is engine-scoped. |
+
+### Layer 2: Domain Content — tailored to engine scope
+
+Governed by what a Rails engine gem (ViewComponents, Stimulus controllers, design tokens, `spec/dummy`) actually needs — not by matching Optimus file-for-file.
+
+| Domain Content | Files | Tailoring Rule |
+|----------------|-------|----------------|
+| Rules selection and content | `.claude/rules/{frontend,testing,self-review,dependencies}.md` | *Which* rules exist and *what they say* is decided by engine scope. Content is authored against the engine's actual code, never fork-and-pruned from an app repo. |
+| Standards selection | `docs/standards/` (lean core: development-lifecycle, code-review, memory-management, cross-repo-sync) | The engine adopts only the standards that apply to a UI-component gem. Optimus carries many more; that's correct for an app. |
+| `CLAUDE.md` / `AGENTS.md` specifics | Tech stack, component catalog, design tokens, consuming-app list, engine architecture | Suite-shared sections (permissions model, commit/PR format, attribution, pre-commit requirements) follow the template; everything else is engine-specific. |
+
+## Deliberate Omissions Are NOT Drift
+
+The engine intentionally omits app-only material. `/compare` must classify these as correct tailorings, not gaps to fix:
+
+- **`.claude/rules/backend.md`, `.claude/rules/migrations.md`** — the engine has no app models, controllers, jobs, or database
+- **`/db-health` command** — no database to health-check
+- **App-credentials `deny` entries** in `settings.json` (`master.key`, `credentials.yml.enc`) — the engine has no app credentials; the engine analog protects `spec/dummy/config/**` instead
+- **App-only required checks** — Optimus's app repos require additional checks beyond linting and tests (a static security scanner and a dependency-vulnerability audit). The engine's required-check set is exactly two: `bundle exec rubocop -a` and `bundle exec rspec`
+- **App-framework standards docs** (query patterns, caching, app view patterns, deployment tooling) and **infra-only plugins**
+
+When adding a new deliberate omission, record it here so future drift checks don't re-litigate it.
+
+## Drift-Check Cadence
+
+Run `/compare` (defaults to comparing this repo against Optimus):
+
+- **Quarterly baseline** — even when nothing is known to have changed
+- **Event-driven** — whenever Optimus's agent configuration changes materially: a new or renamed command, a new lifecycle stage, a change to the `settings.json` structure (hook matchers, attribution block, plugin scheme), a newly shared plugin, an updated branch-protection script, or a revision to the core standards docs
+
+## What To Do When Drift Is Found
+
+1. **Classify** each difference reported by `/compare`:
+   - **Machinery drift** — must sync (converge on Optimus)
+   - **Domain divergence** — evaluate on engine merits; adopt structure, adapt content
+   - **Deliberate omission** — no action; confirm it's recorded above
+2. **Assess** — for anything beyond trivial, open or annotate an issue and run the lifecycle (`/assess`). Trivial machinery syncs may use the compressed workflow per `docs/standards/development-lifecycle.md` (HC decides).
+3. **Sync PR** — a `chore/` or `docs/` branch that converges the machinery and adapts wording to engine scope. Verify every command → doc reference still resolves after the change.
+4. **Gates** — both required checks pass (`bundle exec rubocop -a`, `bundle exec rspec`); grep the changed docs/rules for imported app-isms and confirm none appear.
+5. **Upstream first** — if the better pattern originated in *this* repo, change Optimus first, then propagate back here. The template stays canonical.
+
+## Model Attribution Strings
+
+Attribution strings are hardcoded and go stale as models change: the commit trailer (`Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`) and comment/PR footer (`— Claude Code (Fable 5)`) appear in `CLAUDE.md`, `AGENTS.md`, the `attribution` block of `.claude/settings.json`, and the command templates. Keeping them current is part of this sync process:
+
+- `/compare` checks this repo's attribution strings against Optimus's current attribution block
+- A sync PR that updates the model string updates **all** occurrences in one pass — a half-updated repo is worse than a stale one
+
+## File Structure Convention
+
+The engine's agent-configuration layout (machinery vs. domain content annotated):
+
+```
+mpi-design-system/
+├── CLAUDE.md                          # Shared sections = machinery; engine specifics = domain
+├── AGENTS.md                          # Same split; source of truth for non-Claude agents
+├── .claude/
+│   ├── settings.json                  # Machinery (structure) — plugin list tailored
+│   ├── hooks/
+│   │   └── enforce-branch-creation.sh # Machinery — agent-layer branch protection
+│   ├── commands/                      # Machinery — 11 lifecycle/support commands
+│   ├── rules/                         # Domain content — engine-tailored rules
+│   └── projects.json                  # Machinery — MPI ecosystem registry
+├── .githooks/                         # Machinery — git-layer branch protection
+├── bin/
+│   ├── guard-protected-branch         # Machinery — AC-vs-HC aware guard
+│   └── install-git-hooks              # Machinery — sets core.hooksPath
+├── .github/
+│   └── copilot-instructions.md        # Points Copilot at AGENTS.md
+└── docs/
+    └── standards/                     # Domain selection; structure tracks Optimus
+        ├── development-lifecycle.md
+        ├── code-review.md
+        ├── memory-management.md
+        └── cross-repo-sync.md         # This document
+```

--- a/docs/standards/development-lifecycle.md
+++ b/docs/standards/development-lifecycle.md
@@ -1,0 +1,178 @@
+# MPI Development Lifecycle
+
+## Purpose
+
+Defines how an AI Contributor (AC) works from problem definition through delivery in this repository. The stage names, numbers, and quality gates are shared machinery across the MPI suite (canonical source: Optimus — see `docs/standards/cross-repo-sync.md`); the stage content below is scoped to what a Rails engine gem needs. The lifecycle is model-agnostic — the stages and quality gates stay the same as AC capabilities improve. What changes over time is which gates require external review vs. self-review.
+
+## Roles
+
+- **HC** — Human Contributor. Makes decisions, approves gates, owns the product.
+- **AC** — AI Contributor. Does the work, self-reviews, responds to feedback.
+- **Reviewer** — External AI reviewer (currently Codex). Provides unbiased critique.
+
+## The Lifecycle
+
+### Stage 1: Assess (`/assess`)
+
+**Trigger:** HC assigns an issue or asks AC to review one.
+
+**AC produces:**
+- Summary of the problem and its impact
+- Research into the engine: components (`app/components/admin/`), Stimulus controllers (`app/javascript/mpi_design_system/controllers/`), SCSS tokens, specs, Lookbook previews, and the catalog (`catalog/`) and token docs (`tokens/`)
+- Catalog check — does an existing component or variant already cover the need?
+- Consuming-app impact — component API changes affect Markaz, SFA, Garden, and Harvest; gem packaging changes are checked against the gemspec `files` glob
+- 2-3 options with trade-offs, not just one recommendation
+- Risk assessment for each option
+- Complexity call (Small / Medium / Large — Large recommends `/orch` for parallel agents)
+- Questions for HC if requirements are ambiguous (ask, don't guess)
+
+**Quality gate:** HC sends assessment to Reviewer. Reviewer checks for:
+- Missing options or trade-offs not considered
+- Incorrect assumptions about the codebase
+- Requirements gaps or misunderstandings
+- Architectural or accessibility concerns
+
+**Exit:** HC picks an option (or asks for revisions). AC does not proceed without a chosen option.
+
+---
+
+### Stage 2: Plan (`/cplan`)
+
+**Trigger:** HC picks an option from the assessment.
+
+**AC produces:**
+- Step-by-step implementation plan with specific file paths
+- Testing strategy — decided now, not during implementation:
+  - Component specs: every variant, size, and state, with assertions on rendered output
+  - Lookbook previews: every new component gets one
+  - Interactive behavior: Stimulus controllers exercised through the dummy app (`spec/dummy/`)
+  - Edge cases: invalid/missing params, empty content, accessibility assertions
+- Development environment: simple branch vs. git worktree; branch naming (`feature/`, `fix/`, `chore/`, `docs/`)
+- Agent strategy: single agent, or parallel agents via `/orch` (15+ files or independent subsystems)
+- Risks: breaking component API changes, consuming-app impact, gem packaging, accessibility regressions
+
+**Quality gate:** HC sends plan to Reviewer. Reviewer checks for:
+- Steps too vague to implement without guessing
+- Missing edge cases in the testing strategy
+- Patterns that don't match the engine's conventions
+- Requirements from the issue not addressed in the plan
+
+**Exit:** HC approves plan (or asks for revisions). AC does not write code without an approved plan.
+
+---
+
+### Stage 3: Implement (`/impl`)
+
+**Trigger:** HC approves the plan.
+
+**AC does:**
+- Creates the feature branch specified in the plan
+- Implements according to the plan, step by step, following `CLAUDE.md` conventions and `.claude/rules/frontend.md`
+- Writes tests per the Stage 2 testing strategy, following `.claude/rules/testing.md`
+- Adds or updates a Lookbook preview for every new or changed component
+- Runs both required checks: `bundle exec rubocop -a`, `bundle exec rspec`
+
+**Quality gate:** AC self-review before requesting any review, per `.claude/rules/self-review.md`:
+- [ ] Every item in the plan is implemented
+- [ ] Every test scenario from the plan is covered
+- [ ] Component specs assert rendered output (Capybara matchers) for every variant, size, and state
+- [ ] Interactive behavior exercised through the dummy app (`spec/dummy/`)
+- [ ] Accessibility: ARIA attributes, keyboard access, contrast (WCAG 2.1 AA)
+- [ ] Edge cases: invalid params, empty content, boundary values
+- [ ] "What would the Reviewer flag here?" — identify and fix before moving on
+- [ ] Both checks pass (`bundle exec rubocop -a`, `bundle exec rspec`)
+
+**Exit:** Both checks pass and the self-review checklist is complete. AC creates PR.
+
+---
+
+### Stage 4: Verify (`/verify`)
+
+**Trigger:** PR is created.
+
+**AC does:**
+- Reviews its own PR diff against the approved plan
+- Checks for drift: anything implemented that wasn't in the plan? Anything in the plan that's missing?
+- Reviews test quality: are assertions meaningful, or does a spec merely confirm the component renders without error?
+- Reads every test and asks: "If this test passed but the feature was broken, would I know?"
+- Writes a thorough PR description per the commit/PR standards in `CLAUDE.md`
+
+**Quality gate:** AC self-review of the complete PR. Checklist:
+- [ ] PR description includes Summary, Changes Made, Technical Approach, Testing, Checklist
+- [ ] No files changed that aren't in the plan (no scope creep)
+- [ ] Every plan item has a corresponding test
+- [ ] No "TODO" or "needs manual testing" comments remain
+- [ ] Diff is clean: no debug code, no commented-out code, no unrelated changes
+
+**Exit:** Self-review passes. HC is notified the PR is ready for Reviewer.
+
+---
+
+### Stage 5: Deliver (`/final`, supported by `/rtr`)
+
+**Trigger:** HC sends PR to Reviewer.
+
+**Reviewer checks for:**
+- Testing gaps (the most common finding)
+- Code quality, naming, structure
+- Template escaping and other security concerns
+- Accessibility gaps
+- Edge cases not covered
+- Requirements from the issue not addressed
+
+**AC responds to Reviewer feedback** (via `/rtr`, severities per the "Severity Priority" section of `docs/standards/code-review.md`):
+- Fix every P0 and P1 finding
+- For P2 findings: fix or explain why not (HC decides)
+- Do not argue with Reviewer findings unless factually incorrect — if the Reviewer flags it, it's a real gap
+
+**SOW (Statement of Work) — AC generates and posts on the PR before merge:**
+1. **Issue** — link and one-line summary
+2. **Option chosen** — which approach from the assessment and why
+3. **Technical decisions** — non-obvious choices and reasoning
+4. **What changed** — files created/modified/deleted with purpose
+5. **Testing coverage** — spec types, scenarios, notable edge cases
+6. **Reviewer findings** — what was caught and how it was resolved
+7. **Known limitations** — anything intentionally deferred
+8. **Follow-up items** — issues created for future work
+
+AC posts a reference link on the original issue pointing to the SOW on the PR.
+
+**Exit:** Reviewer finds no P0/P1 issues. SOW is posted. HC merges — the AC never merges.
+
+---
+
+## When to Skip or Compress Stages (Compressed Workflows)
+
+| Scenario | Approach |
+|----------|----------|
+| Trivial fix (typo, config change, dependency bump) | Skip Plan — Assess → Implement → Deliver (compressed self-review) |
+| Bug fix with obvious cause | Assess → Plan (brief) → Implement → Deliver |
+| Large change (15+ files, independent subsystems) | Full lifecycle + `/orch` for parallel agents |
+| Documentation-only change | Skip Assess and Plan — Implement → Deliver |
+
+**HC decides when to compress. AC does not self-select a compressed workflow.**
+
+## Command Mapping
+
+| Stage | Command | Purpose |
+|-------|---------|---------|
+| 1 — Assess | `/assess` | Issue assessment with options and risks |
+| 2 — Plan | `/cplan` | Implementation plan with testing strategy |
+| 3 — Implement | `/impl` | Execute the plan, self-review, create PR |
+| 4 — Verify | `/verify` | PR self-review against the plan |
+| 5 — Deliver | `/final` | SOW generation and merge preparation |
+| 5 — Deliver (support) | `/rtr` | Respond to Reviewer comments by severity |
+| Supporting | `/orch` | Multi-agent orchestration for large changes |
+| Supporting | `/explore` | Codebase research for a topic |
+| Supporting | `/dep-review` | Dependency update PR review |
+| Supporting | `/compare` | Drift check against the Optimus template |
+| Supporting | `/memory-review` | Auto-memory audit |
+
+## Measuring Improvement
+
+Track over time:
+- **Reviewer P0/P1 findings per PR** — goal: trending toward zero
+- **Passes per stage** — goal: 1 pass (Reviewer confirms, not corrects)
+- **HC interventions** — goal: HC makes decisions, not corrections
+
+When the Reviewer consistently finds nothing at a stage, HC can experiment with dropping that review and relying on self-review alone.

--- a/docs/standards/memory-management.md
+++ b/docs/standards/memory-management.md
@@ -1,0 +1,163 @@
+# Memory Management Standards
+
+Standards for managing Claude Code auto-memory (`~/.claude/projects/*/memory/`) for this project. The structure and thresholds are shared MPI machinery (canonical source: Optimus — see `docs/standards/cross-repo-sync.md`); the research basis (findings F5.1–F5.5) is documented in Optimus's `docs/research/ai-best-practices.md`.
+
+## Auto-Memory vs Repo-Tracked Docs
+
+Auto-memory and repo-tracked docs serve different purposes. The boundary is durability and scope.
+
+**Rule: If it should survive across machines and agents, it belongs in the repo. If it's context from the current engagement that may change, it belongs in auto-memory.**
+
+| Belongs in auto-memory | Belongs in repo (CLAUDE.md / .claude/rules/ / docs/) |
+|---|---|
+| User preferences learned in conversation | Coding standards, anti-patterns |
+| Active project status (what's in progress now) | Workflow process definitions |
+| Feedback corrections from HC | Standing instructions (e.g., HC working style) |
+| References to external systems discovered in conversation | Architecture, patterns |
+| Temporary debugging insights for active work | Conventions derivable from code |
+| Issue/PR tracking for in-flight work | Permanent reference material |
+
+**Common mistakes:**
+- Saving coding conventions to memory instead of `.claude/rules/` — these should be version-controlled and available on every machine
+- Saving standing instructions to memory — these get lost when switching machines or pruning
+- Saving architecture knowledge to memory instead of `docs/` — memory is per-machine, docs are shared via git
+
+## Three-Tier Architecture
+
+Memory operates in three tiers with different loading behavior and token costs.
+
+| Tier | Location | Loading | Token Budget | Purpose |
+|------|----------|---------|-------------|---------|
+| **Hot** | `MEMORY.md` | Always loaded on every conversation | < 200 lines (~800 tokens) | Index/pointers to topic files, active project status |
+| **Warm** | Topic files (`*.md` in memory dir) | Loaded when referenced or relevant | ~2,000 tokens per file | Domain knowledge, project details, feedback |
+| **Cold** | `docs/`, `.claude/rules/` | Loaded via exploration or path-scoping | No per-file limit | Full reference material, standards, architecture |
+
+**Total auto-memory budget:** Keep under 10,000 tokens across all memory files (~40KB). Beyond this, context rot degrades agent performance.
+
+## Health Thresholds
+
+`/memory-review` audits against these thresholds (estimate tokens at ~4 characters per token):
+
+| Metric | Warn | Error |
+|--------|------|-------|
+| `MEMORY.md` line count | > 150 lines | > 200 lines (truncation boundary — content beyond line 200 is silently dropped) |
+| Total memory token estimate | > 8,000 tokens | > 10,000 tokens |
+
+## MEMORY.md Standards
+
+`MEMORY.md` is always loaded into context. Every token counts.
+
+- **Max 200 lines** — content beyond line 200 is silently truncated; keep well under (warn at 150)
+- **Index-only** — MEMORY.md contains pointers to topic files, not content itself
+- **No frontmatter** — MEMORY.md is a plain Markdown index file
+- **Required structure:**
+  ```markdown
+  # Memory
+
+  ## [Section Name]
+  - [Brief description] — see [topic-file.md](topic-file.md) for details
+
+  ## [Section Name]
+  - [Pointer to another topic file]
+  ```
+- **Keep concise** — one line per topic file pointer, brief descriptions only
+- **No standing instructions** — these belong in CLAUDE.md or `.claude/rules/`
+
+## Topic File Standards
+
+Topic files are individual memory entries stored alongside MEMORY.md.
+
+### Required Frontmatter
+
+Every topic file must include frontmatter with three fields:
+
+```markdown
+---
+name: Component Catalog Status
+description: Tracking catalog coverage and open component proposals for issue #96
+type: project
+---
+
+[Content here]
+```
+
+| Field | Purpose | Values |
+|-------|---------|--------|
+| `name` | Human-readable name | Free text |
+| `description` | Used by Claude Code to decide retrieval relevance | One line, specific enough to match future queries |
+| `type` | Memory category | `user`, `feedback`, `project`, `reference` |
+
+### Memory Types
+
+| Type | When to Use | Examples |
+|------|------------|---------|
+| `user` | User role, preferences, knowledge level | "HC is senior Rails dev, new to ViewComponent" |
+| `feedback` | Corrections to agent behavior | "Don't summarize at end of responses" |
+| `project` | Active work, decisions, status | "Issue #105 status and PR merge order" |
+| `reference` | Pointers to external systems | "Design proposals tracked on the org project board" |
+
+### Content Guidelines
+
+- Lead with the most important information
+- Use bullet points, not prose paragraphs
+- Include absolute dates, not relative ("2026-07-01", not "last Thursday")
+- For `feedback` and `project` types, include **Why:** and **How to apply:** lines
+- Keep individual topic files under 50 lines (~200 tokens) when possible
+- One topic per file — don't combine unrelated subjects
+
+## What NOT to Store in Memory
+
+These belong elsewhere or are derivable from existing sources:
+
+- **Code patterns and conventions** — derivable from the codebase; put in `.claude/rules/`
+- **Git history, recent changes** — use `git log` / `git blame`
+- **Debugging solutions** — the fix is in the code; the commit message has context
+- **Anything in CLAUDE.md or docs/** — don't duplicate repo-tracked content
+- **Ephemeral task details** — use conversation context or tasks, not memory
+- **Component/token documentation** — belongs in `catalog/` and `tokens/`
+
+## Maintenance Cadence
+
+Memory requires active curation. Indiscriminate accumulation degrades agent performance.
+
+### When to Review
+
+| Trigger | Action |
+|---------|--------|
+| **Quarterly** (baseline) | Run `/memory-review`, prune stale entries |
+| **After closing an issue/PR** | Remove or archive project-type entries that tracked it |
+| **After major features** | Update related topic files, remove debugging notes |
+| **Before starting large new work** | Review MEMORY.md for relevance, clean up before adding |
+
+### What to Check
+
+1. **Staleness** — References to closed issues, merged PRs, or completed projects; entries dated more than 90 days ago are candidates for review
+2. **Contradictions** — Entries that conflict with each other, with CLAUDE.md, or with `.claude/rules/`
+3. **Duplicates** — Content that repeats what's in CLAUDE.md, `.claude/rules/`, or `docs/`
+4. **Misplaced content** — Standing instructions or conventions that belong in repo files
+5. **Token budget** — Total memory size against the thresholds above
+6. **Missing frontmatter** — Topic files without `name`, `description`, `type`
+7. **Orphaned worktree memory** — Leftover worktree memory directories (see below)
+
+### How to Review
+
+Run `/memory-review` — this command audits the current project's memory against every threshold in this document and recommends specific actions. Do not modify memory files without HC approval.
+
+## Worktree Memory
+
+Worktree agent sessions get their own memory directories under `~/.claude/projects/` (paths containing `--claude-worktrees-`). This memory is ephemeral:
+
+- Don't rely on worktree memory persisting — anything durable belongs in the main project memory or the repo
+- Once a worktree is removed, its memory directory is orphaned; `/memory-review` flags these for deletion
+
+## Cross-Project Standards
+
+- **Per-project memory** — Each MPI project has its own memory directory. No sharing between projects.
+- **Consistent structure** — All MPI projects follow these same standards
+- **Per-machine** — Memory is local to each development machine. Content that must be portable belongs in the repo, not memory.
+
+## File Naming
+
+- Use kebab-case: `component-catalog.md`, not `component_catalog.md`
+- Name files by topic, not by date: `component-catalog.md`, not `2026-07-01-notes.md`
+- Keep names short and descriptive: 2-4 words


### PR DESCRIPTION
## Summary

PR-D of #105 — the final PR of the four-PR sequence and, per the issue's refinement comment, the first-class deliverable: it creates the `docs/standards/` layer so every stage number and doc path cited by the PR-A command suite resolves, and it establishes the **ongoing cross-repo sync mechanism** that keeps this engine's agent machinery tracking the Optimus template instead of re-diverging.

Closes #105

## Changes Made

- **`docs/standards/development-lifecycle.md`** (new, 178 lines) — the five stages: Stage 1 Assess (`/assess`), Stage 2 Plan (`/cplan`), Stage 3 Implement (`/impl`), Stage 4 Verify (`/verify`), Stage 5 Deliver (`/final`, supported by `/rtr`). Includes the compressed-workflow rules (trivial fixes may skip Plan; documentation-only changes may skip Assess and Plan; **HC decides, not AC**), a full command-mapping table for all 11 commands, and engine-accurate stage content (component specs, Lookbook previews, dummy-app coverage, consuming-app impact — no app-only material).
- **`docs/standards/code-review.md`** (new, 104 lines) — engine-scoped review checklists (ViewComponents, tokens, Stimulus, security, accessibility, gem packaging, tests) plus the **"Severity Priority"** section cited by `rtr.md`, with P0/P1/P2 definitions aligned word-for-word with `AGENTS.md` Review Guidelines.
- **`docs/standards/memory-management.md`** (new, 163 lines) — backs `/memory-review`: MEMORY.md warn >150 / error >200 lines, index-only rule, topic-file frontmatter (`name`/`description`/`type`), token budget warn 8,000 / error 10,000 (~4 chars/token), staleness checks (closed issues/merged PRs, >90 days), orphaned worktree memory directories, quarterly cadence.
- **`docs/standards/cross-repo-sync.md`** (new, 98 lines) — **the centerpiece.** Defines the two-layer model: (1) *Machinery* syncs tightly with the app suite, canonical source = Optimus — commands (names, stage numbers, structure), `settings.json` structure (attribution block, hook matchers, `enabledPlugins` scheme), agent/git-layer branch-protection scripts, `projects.json` registry; (2) *Domain content* is engine-tailored — `.claude/rules/*` selection and content, standards selection, CLAUDE.md/AGENTS.md specifics. Records deliberate omissions (backend/migrations rules, `db-health`, credentials deny entries, app-only checks) as **NOT drift**. Names `/compare` as the periodic drift check (quarterly baseline + whenever Optimus's agent config changes materially), defines the drift-found flow (classify → assess → sync PR → gates → upstream-first), and covers keeping hardcoded model attribution strings current.
- **`.github/copilot-instructions.md`** (new, 13 lines) — points Copilot agents at `AGENTS.md` as the source of truth.
- **`CLAUDE.md`** (surgical edits) — added "Domain-Triggered Rules" index for `.claude/rules/{frontend,testing,self-review,dependencies}.md` (landing in PR-C) and a "Standards Documentation" pointer to `docs/standards/`; fixed the stale "Claude Opus 4.6" attribution strings to "Claude Fable 5" (commit-format example + Agent Attribution section); added a one-line cross-reference to #96 for machine-readable component inventory/token work.

## Technical Approach

- **Derive-from-Optimus, never fork-and-prune** — each standard was authored against Optimus's structure with engine-accurate content, per the ratified approach in #105. All app-only material (security scanners, database, authorization, deployment, app credentials) was stripped; the engine's required-check set is exactly `bundle exec rubocop -a` + `bundle exec rspec`, and cross-repo-sync.md documents that difference as a deliberate omission.
- **Reference-resolution driven** — the PR-A command suite (`origin/chore/issue-105a-machinery-convergence`) was read command-by-command and every `docs/standards/*` path and section reference it makes was collected first; the docs were then written to resolve all of them (mapping in the implementation-notes comment).
- **Grep-gate clean without exemptions** — omission examples in cross-repo-sync.md are phrased generically ("a static security scanner and a dependency-vulnerability audit") so the app-ism grep over `docs/` returns nothing.

## Testing

- Reference-resolution pass: every stage number, doc path, and section name cited by the 11 PR-A commands resolves to a real file/heading (full mapping posted as a PR comment)
- Grep gate: `grep -rEi 'searchkick|kamal|pundit|goodjob|devise|db/migrate|brakeman|bundler-audit' docs/ .github/copilot-instructions.md` → no matches
- `bundle exec rubocop -a` — 132 files inspected, no offenses detected
- `bundle exec rspec` — 496 examples, 0 failures (suite untouched, as expected for a docs-only PR)

## Checklist

- [x] Tests pass (496 examples, 0 failures)
- [x] Linting passes (no offenses)
- [x] All PR-A command references resolve
- [x] Grep gate clean (no imported app-isms)
- [x] Agent attribution included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude Code (Fable 5)