### PR TITLE
refactor: asset-delivery contract + drop bootstrap dep (Part of #103)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,11 @@ jobs:
         run: yarn install --immutable
       - name: Build JS bundle
         run: yarn build
+      # Proves the SCSS token contract compiles for BOTH consumer models — the
+      # legacy `@import "mpi_design_system/tokens"` path (mirrors spec/dummy) and
+      # the modern `@use "mpi_design_system/tokens_values"` path that feeds the
+      # MPI palette into an app's own Bootstrap without double-compiling it.
+      # Asserts the primary color (#2e75b6) reaches the compiled CSS in each.
+      # (Issue #103, Work item 2.)
+      - name: SCSS token compatibility (legacy @import + modern @use)
+        run: yarn build:css:compat

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,11 +117,23 @@ registerMpiControllers(application)
 
 ### Design Tokens
 
-SCSS tokens at `app/assets/stylesheets/mpi_design_system/_tokens.scss` override Bootstrap defaults before import.
+SCSS tokens live in `app/assets/stylesheets/mpi_design_system/`. There are two entry points for the two Sass consumption models — both resolve through a dart-sass `--load-path=<gem>/app/assets/stylesheets`:
+
+- **Legacy `@import` apps** — import `tokens` before Bootstrap; it maps the MPI palette onto Bootstrap's variables:
+  ```scss
+  @import "mpi_design_system/tokens";
+  @import "bootstrap/scss/bootstrap";
+  ```
+- **Modern Sass-module apps** — `@use` the dependency-free values module and feed the palette into your own Bootstrap config, so the engine's Bootstrap is not double-compiled against your app's `bootstrap@5.3.x`:
+  ```scss
+  @use "mpi_design_system/tokens_values" as mpi;
+  $primary: mpi.$mpi-primary;
+  @import "bootstrap/scss/bootstrap";
+  ```
 
 ### Engine Integration
 
-Consuming apps add the gem and register controllers:
+The engine ships its JS and SCSS as **source** (no Rails asset-pipeline initializer — there is nothing to auto-mount). A consuming app wires up three things:
 
 ```ruby
 # Gemfile
@@ -129,10 +141,23 @@ gem 'mpi_design_system', git: 'git@github.com:mpimedia/mpi-design-system.git'
 ```
 
 ```js
+// esbuild.config.js — alias the bare specifier to the gem's JS source
+alias: { 'mpi_design_system': path.resolve(__dirname, 'path/to/mpi_design_system/app/javascript/mpi_design_system') }
+```
+
+```js
 // application.js
 import { registerMpiControllers } from "mpi_design_system"
 registerMpiControllers(application)
 ```
+
+```bash
+# CSS build — add the gem's stylesheets dir to the sass load path
+sass app/assets/stylesheets/application.scss:app/assets/builds/application.css \
+  --load-path=node_modules --load-path=path/to/mpi_design_system/app/assets/stylesheets
+```
+
+Then import tokens in `application.scss` using one of the two models above.
 
 ## Agent Attribution (Required — No Exceptions)
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem "puma", "~> 8"
 gem "propshaft", "~> 1"
 gem "jsbundling-rails", "~> 1"
 gem "cssbundling-rails", "~> 1"
-gem "bootstrap", "~> 5"
 gem "lookbook", "~> 2"
 gem "foreman", "~> 0"
 

--- a/app/assets/stylesheets/mpi_design_system/_tokens.scss
+++ b/app/assets/stylesheets/mpi_design_system/_tokens.scss
@@ -1,49 +1,25 @@
-// MPI Design System — Token Overrides
-// These override Bootstrap 5 defaults before Bootstrap is imported.
-
-// Brand colors
-$mpi-primary: #2E75B6;
-$mpi-brand-navy: #1B2A4A;
-$mpi-brand-accent: #4EA8DE;
+// MPI Design System — Bootstrap Variable Overrides (legacy @import entry point)
+//
+// Pulls the raw MPI token values (see `_tokens_values.scss`) and maps them onto
+// Bootstrap's variables. Import this BEFORE Bootstrap so these overrides win:
+//
+//   @import "mpi_design_system/tokens";
+//   @import "bootstrap/scss/bootstrap";
+//
+// Apps on the modern Sass module system should instead `@use
+// "mpi_design_system/tokens_values"` and configure Bootstrap themselves — see
+// README / AGENTS.md. (Issue #103, Work item 2.)
+@import "tokens_values";
 
 // Semantic colors → Bootstrap variable overrides
 $primary: $mpi-primary;
-$success: #22A06B;
-$warning: #D4772C;
+$success: $mpi-success;
+$warning: $mpi-warning;
 // $danger uses Bootstrap default (#DC3545)
 $info: $mpi-primary;
-
-// Neutral colors
-$mpi-text: $mpi-brand-navy;
-$mpi-text-muted: #6C757D;
-$mpi-border: #DEE2E6;
-$mpi-background: #F5F7FA;
-$mpi-surface: #FFFFFF;
 
 // Body overrides
 $body-color: $mpi-text;
 
 // Badge overrides
 $badge-border-radius: 999px;
-
-// Tag group colors (CRM)
-$mpi-tag-buyers: #E8733A;
-$mpi-tag-buyers-bg: #FEF3EC;
-$mpi-tag-press: #2DA67E;
-$mpi-tag-press-bg: #ECF8F4;
-$mpi-tag-festivals: #2E75B6;
-$mpi-tag-festivals-bg: #EBF3FB;
-$mpi-tag-sellers: #8B5CF6;
-$mpi-tag-sellers-bg: #F3EFFE;
-$mpi-tag-institutional: #D97706;
-$mpi-tag-institutional-bg: #FEF9EC;
-$mpi-tag-organizations: #6366F1;
-$mpi-tag-organizations-bg: #EEEFFE;
-$mpi-tag-internal: #64748B;
-$mpi-tag-internal-bg: #F1F5F9;
-
-// Engagement type colors (CRM)
-$mpi-engagement-email: #2E75B6;
-$mpi-engagement-meeting: #8B5CF6;
-$mpi-engagement-call: #16A34A;
-$mpi-engagement-note: #E8913A;

--- a/app/assets/stylesheets/mpi_design_system/_tokens.scss
+++ b/app/assets/stylesheets/mpi_design_system/_tokens.scss
@@ -8,7 +8,7 @@
 //
 // Apps on the modern Sass module system should instead `@use
 // "mpi_design_system/tokens_values"` and configure Bootstrap themselves — see
-// README / AGENTS.md. (Issue #103, Work item 2.)
+// AGENTS.md. (Issue #103, Work item 2.)
 @import "tokens_values";
 
 // Semantic colors → Bootstrap variable overrides

--- a/app/assets/stylesheets/mpi_design_system/_tokens_values.scss
+++ b/app/assets/stylesheets/mpi_design_system/_tokens_values.scss
@@ -13,8 +13,8 @@
 //   @import "bootstrap/scss/bootstrap";
 //
 // Apps on the legacy pipeline should import `tokens` instead, which layers the
-// Bootstrap variable overrides on top of these values. See README / AGENTS.md
-// for both install paths. (Issue #103, Work item 2.)
+// Bootstrap variable overrides on top of these values. See AGENTS.md for both
+// install paths. (Issue #103, Work item 2.)
 
 // Brand colors
 $mpi-primary: #2E75B6 !default;

--- a/app/assets/stylesheets/mpi_design_system/_tokens_values.scss
+++ b/app/assets/stylesheets/mpi_design_system/_tokens_values.scss
@@ -1,0 +1,56 @@
+// MPI Design System — Token Values (Sass-module-friendly)
+//
+// Raw MPI brand/palette values with NO Bootstrap dependency. This is the entry
+// point for consuming apps on the modern Sass module system: `@use` it, then map
+// the values onto your OWN Bootstrap configuration — without importing the
+// engine's Bootstrap (which would double-compile Bootstrap against your app's
+// bootstrap@5.3.x). Every variable is `!default` so a `@use … with (…)` override
+// wins.
+//
+//   // modern (@use) consumer:
+//   @use "mpi_design_system/tokens_values" as mpi;
+//   $primary: mpi.$mpi-primary;
+//   @import "bootstrap/scss/bootstrap";
+//
+// Apps on the legacy pipeline should import `tokens` instead, which layers the
+// Bootstrap variable overrides on top of these values. See README / AGENTS.md
+// for both install paths. (Issue #103, Work item 2.)
+
+// Brand colors
+$mpi-primary: #2E75B6 !default;
+$mpi-brand-navy: #1B2A4A !default;
+$mpi-brand-accent: #4EA8DE !default;
+
+// Semantic colors (raw values; `tokens` maps these onto Bootstrap's $primary etc.)
+$mpi-success: #22A06B !default;
+$mpi-warning: #D4772C !default;
+// $danger is intentionally omitted — the palette uses Bootstrap's default (#DC3545).
+
+// Neutral colors
+$mpi-text: $mpi-brand-navy !default;
+$mpi-text-muted: #6C757D !default;
+$mpi-border: #DEE2E6 !default;
+$mpi-background: #F5F7FA !default;
+$mpi-surface: #FFFFFF !default;
+
+// Tag group colors (CRM)
+$mpi-tag-buyers: #E8733A !default;
+$mpi-tag-buyers-bg: #FEF3EC !default;
+$mpi-tag-press: #2DA67E !default;
+$mpi-tag-press-bg: #ECF8F4 !default;
+$mpi-tag-festivals: #2E75B6 !default;
+$mpi-tag-festivals-bg: #EBF3FB !default;
+$mpi-tag-sellers: #8B5CF6 !default;
+$mpi-tag-sellers-bg: #F3EFFE !default;
+$mpi-tag-institutional: #D97706 !default;
+$mpi-tag-institutional-bg: #FEF9EC !default;
+$mpi-tag-organizations: #6366F1 !default;
+$mpi-tag-organizations-bg: #EEEFFE !default;
+$mpi-tag-internal: #64748B !default;
+$mpi-tag-internal-bg: #F1F5F9 !default;
+
+// Engagement type colors (CRM)
+$mpi-engagement-email: #2E75B6 !default;
+$mpi-engagement-meeting: #8B5CF6 !default;
+$mpi-engagement-call: #16A34A !default;
+$mpi-engagement-note: #E8913A !default;

--- a/lib/mpi_design_system/engine.rb
+++ b/lib/mpi_design_system/engine.rb
@@ -2,9 +2,12 @@ module MpiDesignSystem
   class Engine < ::Rails::Engine
     isolate_namespace MpiDesignSystem
 
-    initializer "mpi_design_system.assets" do |app|
-      app.config.assets.paths << root.join("app/javascript")
-      app.config.assets.paths << root.join("app/assets/stylesheets")
-    end
+    # No asset-pipeline initializer by design. The engine ships its component
+    # JS and SCSS as *source*, delivered to each consuming app through that
+    # app's own esbuild alias and dart-sass `--load-path` (see README / AGENTS.md
+    # for the install contract). Pushing these dirs onto `config.assets.paths`
+    # delivers nothing to the esbuild + dart-sass pipeline every MPI app uses and
+    # only misleads consumers into thinking the assets "just work" once mounted.
+    # (Issue #103, Work item 2.)
   end
 end

--- a/lib/mpi_design_system/engine.rb
+++ b/lib/mpi_design_system/engine.rb
@@ -4,8 +4,8 @@ module MpiDesignSystem
 
     # No asset-pipeline initializer by design. The engine ships its component
     # JS and SCSS as *source*, delivered to each consuming app through that
-    # app's own esbuild alias and dart-sass `--load-path` (see README / AGENTS.md
-    # for the install contract). Pushing these dirs onto `config.assets.paths`
+    # app's own esbuild alias and dart-sass `--load-path` (see AGENTS.md for the
+    # install contract). Pushing these dirs onto `config.assets.paths`
     # delivers nothing to the esbuild + dart-sass pipeline every MPI app uses and
     # only misleads consumers into thinking the assets "just work" once mounted.
     # (Issue #103, Work item 2.)

--- a/mpi_design_system.gemspec
+++ b/mpi_design_system.gemspec
@@ -20,8 +20,12 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.4"
 
+  # Runtime dependencies are forced into every consuming app's bundle, so this
+  # set is kept deliberately minimal (see .claude/rules/dependencies.md).
+  # Bootstrap is intentionally NOT here: nothing in the engine loads the Ruby
+  # `bootstrap` gem — consuming apps compile Bootstrap SCSS against their own npm
+  # `bootstrap` package via a dart-sass `--load-path` (Issue #103, Work item 2).
   spec.add_dependency "rails", ">= 8.1"
   spec.add_dependency "view_component", ">= 3.0"
   spec.add_dependency "stimulus-rails"
-  spec.add_dependency "bootstrap", "~> 5.3"
 end

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "node esbuild.config.js",
     "build:css": "sass ./spec/dummy/app/assets/stylesheets/application.scss:./spec/dummy/app/assets/builds/application.css --no-source-map --load-path=node_modules --load-path=app/assets/stylesheets --style=compressed",
+    "build:css:compat": "sass spec/fixtures/scss/legacy_import.scss:tmp/compat/legacy.css --no-source-map --load-path=node_modules --load-path=app/assets/stylesheets --style=expanded --quiet-deps && sass spec/fixtures/scss/modern_use.scss:tmp/compat/modern.css --no-source-map --load-path=node_modules --load-path=app/assets/stylesheets --style=expanded --quiet-deps && sass spec/fixtures/scss/modern_use_override.scss:tmp/compat/modern_override.css --no-source-map --load-path=node_modules --load-path=app/assets/stylesheets --style=expanded --quiet-deps && grep -qi \"#2e75b6\" tmp/compat/legacy.css && grep -qi \"#2e75b6\" tmp/compat/modern.css && grep -qi \"#0a5c2e\" tmp/compat/modern_override.css && echo \"SCSS compat OK: legacy @import, modern @use, and @use with() override all compile and apply the expected palette\"",
     "watch": "node esbuild.config.js --watch",
     "watch:css": "sass --watch ./spec/dummy/app/assets/stylesheets/application.scss:./spec/dummy/app/assets/builds/application.css --no-source-map --load-path=node_modules --load-path=app/assets/stylesheets"
   },

