### PR TITLE
chore: regenerate yarn.lock for yarn 4.17.0 (lockfile v10)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 10
   cacheKey: 10c0
 
 "@esbuild/aix-ppc64@npm:0.28.1":


### PR DESCRIPTION
## Summary

Regenerate `yarn.lock` for the pinned Yarn 4.17.0. This is a repo-wide CI fix, not a feature change — it unblocks `main` and every open branch.

## Problem

`533c482 "updating dependencies"` bumped the pinned Yarn **4.14.1 → 4.17.0** (`.yarn/releases`, `.yarnrc.yml`, `packageManager`, `.tool-versions`) but did not regenerate the lockfile. Yarn 4.14.1 wrote lockfile format `__metadata: version 9`; Yarn 4.17.0 requires `version 10`. So `yarn install --immutable` (the exact CI command) wants to migrate the lockfile it is forbidden to modify and **fails**:

```
YN0028: -  version: 9
        +  version: 10
        The lockfile would have been modified by this install, which is explicitly forbidden.
```

`main`'s own HEAD (`a8820ac`) CI run is already red for this, and it blocks the two open work branches — PR #114 (issue #103 PR3) and the #111 branch — both of which inherit main's install step.

## Changes Made

- `yarn.lock` — a single-line metadata format bump (`version: 9 → 10`), produced by running `yarn install` with the pinned Yarn 4.17.0. No dependency resolutions or checksums change.

## Technical Approach

The lockfile format version is tied to the Yarn binary, not to any dependency change. Regenerating with the already-pinned Yarn 4.17.0 brings the committed lockfile in line with the toolchain the repo declares. `yarn.lock` is a committed file in this repo (per `.claude/rules/dependencies.md`), so the regenerated lockfile is the correct artifact to commit.

## Testing

- `yarn install --immutable` (the CI command) now exits **0** locally against the regenerated lockfile (previously failed).
- Diff is exactly one line (`version: 9 → 10`); no other lockfile churn.

## Checklist
- [x] `yarn install --immutable` passes
- [x] Lockfile diff limited to the format bump
- [x] No closing keyword — this is infra; it references #103/#114/#111 only as context

## Context (no auto-close)

Unblocks CI for #114 and the #111 branch. cc the #111 session — whoever merges this first unblocks both; please rebase onto `main` afterward rather than opening a second lockfile PR.

— Claude Code (Fable 5)
