### PR TITLE
chore(release): v0.4.0 — tokenized Admin::BreadcrumbNav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ include breaking changes).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-14
+
+Tokenizes `Admin::BreadcrumbNav::Component` — the second component change driven by real
+adoption feedback (Harvest `#738`, epic `harvest#692` Phase 3), following the same
+Bootstrap-utility approach `EmptyState` took in v0.3.0. Removes the last inline-hex seam
+standing between the breadcrumb and consumer-configured palettes, and marks the
+current-page element with `aria-current="page"`.
+
 ### Changed
 - **`Admin::BreadcrumbNav::Component` is now class/token-based.** Replaced every inline
   `style=` attribute and literal hex color (`#2E75B6`, `#6C757D`, `#1B2A4A`) with Bootstrap

--- a/lib/mpi_design_system/version.rb
+++ b/lib/mpi_design_system/version.rb
@@ -1,3 +1,3 @@
 module MpiDesignSystem
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/spec/packaging/version_spec.rb
+++ b/spec/packaging/version_spec.rb
@@ -3,11 +3,11 @@
 require "spec_helper"
 
 # Guards the released version constant. PR4 of #103 cut v0.2.0 (first adoption-ready
-# release); v0.3.0 (#121) tokenizes Admin::EmptyState. This spec fails if the constant
-# regresses, keeping lib/mpi_design_system/version.rb in lockstep with CHANGELOG.md and
-# the git tag.
+# release); v0.3.0 (#121) tokenizes Admin::EmptyState; v0.4.0 (#124) tokenizes
+# Admin::BreadcrumbNav. This spec fails if the constant regresses, keeping
+# lib/mpi_design_system/version.rb in lockstep with CHANGELOG.md and the git tag.
 RSpec.describe "MpiDesignSystem::VERSION" do
-  it "is 0.3.0" do
-    expect(MpiDesignSystem::VERSION).to eq("0.3.0")
+  it "is 0.4.0" do
+    expect(MpiDesignSystem::VERSION).to eq("0.4.0")
   end
 end


### PR DESCRIPTION
Cuts **v0.4.0**, releasing the `Admin::BreadcrumbNav` tokenization (#124, PR #125) so **harvest#738** can bump its pin and adopt the component.

## Changes

Same three-file shape as the v0.3.0 release (#123):

| File | Change |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `[0.4.0] - 2026-07-14` + summary; fresh empty `[Unreleased]` left above |
| `lib/mpi_design_system/version.rb` | `0.3.0` → `0.4.0` |
| `spec/packaging/version_spec.rb` | Hard-pinned assertion bumped in lockstep (CI reddens otherwise) |

## What's in v0.4.0

`Admin::BreadcrumbNav::Component` is now class/token-based — every inline `style=` and literal hex (`#2E75B6`, `#6C757D`, `#1B2A4A`) replaced with Bootstrap 5.3 utility classes, so colors resolve against each consumer's configured palette rather than constants. Public API unchanged. Plus `aria-current="page"` on the current-page element.

Three deltas are documented in the CHANGELOG rather than shipped quietly: `py-2` (8px vs the previous 12px), the separator color (`text-body-secondary` is `rgba($body-color, .75)`, not `#6C757D` — on-brand and **4.53:1 AA** vs `#6C757D`'s 2.63:1 fail), and the separator landing at ≈12.25px rather than exactly 12px. The entry also records that sizing moved from fixed pixels to relative units — the intended trade, but a behavioral change rather than a pure refactor.

## After merge

Tag `v0.4.0` at the merge commit **and push it** — Bundler resolves this gem by *remote* tag, so an unpushed tag silently blocks harvest#738.

`bundle exec rubocop` clean · `bundle exec rspec` → **664 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Claude Code (Opus 4.8)