--- a/spec/fixtures/scss/legacy_import.scss
+++ b/spec/fixtures/scss/legacy_import.scss
@@ -1,0 +1,7 @@
+// Compat fixture — legacy `@import` consumer path (mirrors spec/dummy).
+//
+// Proves `_tokens.scss` still overrides Bootstrap after the `tokens_values`
+// split: the MPI palette must reach Bootstrap and emit `#2e75b6` for the
+// primary color. Compiled by the `build:css:compat` yarn script. (Issue #103.)
+@import "mpi_design_system/tokens";
+@import "bootstrap/scss/bootstrap";

--- a/spec/fixtures/scss/modern_use.scss
+++ b/spec/fixtures/scss/modern_use.scss
@@ -1,0 +1,14 @@
+// Compat fixture — modern Sass-module consumer path.
+//
+// Proves an app can adopt MPI values via `@use` and feed them into its OWN
+// Bootstrap configuration WITHOUT importing the engine's Bootstrap (no
+// double-compile). `@use … as *` brings the $mpi-* values into scope; the app
+// then maps them onto Bootstrap's `!default` variables before importing
+// Bootstrap once. Compiled by the `build:css:compat` yarn script. (Issue #103.)
+@use "mpi_design_system/tokens_values" as *;
+
+$primary: $mpi-primary;
+$success: $mpi-success;
+$body-color: $mpi-text;
+
+@import "bootstrap/scss/bootstrap";

