### PR TITLE
feat(empty-state): tokenize EmptyState — Bootstrap classes + configurable heading level (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ include breaking changes).
 
 ## [Unreleased]
 
+### Added
+- **`Admin::EmptyState::Component` gains a `heading_level:` parameter** (`:h1`–`:h6`,
+  default `:h3`; invalid values fall back to `:h3`). Consumers can place the empty state
+  under an existing section heading without a backward heading-level jump (e.g. `:h5`
+  beneath a show-page `<h4>`). The visual size is held constant (`fs-5`) regardless of the
+  chosen semantic level. (#121, harvest#736 — epic harvest#692 Phase 5)
+
+### Changed
+- **`Admin::EmptyState::Component` is now class/token-based.** Replaced every inline `style=`
+  attribute and literal hex color (`#F5F7FA`, `#1B2A4A`, `#4EA8DE`, `#6C757D`, `#DEE2E6`,
+  `#2E75B6`) with Bootstrap 5.3 utility classes that resolve against each consumer's
+  configured palette (`bg-body-tertiary`, `text-primary`, `text-muted`, `rounded-3`, `p-5`,
+  `fs-1`, `fs-5`, `fw-semibold`, `border`, `bg-white`, `text-decoration-none`, …), mirroring
+  the already class-based `Badge`. No consumer-visible API change beyond the additive
+  `heading_level:` parameter. Consuming specs that asserted the inline-hex seam (e.g.
+  `div[style*='#F5F7FA']`) must re-point onto the class markers. (#121, harvest#736)
+
 ## [0.2.0] - 2026-07-02
 
 First release cut to prepare the engine for its first real adoption (Harvest — see

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,13 @@ include breaking changes).
   attribute and literal hex color (`#F5F7FA`, `#1B2A4A`, `#4EA8DE`, `#6C757D`, `#DEE2E6`,
   `#2E75B6`) with Bootstrap 5.3 utility classes that resolve against each consumer's
   configured palette (`bg-body-tertiary`, `text-primary`, `text-muted`, `rounded-3`, `p-5`,
-  `fs-1`, `fs-5`, `fw-semibold`, `border`, `bg-white`, `text-decoration-none`, …), mirroring
-  the already class-based `Badge`. No consumer-visible API change beyond the additive
-  `heading_level:` parameter. Consuming specs that asserted the inline-hex seam (e.g.
-  `div[style*='#F5F7FA']`) must re-point onto the class markers. (#121, harvest#736)
+  `fs-1`, `fs-5`, `fw-semibold`, `border`, `bg-body`, `text-decoration-none`, …), mirroring
+  the already class-based `Badge`. Shortcut cards use the color-mode-aware `bg-body` (not a
+  fixed `bg-white`) so they stay legible under Bootstrap dark mode, and the description /
+  shortcut-cluster measures that were inline `max-width`s are now held by the responsive
+  grid. No consumer-visible API change beyond the additive `heading_level:` parameter.
+  Consuming specs that asserted the inline-hex seam (e.g. `div[style*='#F5F7FA']`) must
+  re-point onto the class markers. (#121, harvest#736)
 
 ## [0.2.0] - 2026-07-02
 

--- a/app/components/mpi_design_system/admin/empty_state/component.html.erb
+++ b/app/components/mpi_design_system/admin/empty_state/component.html.erb
@@ -8,7 +8,9 @@
   <%= content_tag @heading_level, @heading, class: "fs-5 fw-semibold mb-2" %>
 
   <% if @description %>
-    <p class="small text-muted mb-3"><%= @description %></p>
+    <div class="row justify-content-center">
+      <p class="col-12 col-md-8 col-xl-6 small text-muted mb-3"><%= @description %></p>
+    </div>
   <% end %>
 
   <% if show_action? %>
@@ -23,17 +25,21 @@
   <% end %>
 
   <% if show_shortcuts? %>
-    <div class="row g-3 mt-3 justify-content-center" aria-label="Quick access shortcuts">
-      <% @shortcuts.each do |shortcut| %>
-        <div class="col-6">
-          <a href="<%= shortcut[:href] %>" class="shortcut-card d-block h-100 p-3 rounded-3 border bg-white text-decoration-none text-start">
-            <div class="small fw-semibold text-primary"><%= shortcut[:title] %></div>
-            <% if shortcut[:description] %>
-              <div class="small text-muted"><%= shortcut[:description] %></div>
-            <% end %>
-          </a>
+    <div class="row justify-content-center mt-3">
+      <div class="col-12 col-md-10 col-lg-8">
+        <div class="row g-3" aria-label="Quick access shortcuts">
+          <% @shortcuts.each do |shortcut| %>
+            <div class="col-6">
+              <a href="<%= shortcut[:href] %>" class="shortcut-card d-block h-100 p-3 rounded-3 border bg-body text-decoration-none text-start">
+                <div class="small fw-semibold text-primary"><%= shortcut[:title] %></div>
+                <% if shortcut[:description] %>
+                  <div class="small text-muted"><%= shortcut[:description] %></div>
+                <% end %>
+              </a>
+            </div>
+          <% end %>
         </div>
-      <% end %>
+      </div>
     </div>
   <% end %>
 </div>

--- a/app/components/mpi_design_system/admin/empty_state/component.html.erb
+++ b/app/components/mpi_design_system/admin/empty_state/component.html.erb
@@ -1,14 +1,14 @@
-<div style="<%= container_styles %>">
+<div class="bg-body-tertiary rounded-3 p-5 text-center">
   <% if @icon %>
     <div class="mb-3">
-      <i class="bi <%= @icon %>" style="<%= icon_styles %>" aria-hidden="true"></i>
+      <i class="bi <%= @icon %> fs-1 text-primary" aria-hidden="true"></i>
     </div>
   <% end %>
 
-  <h3 style="<%= heading_styles %>" class="mb-2"><%= @heading %></h3>
+  <%= content_tag @heading_level, @heading, class: "fs-5 fw-semibold mb-2" %>
 
   <% if @description %>
-    <p style="<%= description_styles %>" class="mb-3"><%= @description %></p>
+    <p class="small text-muted mb-3"><%= @description %></p>
   <% end %>
 
   <% if show_action? %>
@@ -23,13 +23,13 @@
   <% end %>
 
   <% if show_shortcuts? %>
-    <div class="row g-3 mt-3 justify-content-center" style="max-width: 600px; margin: 0 auto;" aria-label="Quick access shortcuts">
+    <div class="row g-3 mt-3 justify-content-center" aria-label="Quick access shortcuts">
       <% @shortcuts.each do |shortcut| %>
         <div class="col-6">
-          <a href="<%= shortcut[:href] %>" style="<%= shortcut_card_styles %>" class="shortcut-card">
-            <div style="<%= shortcut_title_styles %>"><%= shortcut[:title] %></div>
+          <a href="<%= shortcut[:href] %>" class="shortcut-card d-block h-100 p-3 rounded-3 border bg-white text-decoration-none text-start">
+            <div class="small fw-semibold text-primary"><%= shortcut[:title] %></div>
             <% if shortcut[:description] %>
-              <div style="<%= shortcut_desc_styles %>"><%= shortcut[:description] %></div>
+              <div class="small text-muted"><%= shortcut[:description] %></div>
             <% end %>
           </a>
         </div>

--- a/app/components/mpi_design_system/admin/empty_state/component.html.erb
+++ b/app/components/mpi_design_system/admin/empty_state/component.html.erb
@@ -31,7 +31,7 @@
           <% @shortcuts.each do |shortcut| %>
             <div class="col-6">
               <a href="<%= shortcut[:href] %>" class="shortcut-card d-block h-100 p-3 rounded-3 border bg-body text-decoration-none text-start">
-                <div class="small fw-semibold text-primary"><%= shortcut[:title] %></div>
+                <div class="small fw-semibold text-primary-emphasis"><%= shortcut[:title] %></div>
                 <% if shortcut[:description] %>
                   <div class="small text-muted"><%= shortcut[:description] %></div>
                 <% end %>

--- a/app/components/mpi_design_system/admin/empty_state/component.rb
+++ b/app/components/mpi_design_system/admin/empty_state/component.rb
@@ -4,18 +4,26 @@ module MpiDesignSystem
   module Admin
     module EmptyState
       class Component < ViewComponent::Base
+        HEADING_LEVELS = %i[h1 h2 h3 h4 h5 h6].freeze
+
         # @param icon [String] Bootstrap Icon class (e.g., "bi-search", "bi-inbox")
         # @param heading [String] Heading text
+        # @param heading_level [Symbol] Semantic heading level for the heading text —
+        #   one of :h1..:h6 (default :h3). Lets a consumer compose the empty state under an
+        #   existing section heading without a backward jump (e.g. :h5 beneath a show-page
+        #   <h4>). The visual size is held constant (`fs-5`) regardless of level. Invalid
+        #   values fall back to :h3.
         # @param description [String] Description text
         # @param action_label [String] Optional CTA button text
         # @param action_url [String] Optional CTA button URL
         # @param action_icon [String] Optional icon for CTA button (e.g., "bi-plus-lg")
         # @param shortcuts [Array<Hash>] Optional shortcut cards:
         #   [{ title: "Buyers — no engagement", description: "Follow-up candidates", href: "#" }]
-        def initialize(icon: nil, heading:, description: nil, action_label: nil, action_url: nil,
-                       action_icon: nil, shortcuts: [])
+        def initialize(icon: nil, heading:, heading_level: :h3, description: nil, action_label: nil,
+                       action_url: nil, action_icon: nil, shortcuts: [])
           @icon = icon
           @heading = heading
+          @heading_level = HEADING_LEVELS.include?(heading_level) ? heading_level : :h3
           @description = description
           @action_label = action_label
           @action_url = action_url
@@ -24,53 +32,6 @@ module MpiDesignSystem
         end
 
         private
-
-        def container_styles
-          [
-            "background: #F5F7FA",
-            "border-radius: 8px",
-            "padding: 60px 40px",
-            "text-align: center"
-          ].join("; ")
-        end
-
-        def icon_styles
-          "font-size: 40px; color: #4EA8DE;"
-        end
-
-        def heading_styles
-          "font-size: 18px; font-weight: 600; color: #1B2A4A;"
-        end
-
-        def description_styles
-          [
-            "font-size: 14px",
-            "color: #6C757D",
-            "max-width: 420px",
-            "line-height: 1.5",
-            "margin: 0 auto"
-          ].join("; ")
-        end
-
-        def shortcut_card_styles
-          [
-            "background: #fff",
-            "border: 1px solid #DEE2E6",
-            "border-radius: 8px",
-            "padding: 16px",
-            "text-decoration: none",
-            "display: block",
-            "text-align: left"
-          ].join("; ")
-        end
-
-        def shortcut_title_styles
-          "font-size: 14px; font-weight: 600; color: #2E75B6;"
-        end
-
-        def shortcut_desc_styles
-          "font-size: 12px; color: #6C757D;"
-        end
 
         def show_action?
           @action_label.present? && @action_url.present?

--- a/spec/components/mpi_design_system/admin/empty_state/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/empty_state/component_spec.rb
@@ -6,21 +6,44 @@ RSpec.describe MpiDesignSystem::Admin::EmptyState::Component, type: :component d
   it "renders heading and description" do
     render_inline(described_class.new(heading: "No contacts found", description: "Try adjusting your filters"))
 
-    expect(page).to have_css("h3", text: "No contacts found")
-    expect(page).to have_css("p", text: "Try adjusting your filters")
+    expect(page).to have_css("h3.fs-5.fw-semibold", text: "No contacts found")
+    expect(page).to have_css("p.small.text-muted", text: "Try adjusting your filters")
   end
 
-  it "renders on a light gray background" do
+  it "renders a class-based container with no inline styles or literal hex" do
     render_inline(described_class.new(heading: "Empty"))
 
-    expect(page).to have_css("div[style*='background: #F5F7FA']")
+    # Class/token-based container (was an inline `style='background: #F5F7FA'` seam).
+    expect(page).to have_css("div.bg-body-tertiary.rounded-3.p-5.text-center")
+    # The whole point of #121: no inline styling survives anywhere in the markup.
+    expect(page).to have_no_css("[style]")
+  end
+
+  it "renders the heading at :h3 by default" do
+    render_inline(described_class.new(heading: "Empty"))
+
+    expect(page).to have_css("h3.fs-5.fw-semibold", text: "Empty")
+    expect(page).to have_no_css("h4, h5")
+  end
+
+  it "renders the heading at a caller-supplied level so it composes under a section heading" do
+    render_inline(described_class.new(heading: "No associated users found", heading_level: :h5))
+
+    # Same visual size (`fs-5`), correct semantic level — no backward h4 -> h3 jump.
+    expect(page).to have_css("h5.fs-5.fw-semibold", text: "No associated users found")
+    expect(page).to have_no_css("h3")
+  end
+
+  it "falls back to :h3 when given an unsupported heading level" do
+    render_inline(described_class.new(heading: "Empty", heading_level: :h7))
+
+    expect(page).to have_css("h3.fs-5.fw-semibold", text: "Empty")
   end
 
   it "renders an icon when provided" do
     render_inline(described_class.new(heading: "Search", icon: "bi-search"))
 
-    expect(page).to have_css("i.bi.bi-search[aria-hidden='true']")
-    expect(page).to have_css("i[style*='color: #4EA8DE']")
+    expect(page).to have_css("i.bi.bi-search.fs-1.text-primary[aria-hidden='true']")
   end
 
   it "renders a CTA button when action is provided" do
@@ -47,15 +70,15 @@ RSpec.describe MpiDesignSystem::Admin::EmptyState::Component, type: :component d
 
     expect(page).to have_css(".col-6", count: 2)
     expect(page).to have_css("a[href='/search?q=distribution']")
-    expect(page).to have_css("div[style*='color: #2E75B6']", text: "Distribution")
-    expect(page).to have_css("div[style*='color: #6C757D']", text: "Follow-up candidates")
+    expect(page).to have_css("div.small.fw-semibold.text-primary", text: "Distribution")
+    expect(page).to have_css("div.small.text-muted", text: "Follow-up candidates")
   end
 
   it "shortcut cards are links with text-decoration none" do
     shortcuts = [ { title: "Recent", description: "Last 7 days", href: "/recent" } ]
     render_inline(described_class.new(heading: "Search", shortcuts: shortcuts))
 
-    expect(page).to have_css("a[style*='text-decoration: none'][href='/recent']")
+    expect(page).to have_css("a.text-decoration-none.border.bg-white[href='/recent']")
   end
 
   it "does not render shortcut section when shortcuts are empty" do

--- a/spec/components/mpi_design_system/admin/empty_state/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/empty_state/component_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe MpiDesignSystem::Admin::EmptyState::Component, type: :component d
 
     expect(page).to have_css(".col-6", count: 2)
     expect(page).to have_css("a[href='/search?q=distribution']")
-    expect(page).to have_css("div.small.fw-semibold.text-primary", text: "Distribution")
+    expect(page).to have_css("div.small.fw-semibold.text-primary-emphasis", text: "Distribution")
     expect(page).to have_css("div.small.text-muted", text: "Follow-up candidates")
     # The 2-card cluster is width-capped and centered via the grid (replacing the old
     # inline `max-width: 600px; margin: 0 auto` on the row).

--- a/spec/components/mpi_design_system/admin/empty_state/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/empty_state/component_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe MpiDesignSystem::Admin::EmptyState::Component, type: :component d
     render_inline(described_class.new(heading: "No contacts found", description: "Try adjusting your filters"))
 
     expect(page).to have_css("h3.fs-5.fw-semibold", text: "No contacts found")
-    expect(page).to have_css("p.small.text-muted", text: "Try adjusting your filters")
+    # Description is held to a centered, width-capped measure via the responsive grid
+    # (replacing the old inline `max-width: 420px; margin: 0 auto`).
+    expect(page).to have_css(".row.justify-content-center > p.small.text-muted.col-xl-6", text: "Try adjusting your filters")
   end
 
   it "renders a class-based container with no inline styles or literal hex" do
@@ -72,18 +74,24 @@ RSpec.describe MpiDesignSystem::Admin::EmptyState::Component, type: :component d
     expect(page).to have_css("a[href='/search?q=distribution']")
     expect(page).to have_css("div.small.fw-semibold.text-primary", text: "Distribution")
     expect(page).to have_css("div.small.text-muted", text: "Follow-up candidates")
+    # The 2-card cluster is width-capped and centered via the grid (replacing the old
+    # inline `max-width: 600px; margin: 0 auto` on the row).
+    expect(page).to have_css(".row.justify-content-center > .col-lg-8 > .row.g-3[aria-label='Quick access shortcuts']")
   end
 
-  it "shortcut cards are links with text-decoration none" do
+  it "shortcut cards are color-mode-aware links with no underline" do
     shortcuts = [ { title: "Recent", description: "Last 7 days", href: "/recent" } ]
     render_inline(described_class.new(heading: "Search", shortcuts: shortcuts))
 
-    expect(page).to have_css("a.text-decoration-none.border.bg-white[href='/recent']")
+    # `bg-body` (not fixed `bg-white`) so the card and its `text-muted` copy stay
+    # legible when a consumer enables Bootstrap's dark color mode.
+    expect(page).to have_css("a.text-decoration-none.border.bg-body[href='/recent']")
   end
 
-  it "does not render shortcut section when shortcuts are empty" do
-    render_inline(described_class.new(heading: "Empty"))
+  it "does not render the shortcut section when shortcuts are empty" do
+    render_inline(described_class.new(heading: "Empty", description: "Nothing here yet"))
 
-    expect(page).not_to have_css(".row")
+    expect(page).to have_no_css("[aria-label='Quick access shortcuts']")
+    expect(page).to have_no_css(".shortcut-card")
   end
 end

--- a/spec/components/previews/mpi_design_system/admin/empty_state/component_preview.rb
+++ b/spec/components/previews/mpi_design_system/admin/empty_state/component_preview.rb
@@ -34,4 +34,15 @@ class MpiDesignSystem::Admin::EmptyState::ComponentPreview < ApplicationComponen
       description: "Engagements will appear here once recorded."
     )
   end
+
+  # @label Nested heading (:h5)
+  # Empty state composed under an existing section heading — a consumer passes the level
+  # that keeps the document outline monotonic (e.g. :h5 beneath a show-page <h4>).
+  def nested_heading
+    render MpiDesignSystem::Admin::EmptyState::Component.new(
+      icon: "bi-people",
+      heading: "No associated users found",
+      heading_level: :h5
+    )
+  end
 end


### PR DESCRIPTION
## Summary

Tokenizes `MpiDesignSystem::Admin::EmptyState::Component`: removes every inline `style=` attribute and literal hex color in favor of Bootstrap 5.3 utility classes, and adds a configurable `heading_level:` parameter. This is the **upstream half** of Harvest [#736](https://github.com/mpimedia/harvest/issues/736) (epic [harvest#692](https://github.com/mpimedia/harvest/issues/692) "adopt `mpi_design_system`", Phase 5). It mirrors the pattern already used by the class-based `Badge` component and brings EmptyState into compliance with this engine's own `frontend.md` rule ("Use Bootstrap utility and component classes — no arbitrary hex values, sizes, or spacing").

Harvest adopted this component in harvest#734/#735 with a conscious temporary trade-off (inline hex + hard-coded `<h3>`); this PR removes both so Harvest can bump its pin and re-point its spec.

## Changes Made

- **`app/components/mpi_design_system/admin/empty_state/component.rb`**
  - Deleted the six `*_styles` private methods (`container_styles`, `icon_styles`, `heading_styles`, `description_styles`, `shortcut_card_styles`, `shortcut_title_styles`, `shortcut_desc_styles`).
  - Added `heading_level:` (default `:h3`), validated against `HEADING_LEVELS = %i[h1 h2 h3 h4 h5 h6]` with a `:h3` fallback — same guard style as `Badge`'s `COLORS.include?(...)`.
- **`app/components/mpi_design_system/admin/empty_state/component.html.erb`**
  - Container `#F5F7FA`/8px/60-40/center → `bg-body-tertiary rounded-3 p-5 text-center`.
  - Icon 40px/`#4EA8DE` → `fs-1 text-primary`.
  - Heading (was inline `<h3 style=…>`) → `content_tag @heading_level, …, class: "fs-5 fw-semibold mb-2"` (semantic level configurable, visual size held constant).
  - Description → `small text-muted`.
  - Shortcut card `#fff`/border/16px/etc. → `d-block h-100 p-3 rounded-3 border bg-white text-decoration-none text-start`; title → `small fw-semibold text-primary`; desc → `small text-muted`; dropped the row's `max-width`/`margin` inline style.
- **`spec/components/.../empty_state/component_spec.rb`** — re-pointed every inline-hex assertion onto class markers; added tests for the default level, a caller-supplied `:h5`, the invalid-level fallback, and a guard that **no `[style]` attribute** is emitted anywhere.
- **`spec/components/previews/.../empty_state/component_preview.rb`** — added a "Nested heading (:h5)" example.
- **`CHANGELOG.md`** — `[Unreleased]` Added + Changed entries.

## Technical Approach

- **Option A (Bootstrap utilities), chosen over shipping a component SCSS partial.** The tokens (`$mpi-background`, `$mpi-brand-navy`, …) are SCSS variables that compile away and aren't reachable from server-rendered ERB. Bootstrap utility classes resolve against each consumer's already-configured palette, need no new SCSS-consumption seam, and carry zero Bootstrap double-compile risk — consistent with how `Badge` was done. Minor, deliberate visual drift is accepted (e.g. the `#4EA8DE` accent icon maps to `text-primary`; the exact `#F5F7FA` maps to `bg-body-tertiary`) in exchange for colors now tracking the palette.
- **Configurable heading level** decouples the semantic level (a11y document outline) from the visual size (`fs-5`), so a consumer can request `:h5` under a show-page `<h4>` without a backward jump while the panel still looks identical.
- **No version bump / tag here.** `version.rb` stays at `0.2.0` and `spec/packaging/version_spec.rb` is untouched, following the v0.2.0 release pattern where the bump + tag are a separate release step. A new tag is required before Harvest can consume this.

## Testing

- `bundle exec rubocop -a` — 142 files, **no offenses**.
- `bundle exec rspec` — **658 examples, 0 failures** (includes the EmptyState spec, the Lookbook preview-render smoke spec, and the TagInput Selenium feature specs after `yarn install`).
- Verified no `style=`, literal hex, or `*_styles` residue remains in the component directory.

## Checklist

- [x] Tests pass
- [x] Linting passes
- [x] Spec + Lookbook preview updated for the component change
- [x] No inline styles / literal hex remain; values are Bootstrap classes/tokens
- [x] Accessibility: heading outline no longer forces a backward jump; decorative icon keeps `aria-hidden`

## Follow-up

After merge, cut a release tag (e.g. `v0.3.0` + `version.rb`/`version_spec` bump + move the `[Unreleased]` block). Harvest #736 then bumps its Gemfile pin, passes `heading_level:` from `Admin::TableForIndex`, and re-points its own `table_for_index_component_spec.rb` off the `#F5F7FA` marker.

Closes #121

— Claude Code (Opus 4.8)
