### PR TITLE
chore(release): v0.4.1 — Admin::Badge filled-contrast fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ include breaking changes).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-16
+
+Patch release delivering the `Admin::Badge` filled-contrast fix, so consumers (Harvest —
+epic `harvest#692`) can retire the copied 3.33:1 badge instead of patching it downstream.
+Badge-fix-only — the sole change on `main` since v0.4.0.
+
+### Fixed
+- **`Admin::Badge::Component` filled variant now derives its foreground via Bootstrap's
+  `text-bg-*` utility instead of a hand-maintained `text-white`/`text-dark` table.** The
+  `:success` badge rendered white on `$mpi-success` (`#22A06B`) at **3.33:1**, failing WCAG
+  AA; it now derives `#000` at **6.31:1**. `:primary`/`:secondary`/`:danger` are unchanged
+  (white); `:warning` shifts from `#212529` to `#000` (both AA-pass) and its special-case is
+  removed. The public API (constructor, accepted colors) is unchanged, so consumers inherit
+  the fix on upgrade with no code change. (#128, #129 — harvest#692)
+
 ## [0.4.0] - 2026-07-14
 
 Tokenizes `Admin::BreadcrumbNav::Component` — the second component change driven by real

--- a/lib/mpi_design_system/version.rb
+++ b/lib/mpi_design_system/version.rb
@@ -1,3 +1,3 @@
 module MpiDesignSystem
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/spec/packaging/version_spec.rb
+++ b/spec/packaging/version_spec.rb
@@ -4,10 +4,11 @@ require "spec_helper"
 
 # Guards the released version constant. PR4 of #103 cut v0.2.0 (first adoption-ready
 # release); v0.3.0 (#121) tokenizes Admin::EmptyState; v0.4.0 (#124) tokenizes
-# Admin::BreadcrumbNav. This spec fails if the constant regresses, keeping
-# lib/mpi_design_system/version.rb in lockstep with CHANGELOG.md and the git tag.
+# Admin::BreadcrumbNav; v0.4.1 (#128) fixes Admin::Badge filled contrast. This spec
+# fails if the constant regresses, keeping lib/mpi_design_system/version.rb in lockstep
+# with CHANGELOG.md and the git tag.
 RSpec.describe "MpiDesignSystem::VERSION" do
-  it "is 0.4.0" do
-    expect(MpiDesignSystem::VERSION).to eq("0.4.0")
+  it "is 0.4.1" do
+    expect(MpiDesignSystem::VERSION).to eq("0.4.1")
   end
 end


### PR DESCRIPTION
## Summary
Patch release **v0.4.1**, cutting the merged `Admin::Badge` filled-contrast fix (#128 / #129) so consumers can adopt it via a tag. Harvest pins `tag: "v0.4.0"`, which predates the fix, so it can't consume it until this tag exists. The only change on `main` since v0.4.0 is #129, so this is a badge-fix-only patch bump.

## Changes Made
- `lib/mpi_design_system/version.rb` — `0.4.0` → `0.4.1`
- `spec/packaging/version_spec.rb` — assert `0.4.1` and extend the release-lineage comment (`changelog_spec.rb` still names 0.2.0 and stays green)
- `CHANGELOG.md` — add `## [0.4.1] - 2026-07-16` documenting the Badge `text-bg-*` contrast fix (`:success` 3.33:1 → 6.31:1, no public API change)

## Technical Approach
Follows the same release flow as v0.2.0→v0.3.0→v0.4.0: version constant bump, packaging-guard update, and a Keep-a-Changelog entry (bracketed dated header matching the v0.4.0 precedent). No code change beyond the release metadata — the fix itself already merged in #129.

## Testing
- `mise exec -- bundle exec rubocop` — 142 files, 0 offenses
- `mise exec -- bundle exec rspec` — 666 examples, 0 failures (incl. `spec/packaging/`: version guard now asserts 0.4.1, changelog guard green)

## Checklist
- [x] Tests pass
- [x] Linting passes

After merge: lightweight tag `v0.4.1` on the merge commit + push (matching prior tags — no annotated tag / GitHub Release).

— Claude Code (Fable 5)

https://claude.ai/code/session_018Av1ngf5yQpW25YST8QR8u