--- a/spec/fixtures/scss/modern_use_override.scss
+++ b/spec/fixtures/scss/modern_use_override.scss
@@ -1,0 +1,13 @@
+// Compat fixture — proves the values module's `!default` flags let a modern
+// consumer override MPI tokens via `@use … with (…)`. Two things are asserted
+// by compiling this file: (1) it compiles at all — a `with ()` override of a
+// variable NOT declared `!default` is a hard Sass error, so success proves the
+// flags are present; (2) the overridden primary (#0a5c2e) reaches the compiled
+// CSS, proving the override wins over the default. (Issue #103, Work item 2.)
+@use "mpi_design_system/tokens_values" as mpi with (
+  $mpi-primary: #0A5C2E
+);
+
+$primary: mpi.$mpi-primary;
+
+@import "bootstrap/scss/bootstrap";

--- a/spec/packaging/engine_spec.rb
+++ b/spec/packaging/engine_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Guards Work item 2 of #103: the engine delivers component JS/SCSS as *source*
+# consumed by each host app's esbuild alias + dart-sass `--load-path`, NOT via
+# the Rails asset pipeline. A `config.assets.paths` initializer delivers nothing
+# to the esbuild/dart-sass pipeline every MPI app uses and only misleads
+# consumers, so it must not exist. These examples fail if it is re-introduced.
+RSpec.describe MpiDesignSystem::Engine do
+  describe "asset-delivery contract" do
+    it "registers no config.assets.paths initializer" do
+      initializer_names = described_class.initializers.map(&:name)
+
+      expect(initializer_names).not_to include("mpi_design_system.assets")
+    end
+
+    it "does not push the engine's JS source dir onto the host asset paths" do
+      # `app/javascript` holds esbuild-bundled *source* — it must never be on the
+      # Propshaft path (that was the misleading part of the removed initializer).
+      # `app/assets/stylesheets` is deliberately NOT asserted here: Rails'
+      # built-in `Rails::Engine` `append_assets_path` initializer adds every
+      # engine's `app/assets/*` by default, and that standard contribution is
+      # harmless (Propshaft serves static files; it does not compile the .scss).
+      asset_paths = Rails.application.config.assets.paths.map(&:to_s)
+
+      expect(asset_paths).not_to include(described_class.root.join("app/javascript").to_s)
+    end
+  end
+end

