### PR TITLE
docs: engine README + install contract + packaging specs (#103)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,62 +102,27 @@ app/components/mpi_design_system/admin/
 
 ### Stimulus Controllers
 
-Engine exports controllers via `app/javascript/mpi_design_system/`:
-
-```js
-import { registerMpiControllers } from "mpi_design_system"
-registerMpiControllers(application)
-```
-
-> **Note:** The bare `"mpi_design_system"` import requires an esbuild alias in the consuming app's `esbuild.config.js`:
-> ```js
-> alias: { 'mpi_design_system': path.resolve(__dirname, 'path/to/mpi_design_system/app/javascript/mpi_design_system') }
-> ```
-> See this repo's `esbuild.config.js` for a working example.
+The engine exports its Stimulus controllers from `app/javascript/mpi_design_system/`. A
+consuming app aliases the bare `"mpi_design_system"` specifier to that directory in esbuild,
+then calls `registerMpiControllers(application)` to register them all at once.
 
 ### Design Tokens
 
-SCSS tokens live in `app/assets/stylesheets/mpi_design_system/`. There are two entry points for the two Sass consumption models — both resolve through a dart-sass `--load-path=<gem>/app/assets/stylesheets`:
+SCSS tokens live in `app/assets/stylesheets/mpi_design_system/`, with two entry points:
+`tokens` (legacy `@import`, maps the MPI palette onto Bootstrap's variables) and
+`tokens_values` (modern `@use`, dependency-free values only). Both resolve through a
+dart-sass `--load-path`.
 
-- **Legacy `@import` apps** — import `tokens` before Bootstrap; it maps the MPI palette onto Bootstrap's variables:
-  ```scss
-  @import "mpi_design_system/tokens";
-  @import "bootstrap/scss/bootstrap";
-  ```
-- **Modern Sass-module apps** — `@use` the dependency-free values module and feed the palette into your own Bootstrap config, so the engine's Bootstrap is not double-compiled against your app's `bootstrap@5.3.x`:
-  ```scss
-  @use "mpi_design_system/tokens_values" as mpi;
-  $primary: mpi.$mpi-primary;
-  @import "bootstrap/scss/bootstrap";
-  ```
+### Engine Integration — Install Contract
 
-### Engine Integration
+The engine ships its JS and SCSS as **source** (no Rails asset-pipeline initializer — there
+is nothing to auto-mount). A consuming app wires up the gem, the esbuild alias, and the
+dart-sass `--load-path`.
 
-The engine ships its JS and SCSS as **source** (no Rails asset-pipeline initializer — there is nothing to auto-mount). A consuming app wires up three things:
-
-```ruby
-# Gemfile
-gem 'mpi_design_system', git: 'git@github.com:mpimedia/mpi-design-system.git'
-```
-
-```js
-// esbuild.config.js — alias the bare specifier to the gem's JS source
-alias: { 'mpi_design_system': path.resolve(__dirname, 'path/to/mpi_design_system/app/javascript/mpi_design_system') }
-```
-
-```js
-// application.js
-import { registerMpiControllers } from "mpi_design_system"
-registerMpiControllers(application)
-```
-
-```bash
-# CSS build — add the gem's stylesheets dir to the sass load path
-sass app/assets/stylesheets/application.scss:app/assets/builds/application.css \
-  --load-path=node_modules --load-path=path/to/mpi_design_system/app/assets/stylesheets
-```
-
-Then import tokens in `application.scss` using one of the two models above.
+> **The canonical, self-contained install instructions live in [`README.md`](README.md)** —
+> Gemfile line, esbuild alias, `registerMpiControllers`, dart-sass `--load-path`, and both
+> token entry points, with every path resolved via `bundle show mpi_design_system`. README
+> is the single source of truth; do not duplicate the install steps here.
 
 ## Agent Attribution (Required — No Exceptions)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to `mpi_design_system` are documented here. The format is ba
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (pre-1.0: minor bumps may
 include breaking changes).
 
+## [Unreleased]
+
 ## [0.2.0] - 2026-07-02
 
 First release cut to prepare the engine for its first real adoption (Harvest — see

--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
 # MPI Design System
 
-A shared design language and component catalog for MPI Media applications.
+A mountable **Rails engine gem** that ships the shared ViewComponents, design tokens, and
+Stimulus controllers for every MPI Media application.
 
 ## What This Is
 
-This repo is the **single source of truth** for MPI's visual design language. It contains:
+`mpi_design_system` is the single source of truth for MPI's visual language, delivered as
+installable code — not just documentation. It provides:
 
-- **Design tokens** — Colors, typography, spacing, and Bootstrap 5 customizations
-- **Component catalog** — Specs for every UI building block used across MPI apps
-- **Workflow documentation** — How to propose, design, review, and approve components
-- **Visual references** — Approved renders (PNGs, PDFs) stored alongside their specs
-- **CLAUDE.md** — A context file that anchors AI design sessions to the shared design language
+- **ViewComponents** — 33 shared UI components under the `MpiDesignSystem::Admin::` namespace
+  (badges, cards, tables, layouts, CRM panels, and more)
+- **Design tokens** — Brand colors, semantic palette, and Bootstrap 5 overrides as SCSS
+- **Stimulus controllers** — Hotwire behavior (e.g. `mpi--tag-input`), registered in one call
+- **Component catalog** — Specs for every UI building block (`catalog/`)
+- **Token & workflow docs** — `tokens/*.md`, `CONTRIBUTING.md`, and `CLAUDE.md` for design sessions
 
-This is a **documentation and specification repo**, not a code library. Implementation happens in each app's codebase using ViewComponents and Bootstrap 5.
+The engine ships its component **JS and SCSS as source**. There is no Rails asset-pipeline
+initializer — a consuming app wires the assets into its own esbuild + dart-sass build (see
+[Installation](#installation)). This mirrors the pipeline every MPI app already uses
+(`jsbundling-rails` + `cssbundling-rails` + Propshaft).
 
 ## Applications
 
@@ -25,37 +31,128 @@ The design system serves these MPI Media applications:
 | **Garden** | Static site generator |
 | **Harvest** | Ecommerce platform |
 
+## Installation
+
+Installing the engine is three steps: add the gem, wire the JS, and wire the SCSS. Every
+path below resolves through Bundler with `bundle show mpi_design_system`, so nothing depends
+on where Bundler unpacks the gem.
+
+### 1. Add the gem
+
+```ruby
+# Gemfile
+gem "mpi_design_system", git: "git@github.com:mpimedia/mpi-design-system.git", tag: "v0.2.0"
+```
+
+Pin to a release tag (`tag: "v0.2.0"`) so upgrades are deliberate. Then:
+
+```bash
+bundle install
+```
+
+### 2. Wire the JavaScript (esbuild)
+
+The engine exports its Stimulus controllers under the bare specifier `mpi_design_system`.
+Alias that specifier to the gem's JS source in your app's esbuild config, resolving the gem
+path at build time via `bundle show`:
+
+```js
+// esbuild.config.js
+const path = require("path");
+const { execSync } = require("child_process");
+
+const gemPath = execSync("bundle show mpi_design_system").toString().trim();
+
+require("esbuild").build({
+  // ...your existing options...
+  alias: {
+    mpi_design_system: path.join(gemPath, "app/javascript/mpi_design_system"),
+  },
+});
+```
+
+Then register every engine controller in one call from your Stimulus entrypoint:
+
+```js
+// app/javascript/application.js
+import { Application } from "@hotwired/stimulus";
+import { registerMpiControllers } from "mpi_design_system";
+
+const application = Application.start();
+registerMpiControllers(application);
+```
+
+### 3. Wire the SCSS (dart-sass)
+
+Add the gem's stylesheets directory to your dart-sass `--load-path`, again resolved via
+`bundle show`:
+
+```bash
+sass app/assets/stylesheets/application.scss:app/assets/builds/application.css \
+  --load-path=node_modules \
+  --load-path=$(bundle show mpi_design_system)/app/assets/stylesheets
+```
+
+Then import the MPI tokens in `application.scss` using **one** of the two entry points:
+
+- **Legacy `@import` pipeline** — import `tokens` before Bootstrap; it maps the MPI palette
+  onto Bootstrap's variables:
+
+  ```scss
+  @import "mpi_design_system/tokens";
+  @import "bootstrap/scss/bootstrap";
+  ```
+
+- **Modern Sass-module pipeline** — `@use` the dependency-free values module and feed the
+  palette into your own Bootstrap config, so the engine's Bootstrap is not double-compiled
+  against your app's `bootstrap@5.3.x`:
+
+  ```scss
+  @use "mpi_design_system/tokens_values" as mpi;
+  $primary: mpi.$mpi-primary;
+  @import "bootstrap/scss/bootstrap";
+  ```
+
+### 4. Use a component
+
+```erb
+<%= render MpiDesignSystem::Admin::Badge::Component.new(label: "New", color: :success) %>
+```
+
 ## Repo Structure
 
 ```
 mpi-design-system/
-├── CLAUDE.md                    # Context file for Claude design sessions
-├── CONTRIBUTING.md              # How to propose, review, approve designs
+├── app/
+│   ├── components/mpi_design_system/admin/   # ViewComponents (MpiDesignSystem::Admin::Name::Component)
+│   ├── javascript/mpi_design_system/         # Engine JS + Stimulus controllers
+│   └── assets/stylesheets/mpi_design_system/ # SCSS tokens (_tokens.scss, _tokens_values.scss)
+├── lib/mpi_design_system/                    # Engine, version
+├── spec/                                     # RSpec specs, Lookbook previews, dummy app
 │
-├── tokens/                      # Design tokens
+├── CHANGELOG.md                 # Release history (Keep a Changelog)
+├── CONTRIBUTING.md              # How to propose, review, approve designs
+├── CLAUDE.md                    # Context file for Claude design sessions
+│
+├── tokens/                      # Design token documentation
 │   ├── colors.md
 │   ├── typography.md
 │   ├── spacing.md
 │   └── bootstrap-overrides.md
 │
-├── catalog/                     # Component catalog
+├── catalog/                     # Component catalog specs
 │   ├── elements/                # Buttons, inputs, badges, icons, links
 │   ├── components/              # Cards, modals, navbars, tables, alerts
 │   ├── patterns/                # Forms, search, filters, data entry
 │   └── layouts/                 # Dashboards, detail pages, list views
 │
-├── workflow/                    # Design governance
-│   ├── design-proposal.md
-│   └── review-checklist.md
-│
-├── references/                  # Approved visual references (PNGs, PDFs)
-│
-└── tooling/                     # Tool guides and recommendations
+└── references/                  # Approved visual references (PNGs, PDFs)
 ```
 
-## Taxonomy
+## Component Taxonomy
 
-Components are organized using **plain language categories** with cross-references to Atomic Design and Bootstrap 5 terminology:
+Components are organized using **plain language categories** with cross-references to
+Atomic Design and Bootstrap 5 terminology:
 
 | Category | What it contains | Atomic equivalent |
 |---|---|---|
@@ -64,39 +161,26 @@ Components are organized using **plain language categories** with cross-referenc
 | **Patterns** | Recurring multi-component arrangements — forms, search, filters | Organisms |
 | **Layouts** | Full page structures — dashboards, detail pages, list views | Templates/Pages |
 
-## Quick Start
+## Development
 
-### For Designers (Badie + Claude)
+```bash
+bundle install
+yarn install
 
-1. Open a Claude session (claude.ai or Claude Code)
-2. Paste or attach the contents of [`CLAUDE.md`](CLAUDE.md) at the start of the conversation
-3. Claude will design within the established design language
-4. Export artifacts as PDF/PNG and attach to the relevant GitHub issue
-
-### For Developers
-
-1. Find the approved component spec in [`catalog/`](catalog/)
-2. Implement as a ViewComponent in the target Rails app
-3. Follow the Bootstrap 5 classes and markup documented in the spec
-4. Reference the design tokens in [`tokens/`](tokens/) for customizations
-
-### For Reviewers
-
-1. Check the [GitHub Project board](https://github.com/orgs/mpimedia/projects/14) for items in "In Review"
-2. Review the design against the [`workflow/review-checklist.md`](workflow/review-checklist.md)
-3. Comment on the issue with approval or requested changes
-
-## Design Workflow
-
-```
-Propose → Design → Review → Approve → Implement → Done
+bin/dev                    # Dev server (web, js, css) + Lookbook at /lookbook
+bundle exec rspec          # Run the spec suite
+bundle exec rubocop -a     # Lint and auto-correct
 ```
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full process.
+Reference the design tokens documented in [`tokens/`](tokens/) and the component specs in
+[`catalog/`](catalog/) before adding or changing a component. See
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for the full propose → design → review → approve →
+implement workflow, and [`CHANGELOG.md`](CHANGELOG.md) for release history.
 
 ## Project Board
 
-Track design system progress on the [MPI Design System project board](https://github.com/orgs/mpimedia/projects/15).
+Track design system progress on the
+[MPI Design System project board](https://github.com/orgs/mpimedia/projects/15).
 
 ## Related Repositories
 

--- a/app/assets/stylesheets/mpi_design_system/_tokens.scss
+++ b/app/assets/stylesheets/mpi_design_system/_tokens.scss
@@ -8,7 +8,7 @@
 //
 // Apps on the modern Sass module system should instead `@use
 // "mpi_design_system/tokens_values"` and configure Bootstrap themselves — see
-// AGENTS.md. (Issue #103, Work item 2.)
+// README. (Issue #103, Work item 2.)
 @import "tokens_values";
 
 // Semantic colors → Bootstrap variable overrides

--- a/app/assets/stylesheets/mpi_design_system/_tokens_values.scss
+++ b/app/assets/stylesheets/mpi_design_system/_tokens_values.scss
@@ -13,7 +13,7 @@
 //   @import "bootstrap/scss/bootstrap";
 //
 // Apps on the legacy pipeline should import `tokens` instead, which layers the
-// Bootstrap variable overrides on top of these values. See AGENTS.md for both
+// Bootstrap variable overrides on top of these values. See README for both
 // install paths. (Issue #103, Work item 2.)
 
 // Brand colors

--- a/lib/mpi_design_system/engine.rb
+++ b/lib/mpi_design_system/engine.rb
@@ -4,7 +4,7 @@ module MpiDesignSystem
 
     # No asset-pipeline initializer by design. The engine ships its component
     # JS and SCSS as *source*, delivered to each consuming app through that
-    # app's own esbuild alias and dart-sass `--load-path` (see AGENTS.md for the
+    # app's own esbuild alias and dart-sass `--load-path` (see README for the
     # install contract). Pushing these dirs onto `config.assets.paths`
     # delivers nothing to the esbuild + dart-sass pipeline every MPI app uses and
     # only misleads consumers into thinking the assets "just work" once mounted.

--- a/mpi_design_system.gemspec
+++ b/mpi_design_system.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/mpimedia/mpi-design-system/blob/main/CHANGELOG.md"
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    Dir["{app,config,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
+    Dir["{app,config,lib}/**/*", "CHANGELOG.md", "LICENSE", "Rakefile", "README.md"]
   end
 
   spec.required_ruby_version = ">= 3.4"

--- a/spec/packaging/changelog_spec.rb
+++ b/spec/packaging/changelog_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Guards the release changelog. The gemspec's `changelog_uri` points at
+# CHANGELOG.md, so the file must both exist and ship inside the gem (added to the
+# `files` glob in PR4 of #103) — otherwise a consumer following the changelog
+# link, or `gem` tooling, hits a 404 / missing file.
+RSpec.describe "CHANGELOG.md" do
+  let(:root) { File.expand_path("../..", __dir__) }
+  let(:changelog_path) { File.join(root, "CHANGELOG.md") }
+  let(:changelog) { File.read(changelog_path) }
+
+  let(:gemspec) do
+    Gem::Specification.load(File.join(root, "mpi_design_system.gemspec"))
+  end
+
+  it "exists at the repo root" do
+    expect(File).to exist(changelog_path)
+  end
+
+  it "documents the 0.2.0 release" do
+    expect(changelog).to include("0.2.0")
+  end
+
+  it "is packaged in the gem's files so changelog_uri resolves" do
+    expect(gemspec.files).to include("CHANGELOG.md")
+  end
+end

--- a/spec/packaging/install_contract_spec.rb
+++ b/spec/packaging/install_contract_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Guards the install contract for consuming apps (PR4 of #103, Option A):
+# README.md is the single, self-contained install home. README must carry the
+# canonical wiring strings, and the in-source doc comments must point at README —
+# not the interim "AGENTS.md" pointer used while PR3 (#114) landed. README.md
+# ships in the gem; AGENTS.md does not, so a consumer can only read the install
+# steps from README.
+RSpec.describe "install contract docs" do
+  let(:root) { File.expand_path("../..", __dir__) }
+
+  def read(relative)
+    File.read(File.join(root, relative))
+  end
+
+  describe "README.md" do
+    let(:readme) { read("README.md") }
+
+    it "documents the Stimulus registration entry point" do
+      expect(readme).to include("registerMpiControllers")
+    end
+
+    it "documents the legacy @import token entry point" do
+      expect(readme).to include('@import "mpi_design_system/tokens"')
+    end
+
+    it "documents the modern @use token-values entry point" do
+      expect(readme).to include('@use "mpi_design_system/tokens_values"')
+    end
+
+    it "resolves gem asset paths through Bundler" do
+      expect(readme).to include("bundle show mpi_design_system")
+    end
+  end
+
+  describe "in-source install pointers" do
+    %w[
+      lib/mpi_design_system/engine.rb
+      app/assets/stylesheets/mpi_design_system/_tokens.scss
+      app/assets/stylesheets/mpi_design_system/_tokens_values.scss
+    ].each do |source_file|
+      context "in #{source_file}" do
+        let(:contents) { read(source_file) }
+
+        it "points at README for the install contract" do
+          expect(contents).to include("README")
+        end
+
+        it "no longer points at the interim AGENTS.md" do
+          expect(contents).not_to include("AGENTS.md")
+        end
+      end
+    end
+  end
+end

--- a/spec/packaging/version_spec.rb
+++ b/spec/packaging/version_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Guards the released version constant. PR4 of #103 cut v0.2.0 — the first
+# adoption-ready release. This spec fails if the constant regresses, keeping
+# lib/mpi_design_system/version.rb in lockstep with CHANGELOG.md and the git tag.
+RSpec.describe "MpiDesignSystem::VERSION" do
+  it "is 0.2.0" do
+    expect(MpiDesignSystem::VERSION).to eq("0.2.0")
+  end
+end


### PR DESCRIPTION
## Summary

Final phase of the #103 "prepare engine for first adoption" epic. Reframes the repo's
documentation from a "spec/docs repo, not a code library" into the mountable Rails engine gem
it actually is, and establishes **README.md as the single, self-contained install home** for
consuming apps (Markaz, SFA, Garden, Harvest). README ships inside the gem; AGENTS.md does
not — so a consumer can only read install steps from README.

The v0.2.0 version bump and the `CHANGELOG.md` file itself already landed on `main` via #119,
so this PR does **not** duplicate them. It completes the remaining packaging work: the README
rewrite, shipping the changelog inside the gem, re-pointing interim doc comments, and adding
packaging guard specs.

`Closes #103`.

## Changes Made

- **`README.md`** — full rewrite. Concrete, Bundler-resolved install contract: Gemfile
  `git:`+`tag: "v0.2.0"` pin; esbuild alias resolved via `bundle show mpi_design_system`;
  `registerMpiControllers(application)`; dart-sass `--load-path=$(bundle show …)/app/assets/stylesheets`;
  and **both** SCSS token entry points (`@import "mpi_design_system/tokens"` and
  `@use "mpi_design_system/tokens_values"`). Removed the "not a code library" framing; fixed
  the stale project-board link (now consistently project 15); preserved the Applications
  table, `catalog/` taxonomy, `tokens/*.md`, and `CONTRIBUTING.md` references.
- **`mpi_design_system.gemspec`** — add `CHANGELOG.md` to the `files` glob so the gemspec's
  `changelog_uri` resolves inside the packaged gem.
- **`CHANGELOG.md`** — add a Keep-a-Changelog `## [Unreleased]` heading.
- **`lib/mpi_design_system/engine.rb`, `_tokens.scss`, `_tokens_values.scss`** — re-point the
  interim "see AGENTS.md" install-doc comments (introduced in PR3, #114) to README, the
  canonical source that ships in the gem.
- **`AGENTS.md`** — trim the duplicated install steps down to a short pointer at README
  (single source of truth).
- **`spec/packaging/`** (new) — `version_spec.rb` (`VERSION == "0.2.0"`), `changelog_spec.rb`
  (CHANGELOG exists, names 0.2.0, is packaged in the gemspec `files`), `install_contract_spec.rb`
  (README carries the canonical install strings; the three source comments reference README and
  no longer AGENTS.md).

## Technical Approach

Option A — README is the canonical, self-contained install home. Every asset path in the
install steps resolves through `bundle show mpi_design_system`, so nothing depends on where
Bundler unpacks the gem. The packaging specs are executable guards: they fail if the version
regresses, if the changelog stops shipping in the gem, or if the install docs drift back to
the interim AGENTS.md pointer. Built on `origin/main` (`5a5612d`), which already carries the
#119 release commit, so no version/CHANGELOG duplication.

## Testing

- `bundle exec rubocop -a` → **0 offenses** (142 files).
- `bundle exec rspec` → **654 examples, 0 failures** (includes the 3 new packaging specs), run
  CI-equivalent. Assets pre-built (`MDS_ASSETS_PREBUILT=1`) for the `mpi--tag-input` feature spec.

## Checklist

- [x] Tests pass (654 examples, 0 failures)
- [x] Linting passes (rubocop 0 offenses)
- [x] README is self-contained and ships in the gem
- [x] CHANGELOG.md packaged in the gemspec `files`

— Claude Code (Fable 5)
