### PR TITLE
Release v0.2.0 (Completes #103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to `mpi_design_system` are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html) (pre-1.0: minor bumps may
+include breaking changes).
+
+## [0.2.0] - 2026-07-02
+
+First release cut to prepare the engine for its first real adoption (Harvest — see
+`mpimedia/harvest#692`). Delivers the #103 "prepare engine for first adoption" epic:
+component namespacing, a corrected asset-delivery contract, and preview-render fixes.
+No app depended on the engine at release time, so these packaging corrections land
+before the first consumer locks them in.
+
+### Changed (breaking)
+- **Components re-namespaced** from the bare top-level `Admin::` to `MpiDesignSystem::Admin::`
+  (all 33 components), and Stimulus controller identifiers prefixed with `mpi--`
+  (e.g. `mpi--tag-input`). This removes a hard constant/identifier collision with consuming
+  apps. Consumers must reference `MpiDesignSystem::Admin::<Name>::Component`. (#109, #103)
+- **Asset-delivery contract corrected to alias-only.** The engine no longer attempts to
+  vendor Bootstrap; consuming apps compile Bootstrap SCSS against their own npm `bootstrap`
+  package via a dart-sass `--load-path`. SCSS tokens are split into `_tokens_values.scss` so
+  modern `@use`-based consumers get a values-only fallback alongside the legacy `@import`
+  path. (#114, #103)
+
+### Removed
+- **`bootstrap` runtime dependency dropped from the gemspec** — nothing in the engine loads
+  the Ruby `bootstrap` gem (Bootstrap is delivered via each app's npm package), so forcing it
+  into every consumer's bundle was redundant. (#114, #103)
+
+### Fixed
+- **Two Lookbook preview render defects** surfaced by the namespace rename: the Dashboard
+  preview passed a nonexistent `trend:` kwarg to `StatCard` (→ `trend_text:`), and the
+  `tag_input` dropdown's inline style was missing a `;`, leaving the empty dropdown visible on
+  initial load. (#116, #111)
+
+### Added
+- **Enforcing preview-render sweep** (`spec/components/previews/preview_rendering_spec.rb`) —
+  renders every Lookbook preview scenario and fails if any raises, closing the blind spot that
+  let the two defects above ship green (previews were eager-loaded but never rendered). (#116, #111)
+- **Browser-level feature spec** for the `mpi--tag-input` Stimulus controller, proving
+  hidden-on-load via computed style. (#116, #111)
+
+### Internal
+- DB-free CI (RuboCop, RSpec eager-load + browser, JS build) with `.tool-versions`. (#104, #103)
+- Regenerated `yarn.lock` for Yarn 4.17.0 (lockfile v9 → v10). (#115)
+- Reconciled `.claude/rules/testing.md` with the preview-render sweep and two testing gotchas. (#118, #117)
+
+## 0.1.0
+
+Initial internal version: the ViewComponent library, design tokens, Stimulus controllers,
+and Lookbook previews, prior to the adoption-prep packaging corrections above. (No release
+tag was cut for 0.1.0.)
+
+[0.2.0]: https://github.com/mpimedia/mpi-design-system/releases/tag/v0.2.0

--- a/lib/mpi_design_system/version.rb
+++ b/lib/mpi_design_system/version.rb
@@ -1,3 +1,3 @@
 module MpiDesignSystem
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
## Summary
Cuts **v0.2.0** — the first adoption-ready release, completing the #103 "prepare engine for first adoption" epic and unblocking Harvest's adoption (`mpimedia/harvest#692`). No app depends on the engine yet, so these packaging corrections land before the first consumer locks them in.

## Changes Made
- `lib/mpi_design_system/version.rb` — `VERSION` `0.1.0` → `0.2.0`.
- `CHANGELOG.md` (new) — the gemspec's `changelog_uri` already points here; this adds the file with the 0.2.0 entry.

## What v0.2.0 contains (since 0.1.0)
- **Breaking:** components re-namespaced `Admin::` → `MpiDesignSystem::Admin::`; Stimulus ids prefixed `mpi--` (#109, #103)
- **Changed:** alias-only asset-delivery contract + `_tokens_values.scss` `@use` fallback (#114, #103)
- **Removed:** redundant `bootstrap` runtime dependency from the gemspec (#114, #103)
- **Fixed:** two Lookbook preview render defects (#116, #111)
- **Added:** enforcing preview-render sweep + tag_input browser spec (#116, #111)
- **Internal:** DB-free CI (#104), yarn.lock regen (#115), testing.md reconciliation (#118, #117)

## Technical Approach
Release-only change (version constant + changelog). After merge, the `v0.2.0` tag/release is cut at the merge commit via `gh release`. Pre-1.0 semver: the namespace break is carried by the minor bump, which is acceptable given zero existing consumers.

## Testing
- `bundle exec rubocop -a` and `bundle exec rspec` validated by CI (the change is a version string + a new markdown file; no runtime impact).

## Checklist
- [ ] CI green
- [x] CHANGELOG accurate

Completes #103.

— Claude Code (Fable 5)