--- a/spec/packaging/gemspec_spec.rb
+++ b/spec/packaging/gemspec_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Guards .claude/rules/dependencies.md: the gemspec's runtime dependencies are
+# forced into every consuming app's bundle, so the set is kept deliberately
+# minimal. `bootstrap` was removed in #103 (Work item 2) because nothing in the
+# engine loads the Ruby gem — SCSS resolves Bootstrap against the app's npm
+# package via a dart-sass `--load-path`. This spec fails if it (or any other
+# runtime dependency) creeps back into the gemspec.
+RSpec.describe "mpi_design_system.gemspec" do
+  let(:gemspec) do
+    path = File.expand_path("../../mpi_design_system.gemspec", __dir__)
+    Gem::Specification.load(path)
+  end
+
+  let(:runtime_dependencies) do
+    gemspec.dependencies.select { |dep| dep.type == :runtime }.map(&:name)
+  end
+
+  it "declares exactly the intended runtime dependencies" do
+    expect(runtime_dependencies).to contain_exactly("rails", "view_component", "stimulus-rails")
+  end
+
+  it "does not force Bootstrap into consuming apps' bundles" do
+    expect(runtime_dependencies).not_to include("bootstrap")
+  end
+
+  it "requires Ruby >= 3.4" do
+    expect(gemspec.required_ruby_version.to_s).to include("3.4")
+  end
+end


