### PR TITLE
Fix two preview render defects + enforcing render sweep (Closes #111)

### DIFF
--- a/app/components/mpi_design_system/admin/tag_input/component.html.erb
+++ b/app/components/mpi_design_system/admin/tag_input/component.html.erb
@@ -38,7 +38,7 @@
   </div>
 
   <%# Dropdown suggestion list %>
-  <div style="<%= dropdown_styles %> display: none;"
+  <div style="<%= dropdown_styles %>; display: none;"
        data-mpi--tag-input-target="dropdown"
        role="listbox"
        aria-label="Tag suggestions">

--- a/spec/components/mpi_design_system/admin/tag_input/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/tag_input/component_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe MpiDesignSystem::Admin::TagInput::Component, type: :component do
   it "renders dropdown hidden by default" do
     render_inline(described_class.new(available_tags: available_tags))
 
-    expect(page).to have_css("div[data-mpi--tag-input-target='dropdown'][style*='display: none']", visible: :hidden)
+    expect(page).to have_css("div[data-mpi--tag-input-target='dropdown'][style*='margin-top: 4px; display: none']", visible: :hidden)
   end
 
   it "renders selected tag chips with correct colors" do

--- a/spec/components/previews/mpi_design_system/admin/dashboard/component_preview/default.html.erb
+++ b/spec/components/previews/mpi_design_system/admin/dashboard/component_preview/default.html.erb
@@ -31,15 +31,15 @@
   ]
 ) do |dashboard| %>
   <% dashboard.with_stat_card do %>
-    <%= render MpiDesignSystem::Admin::StatCard::Component.new(label: "Total Contacts", value: "2,307", trend: "+12%", trend_direction: :up) %>
+    <%= render MpiDesignSystem::Admin::StatCard::Component.new(label: "Total Contacts", value: "2,307", trend_text: "+12%", trend_direction: :up) %>
   <% end %>
   <% dashboard.with_stat_card do %>
-    <%= render MpiDesignSystem::Admin::StatCard::Component.new(label: "Engagements This Week", value: "47", trend: "+8%", trend_direction: :up) %>
+    <%= render MpiDesignSystem::Admin::StatCard::Component.new(label: "Engagements This Week", value: "47", trend_text: "+8%", trend_direction: :up) %>
   <% end %>
   <% dashboard.with_stat_card do %>
-    <%= render MpiDesignSystem::Admin::StatCard::Component.new(label: "Avg. Data Quality", value: "72%", trend: "+3%", trend_direction: :up) %>
+    <%= render MpiDesignSystem::Admin::StatCard::Component.new(label: "Avg. Data Quality", value: "72%", trend_text: "+3%", trend_direction: :up) %>
   <% end %>
   <% dashboard.with_stat_card do %>
-    <%= render MpiDesignSystem::Admin::StatCard::Component.new(label: "Follow-ups Due", value: "12", trend: "-2", trend_direction: :down) %>
+    <%= render MpiDesignSystem::Admin::StatCard::Component.new(label: "Follow-ups Due", value: "12", trend_text: "-2", trend_direction: :down) %>
   <% end %>
 <% end %>

