### PR TITLE
chore(release): v0.3.0 — tokenized Admin::EmptyState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ include breaking changes).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-14
+
+Tokenizes `Admin::EmptyState::Component` — the first component change driven by real
+adoption feedback (Harvest `#736`, epic `harvest#692` Phase 5). Removes the inline-hex
+seam the component shipped with and makes its heading level configurable so consumers can
+compose it under their own section headings.
+
 ### Added
 - **`Admin::EmptyState::Component` gains a `heading_level:` parameter** (`:h1`–`:h6`,
   default `:h3`; invalid values fall back to `:h3`). Consumers can place the empty state

--- a/lib/mpi_design_system/version.rb
+++ b/lib/mpi_design_system/version.rb
@@ -1,3 +1,3 @@
 module MpiDesignSystem
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/packaging/version_spec.rb
+++ b/spec/packaging/version_spec.rb
@@ -2,11 +2,12 @@
 
 require "spec_helper"
 
-# Guards the released version constant. PR4 of #103 cut v0.2.0 — the first
-# adoption-ready release. This spec fails if the constant regresses, keeping
-# lib/mpi_design_system/version.rb in lockstep with CHANGELOG.md and the git tag.
+# Guards the released version constant. PR4 of #103 cut v0.2.0 (first adoption-ready
+# release); v0.3.0 (#121) tokenizes Admin::EmptyState. This spec fails if the constant
+# regresses, keeping lib/mpi_design_system/version.rb in lockstep with CHANGELOG.md and
+# the git tag.
 RSpec.describe "MpiDesignSystem::VERSION" do
-  it "is 0.2.0" do
-    expect(MpiDesignSystem::VERSION).to eq("0.2.0")
+  it "is 0.3.0" do
+    expect(MpiDesignSystem::VERSION).to eq("0.3.0")
   end
 end


### PR DESCRIPTION
## Summary

Release **v0.3.0**. Bumps the version constant, updates the packaging version guard, and finalizes the `CHANGELOG.md` `[Unreleased]` block as `[0.3.0] - 2026-07-14`. Follows the same version-bump-then-tag convention used for v0.2.0.

Ships the #121 EmptyState tokenization (PR #122, already merged) as a consumable tag so **Harvest ([harvest#736](https://github.com/mpimedia/harvest/issues/736))** can bump its Gemfile pin off `v0.2.0`.

## Changes Made
- `lib/mpi_design_system/version.rb` — `VERSION` `0.2.0` → `0.3.0`.
- `spec/packaging/version_spec.rb` — guard now asserts `0.3.0` (kept in lockstep with the tag).
- `CHANGELOG.md` — moved the `[Unreleased]` Added/Changed entries under `## [0.3.0] - 2026-07-14`; left a fresh empty `[Unreleased]`.

## Testing
- `bundle exec rubocop` — no offenses.
- `bundle exec rspec` — 658 examples, 0 failures (packaging guards included).

## After merge
Tag `v0.3.0` on the merge commit and push it (`git tag v0.3.0 <sha> && git push origin v0.3.0`), then Harvest #736 bumps its pin to `v0.3.0`.

## Checklist
- [x] Tests pass
- [x] Linting passes
- [x] Version constant, spec guard, and CHANGELOG in lockstep

— Claude Code (Opus 4.8)