### PR DESCRIPTION
## Summary

PR3 of the #103 sequence — **Work item 2: asset-delivery contract** (HC-ratified Option A: alias-only + cleanup). This corrects the engine's asset contract so a consuming app on the standard MPI pipeline (Propshaft + esbuild + dart-sass) can actually load the engine's JS and SCSS, and stops forcing an unused runtime dependency on every consumer.

Linked as **Part of #103** only — no closing keyword. The umbrella is finished by PR4 (README rewrite + `v0.2.0` tag), which is gated on #111 landing first.

## Changes Made

- **`lib/mpi_design_system/engine.rb`** — removed the dead `config.assets.paths` initializer. esbuild and the dart-sass CLI don't read `config.assets.paths`, so it delivered no component JS/CSS to any consumer and only implied assets "just work" once mounted. Replaced with a comment documenting why there is no initializer.
- **`mpi_design_system.gemspec`** — dropped the `bootstrap ~> 5.3` runtime dependency. Runtime set is now `{rails, view_component, stimulus-rails}`.
- **`Gemfile`** — removed the now-orphaned `gem "bootstrap", "~> 5"` (see "For the reviewer" below).
- **`app/assets/stylesheets/mpi_design_system/_tokens_values.scss`** (new) — dependency-free values module; every variable is `!default`.
- **`app/assets/stylesheets/mpi_design_system/_tokens.scss`** — now `@import`s the values module and layers the Bootstrap variable overrides on top (legacy `@import` output is byte-identical).
- **`AGENTS.md`** — documented the real install contract (Gemfile + esbuild alias + sass `--load-path` + `registerMpiControllers`, and both token entry points).
- **`package.json` + `spec/fixtures/scss/*` + `.github/workflows/ci.yml`** — new `build:css:compat` script + fixtures, wired into the CI `js-build` job.
- **`spec/packaging/engine_spec.rb`, `spec/packaging/gemspec_spec.rb`** (new) — Ruby guards for the contract.

