### PR TITLE
Add /ship streamlined lifecycle command (issue #112)

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,76 @@
+Autonomously drive GitHub issue #$ARGUMENTS through the full MPI Development Lifecycle, stopping only at the two human gates: **plan approval** and **merge**.
+
+This is the **streamlined / hands-off track** of the MPI Development Lifecycle (see `docs/standards/development-lifecycle.md`). It composes the existing stage commands — `/assess`, `/cplan`, `/impl`, `/verify`, `/rtr`, `/final` — into one supervised run. It does NOT replace them; it sequences them and overrides the per-stage "wait for HC" gates with a single pair of real checkpoints, keeping the external Reviewer (Codex — see the lifecycle doc's Roles) in the loop at both the plan gate and the PR review.
+
+## When to use
+
+- Standard, engine-internal work: a new component variant, a spec/preview backfill, a refactor within existing component APIs, a well-understood bug fix, docs or agent-config maintenance.
+- The issue is well-specified enough to plan without a back-and-forth.
+
+## When NOT to use (run the stages manually instead)
+
+- **Ecosystem-propagating changes** — anything that reaches into all four consuming apps (Markaz, SFA, Garden, Harvest): gemspec **runtime dependency** changes (see `.claude/rules/dependencies.md` — an ecosystem-wide decision), **breaking changes to a public component API**, **design-token value changes** in `_tokens.scss`, or changes to what ships in the gem (the gemspec `files` glob). `/ship` will still *stop and ask* if it discovers such a change mid-run, but prefer the manual lifecycle here from the start.
+- The issue is ambiguous or underspecified — `/assess` would need to ask clarifying questions anyway.
+
+## The two gates (and nothing else by default)
+
+1. **Plan-approval gate** — after `/cplan`, post the plan and **STOP**. Await the HC's explicit "approved" (or chosen option / revisions) before writing any code.
+2. **Merge gate** — after `/final` posts the SOW and CI is green with no open P0/P1, **STOP**. The HC clicks merge. Never merge the PR yourself.
+
+Between those two gates, run autonomously. **Plus** these unconditional emergency stops — if any occurs, halt and ask the HC with `AskUserQuestion`, do not guess:
+
+- A required check (`bundle exec rubocop -a`, `bundle exec rspec`, or CI) fails and the fix is non-obvious or would change behavior beyond the plan.
+- Implementation reveals the change is ecosystem-propagating in a way the plan didn't anticipate — a gemspec runtime dependency, a breaking component API change, a design-token value change, or a gem-packaging change.
+- A Reviewer comment is architectural, ambiguous, or contradicts the approved plan (a **Discussion**-class finding — see auto-`/rtr` policy below).
+
+## Context hygiene via subagent offloading
+
+`/ship`'s biggest context cost is three heavy operations whose *output* dwarfs the *signal* the orchestrator needs. Each is **dispatched to a subagent whose context is discarded**; the orchestrator keeps only a compact structured summary. This keeps the highest-judgment work (planning, reconciliation, the merge decision) out of the degraded long-context zone. The per-stage commands define the work each subagent performs; this is the map:
+
+| Heavy op | Stage | Subagent | Returns |
+|----------|-------|----------|---------|
+| Codebase exploration | `/assess` step 4 | built-in `Explore` (read-only) | exploration-summary (file map + findings) |
+| Code + test/lint/fix loop | `/impl` steps 3–5 | built-in `general-purpose`, **shared worktree** | check-result (per-check results + git-state + commit/PR body) |
+| Full-diff review | `/verify` | built-in `general-purpose` (read-only) | drift-report (+ ready-to-post self-review markdown) |
+
+Built-in agent types only (`Explore`, `general-purpose`) — targeted prompts that embed the stage's checklist and the `.claude/rules/testing.md` definition of done are the contract. Both required checks and the testing definition-of-done run **inside** the subagent at full strength — offloading changes *where* the work runs, never *whether* the gates apply.
+
+**Faithfulness — the review subagent's second pass must be real, not assumed.** A `/verify` subagent that misses a finding *hides* it from the orchestrator. The backstop is the independent external Reviewer (Codex). This engine has **no Codex GitHub Actions** (`.github/workflows/` contains only `ci.yml`) — do not poll for a `codex-review` or `codex-plan-review` workflow run; none exists. Instead, **invoke Codex directly**: on the plan in Phase 1, and on the PR diff in Phase 2. If no second model is reachable, treat the lone `/verify` pass as unverified and **stop and ask the HC**. Never log "Codex reviewed" without a Codex-authored review actually in hand.
+
+## Phase 1 — Plan (stops at gate 1)
+
+1. Run the full `/assess $ARGUMENTS` steps — its step-4 codebase exploration is dispatched to a read-only `Explore` subagent that returns an exploration-summary (see `assess.md` and *Context hygiene* above). Post the assessment comment on the issue and display it.
+2. If `/assess` surfaced blocking clarifying questions, **stop and ask** — do not proceed to a plan on guesses.
+3. Otherwise pick the recommended option and run the full `/cplan $ARGUMENTS` steps. Post the plan comment on the issue and display it.
+4. **Codex reviews the plan, then you reconcile** (the external review happens *before* any code is written — the cheapest place to catch a flawed plan):
+   - **Obtain Codex's review of the plan** by invoking Codex directly against the plan plus the relevant code (there is no plan-review GitHub Action in this repo).
+   - **Reconcile.** Read Codex's review critically. Apply the same severity lens as the PR auto-`/rtr` policy (per `docs/standards/code-review.md` "Severity Priority"): fold in valid P0/P1/P2 points, and for anything architectural/ambiguous or that conflicts with the chosen option, **stop and ask the HC** rather than silently reshaping the plan.
+   - **Repost.** If you revised the plan, post the updated plan and a short "Codex flagged X → handled by Y" note so the HC sees what the second model caught. If Codex found nothing material, say so.
+5. **STOP.** Tell the HC: "Plan posted and Codex-reviewed on #$ARGUMENTS. Reply `approved` (or pick a different option / request changes) to start the autonomous build." **Recommend a clean-context start for the build:** Phase 1 (assess + plan + Codex reconcile) can fill a large fraction of the context window before any code is written, so advise the HC to **begin Phase 2 in a fresh session** (or `/compact` first) and resume with `/impl $ARGUMENTS` — the approved plan is durably on the issue, so a reset loses nothing. Continuing in-session is supported but carries Phase 1's accumulated context into the build. End the turn.
+
+## Phase 2 — Build → Review → SOW (resumes on approval, stops at gate 2)
+
+Trigger: HC approves the plan in the conversation. `/ship` takes only the numeric issue id as `$ARGUMENTS` — it does not parse resume flags. To resume in a fresh session, run the underlying stage command directly (`/impl NNN`, then `/verify <PR_NUMBER>`, etc.).
+
+> **Identifiers — read first.** `$ARGUMENTS` is the **issue** id. `/impl` opens a PR whose number is **different**. The PR-scoped stages — `/verify`, `/rtr`, `/final`, and `gh pr checks` — operate on the **PR number**, not the issue id (see `.claude/commands/{verify,rtr,final}.md`). Capture the PR number `/impl` creates as `<PR_NUMBER>` and pass *that* to every PR-scoped stage below. Pass `$ARGUMENTS` only to issue-scoped commands.
+
+1. **Implement** — run the full `/impl $ARGUMENTS` steps: feature branch, code + specs per the plan's testing strategy (spec + Lookbook preview for every component touched), both required checks green, self-review checklist, commit, push, open the PR, post implementation notes. The orchestrator creates the branch and confirms a clean tree, then the code + test/lint/fix loop runs in a shared-worktree `general-purpose` subagent; the orchestrator reconciles git state against the returned **check-result** and then commits / pushes / opens the PR from it — never reloading the diff (see `impl.md` and *Context hygiene* above). **Record the new PR number as `<PR_NUMBER>`** (e.g. from `gh pr view --json number`).
+   - **Issue linking** — use `Closes #$ARGUMENTS` for a normal (leaf) issue. **If `$ARGUMENTS` is an umbrella/epic issue** delivered across multiple PRs, reference it as `Part of #$ARGUMENTS` and never with a closing keyword adjacent — GitHub ignores negation and would close the umbrella when this PR merges, orphaning the remaining phases. Close the specific phase sub-issue instead.
+2. **Verify** — run the full `/verify <PR_NUMBER>` steps: the diff review is dispatched to a read-only `general-purpose` subagent that returns a **drift-report**; fix any drift NOW, then post the self-review comment from the report (see `verify.md`).
+3. **External review — obtain it directly.** There is no PR-review GitHub Action in this repo, so opening the PR triggers nothing by itself. **Invoke Codex directly on the PR diff** and have it post (or relay) its findings, so the `/verify` subagent's pass has a real independent second model. **GitHub Copilot may also post a PR _review_ with inline diff comments** (this repo carries `.github/copilot-instructions.md`). Inline reviews are surfaced by `gh pr view <PR_NUMBER> --json reviews` and `gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments` — **not** by `gh pr checks` or issue-level `--comments`, so fetch the review surface explicitly or you will silently miss Copilot's findings. In the local CLI there is no event push — re-check the review surface after each push and before `/final`.
+4. **Auto-respond to review** — **first fetch the full review surface from every reviewer** (`gh pr view <PR_NUMBER> --json reviews`, `gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments` for inline threads, and issue-level comments — checking CI status or issue comments alone misses inline reviews), then for each batch apply the `/rtr <PR_NUMBER>` steps with this **autonomous resolution policy** (replacing `/rtr`'s "wait for HC to choose"), severities per `docs/standards/code-review.md` "Severity Priority":
+   - **P0 / P1** — fix automatically, re-run both required checks, push, reply to each comment with the fixing commit.
+   - **P2** — fix if straightforward; otherwise reply with rationale or defer to a follow-up issue.
+   - **Discussion / architectural / ambiguous / conflicts-with-plan** — **stop and ask the HC** (`AskUserQuestion`). Do not guess on architecture.
+   - Post the Review Response Summary comment after each round.
+   - Loop until CI is green (`gh pr checks <PR_NUMBER>`) and there are no open P0/P1 findings.
+5. **Context-budget check, then Finalize.** Before `/final`: if this session has accumulated heavy context (multiple full test-suite runs, large diffs, long review threads), **stop and ask the HC to resume `/final <PR_NUMBER>` in a fresh session** — `/final` is the last quality gate plus SOW generation and must run with full attention, not deep in a filled window (auto-compaction is not a safety net; it fires well inside the degraded zone). Otherwise run the full `/final <PR_NUMBER>` steps: rebase if needed, confirm both required checks + CI green, generate and post the SOW, post the reference link on the issue, surface any `CLAUDE.md`/rules improvement suggestions to the HC.
+6. **STOP at the merge gate.** Tell the HC the PR is green, reviewed, and SOW-posted — ready to merge. **Do not merge.** Re-check CI status and merge-conflict state when reporting — they can change between the last push and the gate.
+
+## Quality bar
+
+`/ship` must never lower the bar of the individual stages to "keep the pipeline moving." Every gate the stage commands enforce — both required checks, the `.claude/rules/testing.md` definition of done, the `.claude/rules/self-review.md` checklist — still applies at full strength. Every component touched still ships with its spec and Lookbook preview. Faster cadence, same rigor. If you cannot clear a gate honestly, stop and say so.
+
+## Attribution
+
+Every GitHub comment posted across the run carries `— Claude Code (Fable 5)` (or current model) per `CLAUDE.md`. Commits carry the `Co-Authored-By` trailer.

--- a/docs/standards/cross-repo-sync.md
+++ b/docs/standards/cross-repo-sync.md
@@ -14,7 +14,7 @@ Same names, same numbers, same structure as Optimus. Engine-scoped wording *insi
 
 | Machinery | Files | Sync Rule |
 |-----------|-------|-----------|
-| Lifecycle commands | `.claude/commands/*.md` | Same command names, stage numbers, and document structure as Optimus. This repo's flat set: `assess`, `compare`, `cplan`, `dep-review`, `explore`, `final`, `impl`, `memory-review`, `orch`, `rtr`, `verify`. Step content is engine-scoped (components, previews, tokens — not app systems). |
+| Lifecycle commands | `.claude/commands/*.md` | Same command names, stage numbers, and document structure as Optimus. This repo's flat set: `assess`, `compare`, `cplan`, `dep-review`, `explore`, `final`, `impl`, `memory-review`, `orch`, `rtr`, `ship`, `verify`. Step content is engine-scoped (components, previews, tokens — not app systems). `ship` is ahead of the template: adopted from Markaz before Optimus carries it (see Upstream Findings Log) — when Optimus adopts `/ship`, converge on its version. |
 | `settings.json` structure | `.claude/settings.json` | The **attribution block** (commit trailer + PR footer strings), the **PreToolUse hook matcher** list (`Write\|Edit\|Bash(git commit:*)\|Bash(git push:*)\|Bash(git merge:*)\|Bash(git rebase:*)`), and the **enabledPlugins** scheme converge with Optimus. The plugin *list* is tailored to engine relevance: design/frontend-facing plugins kept, app/infra-only plugins dropped. |
 | Agent-layer branch hook | `.claude/hooks/enforce-branch-creation.sh` | Optimus's fail-closed variant. Logic changes sync from Optimus, not local edits. |
 | Git-layer branch guard | `.githooks/{pre-commit,pre-push,pre-merge-commit,pre-rebase}`, `bin/guard-protected-branch`, `bin/install-git-hooks` | Ported from Optimus; the AC-vs-HC detection logic must match the template. |
@@ -68,6 +68,7 @@ The standing record of findings *against the canonical template* that were delib
 | Date | Finding | Disposition | Evidence | Status |
 |------|---------|-------------|----------|--------|
 | 2026-07-01 | `bin/guard-protected-branch` (byte-identical Optimus port) intends to exempt Human Contributors via TTY detection (`[[ ! -t 0 ]]` fallback), but git >= 2.36 runs hooks with stdin attached to `/dev/null` — so through the git layer (`.githooks/*`) **every** invocation, human or AI, is classified as an AC and blocked on protected branches. Verified empirically on git 2.55 (scratch repo, hooks installed, AC env vars unset, real PTY: commit and push on `main` both blocked). Practical impact low: the flow is PR-based and HCs retain `git commit/push --no-verify`. The alternative fix (probing `/dev/tty`) risks silently exempting ACs. Found during Stage-4 verification of PR #108. | Accept-and-document; byte-identity with Optimus preserved | [PR #108 comment](https://github.com/mpimedia/mpi-design-system/pull/108#issuecomment-4860931688) | To raise upstream in Optimus |
+| 2026-07-01 | Optimus lacks the `/ship` streamlined-track command. It originated in Markaz (`markaz/.claude/commands/ship.md` + a "Automated / Streamlined Track" section in its lifecycle doc); this engine adopted it directly from Markaz (issue #112) — a Markaz → engine transfer that bypasses the normal Optimus → engine flow. The engine's copy is tailored (two required checks, ecosystem-propagation emergency stops, direct Codex invocation instead of the `codex-review`/`codex-plan-review` Actions this repo doesn't have). Until Optimus carries `/ship`, drift checks must not flag the engine's `ship.md` as local drift to delete. | Adopted locally from Markaz; template should adopt `/ship` so the suite converges on one canonical version | [Issue #112](https://github.com/mpimedia/mpi-design-system/issues/112) | To raise upstream in Optimus |
 
 ## Model Attribution Strings
 
@@ -88,7 +89,7 @@ mpi-design-system/
 │   ├── settings.json                  # Machinery (structure) — plugin list tailored
 │   ├── hooks/
 │   │   └── enforce-branch-creation.sh # Machinery — agent-layer branch protection
-│   ├── commands/                      # Machinery — 11 lifecycle/support commands
+│   ├── commands/                      # Machinery — 12 lifecycle/support commands
 │   ├── rules/                         # Domain content — engine-tailored rules
 │   └── projects.json                  # Machinery — MPI ecosystem registry
 ├── .githooks/                         # Machinery — git-layer branch protection

--- a/docs/standards/development-lifecycle.md
+++ b/docs/standards/development-lifecycle.md
@@ -152,6 +152,23 @@ AC posts a reference link on the original issue pointing to the SOW on the PR.
 
 **HC decides when to compress. AC does not self-select a compressed workflow.**
 
+## Automated / Streamlined Track (`/ship`)
+
+For standard, engine-internal work the HC can run the whole lifecycle hands-off with `/ship NNN`. It sequences `/assess → /cplan → /impl → /verify → /rtr → /final` and replaces the per-stage "wait for HC" pauses with exactly **two gates**:
+
+1. **Plan approval** — after `/cplan` *and* the Reviewer's (Codex) pass over the plan, `/ship` stops and waits for the HC to approve the plan (or pick a different option). **To keep the build phase in clean context, the HC should start a fresh session (or `/compact`) after approving and resume with `/impl NNN`** — the plan is durably on the issue, so the reset loses nothing and keeps the build out of the degraded long-context zone.
+2. **Merge** — after `/final` posts the SOW with green CI and no open P0/P1, `/ship` stops. The HC merges. `/ship` never merges itself.
+
+Everything in between runs autonomously, **plus** unconditional emergency stops: a required check or CI failure that can't be auto-resolved, a discovery that the change is ecosystem-propagating in a way the plan didn't anticipate (gemspec runtime dependency, breaking component API, design-token value change, gem packaging), or an architectural/ambiguous review comment. On any of those, `/ship` halts and asks rather than guessing.
+
+**Context hygiene — subagent offloading.** `/ship`'s three heaviest operations are dispatched to subagents whose context is discarded, so the orchestrator keeps only a compact structured summary: `/assess` codebase exploration → a read-only `Explore` subagent (exploration-summary); the `/impl` code + test/lint/fix loop → a `general-purpose` subagent in the shared worktree (check-result; the orchestrator reconciles git state, then commits/pushes/opens the PR without reloading the diff); the `/verify` full-diff review → a read-only `general-purpose` subagent (drift-report). Both required checks and the `.claude/rules/testing.md` definition of done run **inside** the subagent at full strength.
+
+**External review without Actions.** This engine has no Codex GitHub Actions (`.github/workflows/` contains only `ci.yml`), so `/ship` invokes Codex directly — on the plan before gate 1 and on the PR diff during Phase 2. If no second model is reachable, the run stops and asks the HC rather than logging an unverified pass.
+
+**Identifiers:** `/ship NNN` takes the **issue** id. `/impl` opens a PR with a *different* number; the PR-scoped stages (`/verify`, `/rtr`, `/final`, `gh pr checks`) operate on that **PR number**. To resume mid-lifecycle, invoke the underlying stage command directly — `/impl NNN` (issue) or `/verify <PR_NUMBER>` / `/rtr <PR_NUMBER>` (PR).
+
+**Eligibility mirrors the ecosystem-propagation rule:** use `/ship` for component variants, spec/preview backfills, refactors within existing component APIs, well-understood fixes, and docs/config maintenance. For changes that propagate to all four consuming apps — gemspec runtime dependencies, breaking component API changes, design-token value changes — run the stages manually and synchronously.
+
 ## Command Mapping
 
 | Stage | Command | Purpose |
@@ -162,6 +179,7 @@ AC posts a reference link on the original issue pointing to the SOW on the PR.
 | 4 — Verify | `/verify` | PR self-review against the plan |
 | 5 — Deliver | `/final` | SOW generation and merge preparation |
 | 5 — Deliver (support) | `/rtr` | Respond to Reviewer comments by severity |
+| Full hands-off run | `/ship` | Sequences all stages with two human gates |
 | Supporting | `/orch` | Multi-agent orchestration for large changes |
 | Supporting | `/explore` | Codebase research for a topic |
 | Supporting | `/dep-review` | Dependency update PR review |


### PR DESCRIPTION
## Summary

Ports the `/ship` command from Markaz into this engine, customized for how MDS works. `/ship NNN` drives a GitHub issue through the full MPI Development Lifecycle hands-off — sequencing `/assess → /cplan → /impl → /verify → /rtr → /final` — and stops only at the two human gates: **plan approval** and **merge**. All six stage commands it composes already exist in this repo; this PR adds the orchestrator plus the standards-doc updates that anchor it.

Closes #112

## Changes Made

- **`.claude/commands/ship.md`** (new) — the streamlined-track orchestrator, structurally parallel to Markaz's version so future suite-wide convergence stays cheap, with every Markaz-specific assumption tailored to the engine (see Technical Approach)
- **`docs/standards/development-lifecycle.md`** — new "Automated / Streamlined Track (`/ship`)" section (placed between Compressed Workflows and Command Mapping, mirroring Markaz's lifecycle doc), plus a `/ship` row in the Command Mapping table
- **`docs/standards/cross-repo-sync.md`** — `ship` added to the Layer 1 lifecycle-command set with an ahead-of-template note; command count comment updated (11 → 12); new Upstream Findings Log entry recording that Optimus lacks `/ship`, so future `/compare` runs classify `ship.md` as a deliberate ahead-of-template adoption rather than local drift to delete

## Technical Approach

Tailorings from the Markaz source (`markaz/.claude/commands/ship.md`), per issue #112:

1. **Quality checks: four → two.** Every "all four quality checks" reference (rubocop, rspec, brakeman, bundler-audit) is rewritten to this engine's exactly-two required checks: `bundle exec rubocop -a` and `bundle exec rspec` (per `.claude/rules/self-review.md` and the deliberate-omissions list in `cross-repo-sync.md`).
2. **Emergency stops keyed to ecosystem propagation.** Markaz halts on core-business-logic surprises (rights data, authorization). The engine equivalent: gemspec **runtime dependency** changes (`.claude/rules/dependencies.md`), **breaking component API** changes consumed by Markaz/SFA/Garden/Harvest, **design-token value** changes, and gem-packaging changes. Same stop-and-ask behavior, engine-shaped trigger.
3. **Direct Codex invocation instead of GitHub Actions.** Markaz's `/ship` polls the `codex-review`/`codex-plan-review` Actions and carries green-skip detection for them. This repo's `.github/workflows/` contains only `ci.yml`, so that machinery is replaced: invoke Codex directly on the plan (Phase 1) and the PR diff (Phase 2); if no second model is reachable, stop and ask rather than logging an unverified pass. The Copilot review-surface guidance is kept (this repo carries `.github/copilot-instructions.md`), including the explicit `gh pr view --json reviews` / `gh api .../pulls/N/comments` fetches that issue-level `--comments` would miss.
4. **Severity framework reference.** The auto-`/rtr` resolution policy points at `docs/standards/code-review.md` "Severity Priority" (verified the section exists) instead of Markaz's `AGENTS.md` Review Guidelines.
5. **Attribution.** `— Claude Code (Fable 5)` / `Co-Authored-By: Claude Fable 5` per this repo's current attribution strings (tracked by `cross-repo-sync.md`).
6. **Markaz-only references removed.** Markaz issue numbers (#1386/#1392/#1393), the pr-review-toolkit-trim rationale (this repo has the plugin enabled), the `AGENTS.md` umbrella-section citation (this repo's `AGENTS.md` has no such section — the umbrella/closing-keyword caution is stated inline instead), and the web-only event-subscription flow (replaced with re-checking the review surface after each push).

Kept intact from the source: the two-gate structure, the subagent-offloading context-hygiene map (`Explore` for assess exploration, shared-worktree `general-purpose` for the impl loop, read-only `general-purpose` for the verify diff review), the issue-id vs PR-number identifier warning, the fresh-session recommendation at the plan gate, the context-budget check before `/final`, and the quality-bar section.

**Sync direction note:** this is a Markaz → engine transfer, bypassing the normal Optimus → engine flow, because Optimus doesn't carry `/ship` yet. Per "Upstream first" in `cross-repo-sync.md`, the Upstream Findings Log entry flags `/ship` for adoption in Optimus; when the template carries it, this repo converges on the template's version.

## Testing

- `bundle exec rubocop -a` — 133 files inspected, no offenses
- `bundle exec rspec` — 504 examples, 0 failures
- Verified every path/section `ship.md` references resolves in this repo: the six stage commands, `docs/standards/development-lifecycle.md`, `docs/standards/code-review.md` `## Severity Priority`, `.claude/rules/{testing,self-review,dependencies}.md`, `.github/copilot-instructions.md`
- Confirmed the new command registers as the `/ship` skill in Claude Code

## Checklist
- [x] Tests pass
- [x] Linting passes

— Claude Code (Fable 5)