--- a/spec/components/previews/preview_rendering_spec.rb
+++ b/spec/components/previews/preview_rendering_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Lookbook preview rendering", type: :component do
+  ViewComponent::Preview.all.each do |preview|
+    preview.examples.each do |scenario|
+      it "renders #{preview}##{scenario} without error" do
+        expect { render_preview(scenario, from: preview) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/dummy/app/views/layouts/component_preview.html.erb
+++ b/spec/dummy/app/views/layouts/component_preview.html.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Component Preview</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%#
+      Deliberately asset-free. The preview-render sweep
+      (spec/components/previews/preview_rendering_spec.rb) renders every Lookbook
+      example through this layout to prove no preview raises. It must not depend on
+      the Propshaft-served esbuild/dart-sass bundle (spec/dummy/app/assets/builds/*,
+      which is gitignored and only built for feature specs), so the sweep stays
+      hermetic and order-independent. Scoped to the test environment via
+      config.view_component.previews.default_layout in config/environments/test.rb,
+      so the development Lookbook UI keeps rendering previews in the full,
+      asset-loaded application layout.
+    %>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -39,4 +39,12 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Render ViewComponent previews through a bare, asset-free layout during tests so
+  # the preview-render sweep (spec/components/previews/preview_rendering_spec.rb) does
+  # not depend on the gitignored Propshaft asset bundle
+  # (spec/dummy/app/assets/builds/*, built only for feature specs). This keeps the
+  # sweep hermetic and order-independent. Development Lookbook is unaffected — it runs
+  # in the development environment and keeps the default (application) preview layout.
+  config.view_component.previews.default_layout = "component_preview"
 end

--- a/spec/features/tag_input_stimulus_spec.rb
+++ b/spec/features/tag_input_stimulus_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe "TagInput Stimulus controller", type: :feature, js: true do
       fill_tag_input("VIP")
       expect(page).to have_css("[role='option']", text: "VIP")
     end
+
+    it "keeps the suggestion dropdown hidden on initial load" do
+      visit "/tag_input_demo"
+      expect(page).to have_css("[data-controller='mpi--tag-input']")
+      display = page.evaluate_script(
+        "getComputedStyle(document.querySelector(\"[data-mpi--tag-input-target='dropdown']\")).display"
+      )
+      expect(display).to eq("none")
+    end
   end
 
   describe "adding a tag" do


### PR DESCRIPTION
## Summary
Fixes #111. Two Lookbook preview-definition defects were shipping green because the suite eager-loaded preview constants but never rendered them. This PR fixes both defects, hardens the false-green assertion that let Defect 2 hide, adds a browser-level computed-style proof, and lands the enforcing preview-render sweep (DoD #6) so this class of defect can no longer ship green.

Both defects are **pre-existing** — surfaced (not introduced) by the #103/#109 namespace rename and deliberately deferred to keep #109 a pure rename.

## Changes Made
- `spec/components/previews/mpi_design_system/admin/dashboard/component_preview/default.html.erb` — renamed `trend:` → `trend_text:` on all four StatCard calls (Defect 1; the component has no `trend:` param). `trend_direction:` unchanged.
- `app/components/mpi_design_system/admin/tag_input/component.html.erb` — inserted the missing `;` separator before `display: none` in the dropdown style (Defect 2; the dropdown was not hidden on initial load).
- `spec/components/mpi_design_system/admin/tag_input/component_spec.rb` — hardened the "renders dropdown hidden by default" assertion to the well-formed boundary substring `margin-top: 4px; display: none`.
- `spec/features/tag_input_stimulus_spec.rb` — added a `js: true` example asserting the dropdown's real computed `display` is `none` on initial load.
- `spec/components/previews/preview_rendering_spec.rb` (new) — renders every `ViewComponent::Preview` example (126 examples / 33 previews) asserting `not_to raise_error`.
- `spec/dummy/app/views/layouts/component_preview.html.erb` (new) + `spec/dummy/config/environments/test.rb` — a bare, asset-free preview layout used **only in the test env** so the sweep is hermetic (no dependence on the gitignored esbuild/dart-sass bundle). Development Lookbook is unaffected.

## Technical Approach
Both defects raise/misrender only at preview **render** time, so a render-level guard is required — the eager-load pass loads the preview constant but never invokes the template. The new sweep closes that gap. To keep the sweep fast, browser-free, and order-independent, previews render through a minimal asset-free layout in the test environment via `config.view_component.previews.default_layout`; the dummy app's application layout calls `stylesheet_link_tag "application"` / `javascript_include_tag "application"`, which Propshaft raises on when the gitignored `spec/dummy/app/assets/builds/*` bundle is absent (it is built only for feature specs). Rendering the sweep through that layout would therefore fail for a non-defect reason; the bare layout avoids that while still exercising every preview's component ERB (verified to still catch Defect 1). The false-green assertion was tightened to a well-formed boundary substring so a separator regression fails the test, and a computed-style browser assertion complements it (a `visible: :hidden` check can false-pass on a zero-size box).

## Testing
- `bundle exec rubocop -a` — 137 files, 0 offenses.
- `bundle exec rspec` — **635 examples, 0 failures, 0 pending** (sweep: 126; tag_input feature spec: 5/5 in headless Chrome, incl. the new hidden-on-load example).
- Negative-tested the sweep: reintroducing the `trend:` kwarg makes the Dashboard preview example fail, confirming the guard is enforcing.
- Confirmed the sweep is hermetic: passes with `spec/dummy/app/assets/builds/*` removed.

## Note for reviewers
Scope is 7 files: the 5 in the approved plan plus the 2-file test-env-only bare preview layout described above (both under `spec/dummy/**`, which is excluded from the gemspec `files` glob, so nothing new ships to consuming apps). Flagged transparently — it's the one deviation from the literal plan, made because the sweep is otherwise coupled to the gitignored asset bundle.

## Checklist
- [x] Tests pass
- [x] Linting passes

Part of the #103 adoption-prep effort; both defects originated in #109.

— Claude Code (Fable 5)