## Technical Approach

- **Why remove, not scope, the initializer:** the engine images dir is empty and no template references an engine image; Rails' built-in `Rails::Engine` `append_assets_path` still contributes `app/assets/*` as static Propshaft paths (standard + harmless). The only *misleading* addition was `app/javascript` (JS source is esbuild-bundled, never Propshaft-served) — now correctly absent.
- **Why the values-module split:** `_tokens.scss` mixed raw MPI values with Bootstrap `$var` reassignments, which only work in the legacy pre-Bootstrap-`@import` position. Extracting a `!default` values module lets a modern `@use`-based app adopt the palette — and override it via `@use … with ()` — without double-compiling Bootstrap against its own `bootstrap@5.3.x`. `_tokens.scss` keeps the legacy path byte-compatible.

## Testing

- **`spec/packaging/engine_spec.rb`** — asserts no `mpi_design_system.assets` initializer exists and `app/javascript` is not on the asset path (fails if the initializer is re-added).
- **`spec/packaging/gemspec_spec.rb`** — asserts runtime deps are exactly `{rails, view_component, stimulus-rails}` and Bootstrap is absent (fails if a runtime dep creeps back).
- **`yarn build:css:compat`** (CI `js-build` job) — compiles three consumer models and asserts the expected primary color reaches the compiled CSS:
  - legacy `@import "mpi_design_system/tokens"` → `#2e75b6` (proves the split didn't change values)
  - modern `@use "mpi_design_system/tokens_values"` → `#2e75b6` (proves the palette feeds Bootstrap with no double-compile)
  - `@use … with ($mpi-primary: #0A5C2E)` → `#0a5c2e` (a `with ()` override of a non-`!default` var is a hard Sass error, so a clean compile proves the flags; the color proves the override wins)
- `bundle exec rubocop -a` → **0 offenses**. `bundle exec rspec` → **513 examples, 0 failures**.

## For the reviewer

- **Gemfile bootstrap removal is slightly beyond the literal "drop the gemspec dep" decision.** I removed `gem "bootstrap"` from the Gemfile too because it was unused (nothing Ruby-side loads it; CSS compiles against npm `bootstrap`), and leaving it would keep pulling an unused gem into the dev bundle. The bundle re-resolves cleanly (111 gems) and the full suite passes without it. Revert this one line if you'd rather keep it.
- **`@import` remains in the engine's own SCSS.** Migrating the engine off deprecated `@import` is out of scope; the values module gives modern apps the `@use` path without forcing that migration now.

## Checklist
- [x] Tests pass (`bundle exec rspec` — 513/0)
- [x] Linting passes (`bundle exec rubocop -a` — 0 offenses)
- [x] SCSS compat matrix (legacy `@import` + modern `@use` + `with()` override) green
- [x] `Part of #103` — not a closing reference (PR4 finishes the umbrella)

— Claude Code (Fable 5)
