### PR TITLE
fix(badge): derive filled foreground via text-bg-* for AA contrast (#128)

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -75,8 +75,9 @@ If a catalog entry exists, implement to that spec. If not, raise it with the HC 
 
 - All interactive elements keyboard-accessible
 - Appropriate ARIA roles and labels (e.g. Badge adds `aria-label` for its count)
-- Contrast: 4.5:1 for normal text, 3:1 for large text — pair light backgrounds with dark
-  text classes (e.g. `bg-warning` with `text-dark`)
+- Contrast: 4.5:1 for normal text, 3:1 for large text — prefer Bootstrap's `text-bg-*`
+  utilities, which derive an accessible foreground automatically (e.g. `text-bg-warning`
+  yields dark text), rather than hand-pairing a background with a `text-*` class
 - Visible focus indicators on every focusable element
 
 ## Anti-Patterns

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -20,10 +20,11 @@ Applies to: `app/components/**`, `app/javascript/**`, `app/assets/**`
 - Validate params in the component and fall back to safe defaults (e.g. `MpiDesignSystem::Admin::Badge::Component`
   maps an unknown color to `primary`) — never let bad input render broken markup
 
-## Renaming a Component or Namespace
+## Renaming a Component, Namespace, or Styling Convention
 
-A component or namespace rename is not finished when the constants resolve — two blind spots
-routinely survive a constant-only sweep and ship green:
+A component/namespace rename — or a change to a styling convention (e.g. a Bootstrap class
+pattern) — is not finished when the constants resolve or the component renders. Blind spots
+routinely survive a narrow sweep and ship green:
 
 - **Path strings, not just constants.** Old paths also live in lowercase string literals a
   `grep 'Admin::'` never sees: `render_with_template(template: "…")`, `render partial: "…"`,
@@ -36,6 +37,13 @@ routinely survive a constant-only sweep and ship green:
   convention documented one way while the code does another tells the next agent to re-create
   the old pattern. (Reference: #103 renamed `Admin::` → `MpiDesignSystem::Admin::`; the catalog
   and standards docs had to be swept in the same change.)
+- **A styling-convention change is a rename too — grep the pattern, not the lines you know.**
+  When you change a Bootstrap class convention (e.g. `bg-#{color}` + `text-white`/`text-dark`
+  → `text-bg-#{color}`), `git grep` the *old class pattern* across the whole repo — specs,
+  `catalog/**`, and `.claude/rules/**` included — rather than editing a known list of line
+  numbers; a line-scoped sweep misses second occurrences in the same file. (Reference: #128
+  tokenized Badge's filled contrast; the external review caught a retired `bg-warning` +
+  `text-dark` example still in `.claude/rules/testing.md` that a line-scoped sweep skipped.)
 
 ## Component Catalog First
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -72,7 +72,7 @@ No component is complete until its spec covers:
 4. **Edge cases** — missing/invalid params (e.g. an invalid color falls back to the
    default), empty or nil content, empty collections
 5. **Accessibility assertions where relevant** — `aria-label`s, roles, and
-   contrast-pairing classes (e.g. `bg-warning` renders with `text-dark`)
+   derived contrast classes (e.g. `text-bg-warning` yields dark text for AA contrast)
 6. **A matching Lookbook preview** exists and actually **renders** — not merely eager-loads.
    Eager-load loads the preview *constant* but never renders it, so a missing template
    (`render_with_template(template: "…")`) or a bad component kwarg ships green under a fully

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -94,7 +94,7 @@ RSpec.describe MpiDesignSystem::Admin::Badge::Component, type: :component do
     it "falls back to the primary color" do
       render_inline(described_class.new(label: "Test", color: :invalid))
 
-      expect(page).to have_css("span.badge.bg-primary")
+      expect(page).to have_css("span.badge.text-bg-primary")
     end
   end
 end

--- a/app/components/mpi_design_system/admin/badge/component.rb
+++ b/app/components/mpi_design_system/admin/badge/component.rb
@@ -46,8 +46,7 @@ module MpiDesignSystem
         def variant_classes
           case @variant
           when :filled
-            text_class = @color == :warning ? "text-dark" : "text-white"
-            [ "bg-#{@color}", text_class ]
+            [ "text-bg-#{@color}" ]
           when :outline
             [ "border", "border-#{@color}", "text-#{@color}", "bg-transparent" ]
           when :tag_group

--- a/catalog/elements/badge.md
+++ b/catalog/elements/badge.md
@@ -19,7 +19,7 @@ Pill-shaped badges used for status indicators, counts, and labels across all MPI
 
 | Variant | Description |
 |---|---|
-| **Filled** | Solid background with white text. Used for status indicators (Active, Overdue) |
+| **Filled** | Solid background with a Bootstrap-computed foreground (light or dark, whichever meets WCAG-AA contrast — not always white). Used for status indicators (Active, Overdue) |
 | **Outline** | Transparent background with colored border and text. Used for secondary emphasis |
 | **Tag Group** | Colored text on light background. Used for CRM tag group labels (Buyer, Press, etc.) |
 | **With Count** | Filled badge with an inline number (e.g., "Contacts 24") |
@@ -80,13 +80,16 @@ end
 
 - `badge` — base class
 - `rounded-pill` — pill shape (or global override)
-- `bg-primary`, `bg-success`, `bg-danger`, `bg-warning`, `bg-secondary` — filled variants
+- `text-bg-primary`, `text-bg-success`, `text-bg-danger`, `text-bg-warning`, `text-bg-secondary` — filled variants (each pairs the background with a Bootstrap-computed accessible foreground)
 - `border` — outline variant base
 - Custom inline styles for tag group color pairs
 
 ## Accessibility
 
 - Ensure 4.5:1 contrast ratio on all text/background combinations
+- Filled badges derive their foreground via Bootstrap's `text-bg-*` utilities, so every
+  semantic color meets WCAG AA automatically (previously `success` paired a hardcoded
+  `text-white` for only 3.33:1 — see #128)
 - All tag group color pairs have been verified for WCAG AA compliance
 - Use `aria-label` when badge text alone is insufficient context (e.g., a count badge)
 

--- a/catalog/previews/badge.html
+++ b/catalog/previews/badge.html
@@ -1,4 +1,10 @@
 <!DOCTYPE html>
+<!--
+  Static hand-authored snapshot for documentation only. The live
+  MpiDesignSystem::Admin::Badge::Component is canonical — filled badges now derive their
+  foreground via Bootstrap's text-bg-* utilities (see #128). The companion
+  screenshots/badge.png is stale pending regeneration.
+-->
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -22,9 +28,9 @@
     <div class="preview-row">
       <span class="badge" style="background-color: #2E75B6;">Primary</span>
       <span class="badge bg-secondary">Secondary</span>
-      <span class="badge" style="background-color: #22A06B;">Success</span>
+      <span class="badge" style="background-color: #22A06B; color: #000;">Success</span>
       <span class="badge" style="background-color: #DC3545;">Danger</span>
-      <span class="badge" style="background-color: #D4772C;">Warning</span>
+      <span class="badge" style="background-color: #D4772C; color: #000;">Warning</span>
       <span class="badge" style="background-color: #2E75B6;">Info</span>
     </div>
   </div>
@@ -33,7 +39,7 @@
     <div class="preview-label">With Counts</div>
     <div class="preview-row">
       <span class="badge" style="background-color: #2E75B6;">Contacts <span class="ms-1">24</span></span>
-      <span class="badge" style="background-color: #22A06B;">Active <span class="ms-1">12</span></span>
+      <span class="badge" style="background-color: #22A06B; color: #000;">Active <span class="ms-1">12</span></span>
       <span class="badge" style="background-color: #DC3545;">Overdue <span class="ms-1">3</span></span>
     </div>
   </div>
@@ -64,7 +70,7 @@
       <tbody>
         <tr>
           <td>John Smith</td>
-          <td><span class="badge" style="background-color: #22A06B;">Active</span></td>
+          <td><span class="badge" style="background-color: #22A06B; color: #000;">Active</span></td>
           <td><span class="badge" style="color: #E8733A; background: #FEF3EC;">Buyer</span></td>
         </tr>
         <tr>

--- a/spec/components/mpi_design_system/admin/account_detail_panel/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/account_detail_panel/component_spec.rb
@@ -207,6 +207,6 @@ RSpec.describe MpiDesignSystem::Admin::AccountDetailPanel::Component, type: :com
   it "defaults invalid account_type_color to primary" do
     render_inline(described_class.new(name: "Test", account_type: "Custom", account_type_color: :invalid))
 
-    expect(page).to have_css("span.badge.bg-primary", text: "Custom")
+    expect(page).to have_css("span.badge.text-bg-primary", text: "Custom")
   end
 end

--- a/spec/components/mpi_design_system/admin/badge/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/badge/component_spec.rb
@@ -6,13 +6,43 @@ RSpec.describe MpiDesignSystem::Admin::Badge::Component, type: :component do
   it "renders a filled badge with default color" do
     render_inline(described_class.new(label: "Active"))
 
-    expect(page).to have_css("span.badge.rounded-pill.bg-primary", text: "Active")
+    expect(page).to have_css("span.badge.rounded-pill.text-bg-primary", text: "Active")
   end
 
-  it "renders with a specific color" do
+  it "renders a filled danger badge" do
     render_inline(described_class.new(label: "Overdue", color: :danger))
 
-    expect(page).to have_css("span.badge.bg-danger", text: "Overdue")
+    expect(page).to have_css("span.badge.text-bg-danger", text: "Overdue")
+  end
+
+  it "renders a filled secondary badge" do
+    render_inline(described_class.new(label: "Draft", color: :secondary))
+
+    expect(page).to have_css("span.badge.text-bg-secondary", text: "Draft")
+  end
+
+  it "renders a filled success badge with Bootstrap-computed contrast" do
+    render_inline(described_class.new(label: "Paid", color: :success))
+
+    # text-bg-success lets Bootstrap derive the foreground (#000 / 6.31:1 against
+    # $mpi-success #22A06B) instead of the retired hardcoded text-white (3.33:1).
+    expect(page).to have_css("span.badge.text-bg-success", text: "Paid")
+    expect(page).to have_no_css("span.badge.bg-success")
+    expect(page).to have_no_css("span.badge.text-white")
+  end
+
+  it "uses Bootstrap-computed dark text on warning background for accessibility" do
+    render_inline(described_class.new(label: "Pending", color: :warning))
+
+    expect(page).to have_css("span.badge.text-bg-warning", text: "Pending")
+    expect(page).to have_no_css("span.badge.bg-warning")
+    expect(page).to have_no_css("span.badge.text-dark")
+  end
+
+  it "defaults invalid color to primary" do
+    render_inline(described_class.new(label: "Test", color: :invalid))
+
+    expect(page).to have_css("span.badge.text-bg-primary")
   end
 
   it "renders an outline variant" do
@@ -32,17 +62,5 @@ RSpec.describe MpiDesignSystem::Admin::Badge::Component, type: :component do
 
     expect(page).to have_css("span.badge", text: "Contacts 24")
     expect(page).to have_css("span[aria-label='Contacts: 24']")
-  end
-
-  it "defaults invalid color to primary" do
-    render_inline(described_class.new(label: "Test", color: :invalid))
-
-    expect(page).to have_css("span.badge.bg-primary")
-  end
-
-  it "uses dark text on warning background for accessibility" do
-    render_inline(described_class.new(label: "Pending", color: :warning))
-
-    expect(page).to have_css("span.badge.bg-warning.text-dark", text: "Pending")
   end
 end


### PR DESCRIPTION
## Summary
The Badge component's filled `:success` variant hardcoded `text-white` on `bg-success`,
yielding a 3.33:1 contrast ratio against `$mpi-success` (#22A06B) — a WCAG 2.1 AA failure.
This PR (Option A) removes the hand-maintained foreground/background contrast table and
lets Bootstrap derive the accessible foreground via its `text-bg-*` utilities.

Closes #128

## Changes Made
- `app/components/mpi_design_system/admin/badge/component.rb` — `variant_classes` `:filled`
  branch returns `[ "text-bg-#{@color}" ]`; removes the `text-white`/`text-dark` table and
  the `:warning` special-case. `:outline`/`:tag_group` untouched.
- `spec/components/mpi_design_system/admin/badge/component_spec.rb` — one example per filled
  color; success and warning pin the derived `text-bg-*` class and assert the retired
  `bg-*`/`text-white`/`text-dark` classes are gone.
- `spec/components/mpi_design_system/admin/account_detail_panel/component_spec.rb` — updated
  the one filled-Badge assertion (`bg-primary` → `text-bg-primary`).
- `catalog/elements/badge.md` — variants table, Bootstrap Classes list, and accessibility
  bullets updated to the derived-foreground behavior.
- `catalog/previews/badge.html` — static mock: success/warning filled swatches show the
  accessible dark foreground; added a comment flagging it as a static snapshot (live
  component canonical, `screenshots/badge.png` stale pending regeneration).
- `.claude/rules/testing.md`, `.claude/rules/frontend.md` — canonical examples updated to
  `text-bg-*`.

## Technical Approach
Bootstrap 5.3's `text-bg-{color}` utility applies `color-contrast($value)`, choosing `#000`
or `#fff` per luminance, so foreground contrast is computed from the token rather than
hand-maintained. Against MPI tokens this yields: primary/secondary/danger → white
(unchanged), warning → #000 (was `#212529`, both AA-pass), success → #000 / 6.31:1
(fixes the 3.33:1 failure). Deleting the table also removes a class of future drift where a
new token could silently reintroduce a low-contrast pairing. The utility sets `color` with
`!important` at equal specificity to `.badge`, so it reliably overrides the badge default
`--bs-badge-color: #fff`.

## Testing
- `mise exec -- bundle exec rspec` — 666 examples, 0 failures.
- `mise exec -- bundle exec rubocop -a` — 142 files, 0 offenses.
- Compile evidence (`yarn build:css`, gitignored output): `.text-bg-success{color:#000…}`,
  `.text-bg-warning{color:#000…}`, `.text-bg-primary{color:#fff…}` — proves the derived
  foregrounds the asset-free render specs can't assert directly.

## Checklist
- [x] Tests pass
- [x] Linting passes

— Claude Code (Fable 5)

https://claude.ai/code/session_018Av1ngf5yQpW25YST8QR8u
