### PR TITLE
feat(pagination): opt-in max_links windowing for Admin::Pagination (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ include breaking changes).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-16
+
+Adds opt-in link **windowing** to `Admin::Pagination`, driven by the first real high-page-count
+adoption (Harvest's admin log/audit tables — `harvest#769`, epic `harvest#692`). The component
+previously rendered *every* page number — fine for small CRM lists, but it dumps thousands of
+links on deep tables. The default is unchanged (all pages shown), so existing consumers are
+unaffected.
+
+### Added
+- **`Admin::Pagination::Component` accepts `max_links:`** (default `nil`) — the maximum number of
+  numeric page links to show before truncating a run with a non-interactive `…` gap. Page 1 and
+  the last page are always visible; the window stays centered on the current page (values `< 5`
+  are treated as `5`, and even values round down to odd for symmetry). `nil`, `0`, or a value
+  `>= total_pages` renders every page — the prior behavior. (harvest#769, epic harvest#692)
+
+### Changed
+- **The pagination button row now wraps (`flex-wrap`)** so a windowed row degrades gracefully on
+  narrow viewports instead of forcing horizontal overflow. (harvest#769)
+
 ## [0.4.1] - 2026-07-16
 
 Patch release delivering the `Admin::Badge` filled-contrast fix, so consumers (Harvest —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@ unaffected.
 
 ### Added
 - **`Admin::Pagination::Component` accepts `max_links:`** (default `nil`) — the maximum number of
-  numeric page links to show before truncating a run with a non-interactive `…` gap. Page 1 and
-  the last page are always visible; the window stays centered on the current page (values `< 5`
-  are treated as `5`, and even values round down to odd for symmetry). `nil`, `0`, or a value
-  `>= total_pages` renders every page — the prior behavior. (harvest#769, epic harvest#692)
+  page *slots* (numeric links plus `…` gap markers) to render before the middle truncates. Page 1
+  and the last page are always visible, so e.g. 7 slots on a middle page is 5 numbers + 2 gaps;
+  the window stays centered on the current page (values `< 5`, including `0`/negative, are treated
+  as `5`, and even values round down to odd for symmetry). `nil` is the only "unlimited" value; it
+  or a value `>= total_pages` renders every page — the prior behavior. (harvest#769, epic harvest#692)
 
 ### Changed
 - **The pagination button row now wraps (`flex-wrap`)** so a windowed row degrades gracefully on

--- a/app/components/mpi_design_system/admin/pagination/component.html.erb
+++ b/app/components/mpi_design_system/admin/pagination/component.html.erb
@@ -2,7 +2,7 @@
   <div class="d-flex align-items-center justify-content-between">
     <span style="<%= results_text_styles %>"><%= results_text %></span>
 
-    <div class="d-flex align-items-center gap-1">
+    <div class="d-flex align-items-center flex-wrap gap-1">
       <% if show_prev? %>
         <a href="<%= page_url(@current_page - 1) %>"
            style="<%= page_btn_styles %>"
@@ -13,7 +13,9 @@
       <% end %>
 
       <% pages.each do |page_num| %>
-        <% if page_num == @current_page %>
+        <% if page_num == :gap %>
+          <span class="text-body-secondary" style="<%= gap_styles %>" aria-hidden="true">&hellip;</span>
+        <% elsif page_num == @current_page %>
           <span style="<%= page_btn_styles(active: true) %>" aria-current="page" aria-label="Page <%= page_num %>">
             <%= page_num %>
           </span>

--- a/app/components/mpi_design_system/admin/pagination/component.rb
+++ b/app/components/mpi_design_system/admin/pagination/component.rb
@@ -10,11 +10,13 @@ module MpiDesignSystem
         # @param per_page [Integer] Records per page (default: 25)
         # @param url_builder [Proc] Lambda that builds page URLs: ->(page) { "?page=#{page}" }
         # @param turbo_frame [String] Turbo Frame target for page loads
-        # @param max_links [Integer, nil] Max numeric page links to show before truncating
-        #   with a gap (first and last are always shown). nil (default) shows every page —
-        #   unchanged behavior for existing consumers. A value < 5 is treated as 5; even
+        # @param max_links [Integer, nil] Max page *slots* to render — numeric links and gap
+        #   (…) markers combined — before the middle is truncated. First and last page are
+        #   always shown, so e.g. 7 slots on a middle page is 5 numbers + 2 gaps. nil
+        #   (default) shows every page, the only "unlimited" value — unchanged behavior for
+        #   existing consumers. Any value < 5 (including 0 / negative) is treated as 5; even
         #   values round down to the nearest odd so the window stays symmetric around the
-        #   current page. Ignored when it is >= total_pages (all pages fit, no gap).
+        #   current page. A value >= total_pages renders all pages (they all fit, no gap).
         def initialize(current_page:, total_pages:, total_count:, per_page: 25, url_builder: nil, turbo_frame: nil, max_links: nil)
           @total_pages = [ total_pages, 1 ].max
           @current_page = [ [ current_page, 1 ].max, @total_pages ].min
@@ -92,13 +94,12 @@ module MpiDesignSystem
 
         # The ordered list of page links to render: Integers, with :gap sentinels where a
         # run of pages is truncated. First and last page are always present. Returns every
-        # page (no gaps) when max_links is nil or wide enough to fit them all.
+        # page (no gaps) when max_links is nil or wide enough to fit them all. `slots` counts
+        # total rendered entries (numbers + gaps), matching the max_links contract.
         def pages
           return (1..@total_pages).to_a if @max_links.nil?
 
           slots = @max_links.to_i
-          return (1..@total_pages).to_a if slots <= 0 || slots >= @total_pages
-
           slots = 5 if slots < 5
           slots -= 1 if slots.even?
           return (1..@total_pages).to_a if slots >= @total_pages

--- a/app/components/mpi_design_system/admin/pagination/component.rb
+++ b/app/components/mpi_design_system/admin/pagination/component.rb
@@ -10,13 +10,19 @@ module MpiDesignSystem
         # @param per_page [Integer] Records per page (default: 25)
         # @param url_builder [Proc] Lambda that builds page URLs: ->(page) { "?page=#{page}" }
         # @param turbo_frame [String] Turbo Frame target for page loads
-        def initialize(current_page:, total_pages:, total_count:, per_page: 25, url_builder: nil, turbo_frame: nil)
+        # @param max_links [Integer, nil] Max numeric page links to show before truncating
+        #   with a gap (first and last are always shown). nil (default) shows every page —
+        #   unchanged behavior for existing consumers. A value < 5 is treated as 5; even
+        #   values round down to the nearest odd so the window stays symmetric around the
+        #   current page. Ignored when it is >= total_pages (all pages fit, no gap).
+        def initialize(current_page:, total_pages:, total_count:, per_page: 25, url_builder: nil, turbo_frame: nil, max_links: nil)
           @total_pages = [ total_pages, 1 ].max
           @current_page = [ [ current_page, 1 ].max, @total_pages ].min
           @total_count = total_count
           @per_page = per_page
           @url_builder = url_builder || ->(page) { "?page=#{page}" }
           @turbo_frame = turbo_frame
+          @max_links = max_links
         end
 
         private
@@ -55,6 +61,19 @@ module MpiDesignSystem
           styles.join("; ")
         end
 
+        # Non-interactive ellipsis between truncated page runs — sized to align with the
+        # page buttons but carries no border/background (color comes from text-body-secondary).
+        def gap_styles
+          [
+            "width: 32px",
+            "height: 32px",
+            "font-size: 13px",
+            "display: inline-flex",
+            "align-items: center",
+            "justify-content: center"
+          ].join("; ")
+        end
+
         def page_url(page)
           @url_builder.call(page)
         end
@@ -71,8 +90,38 @@ module MpiDesignSystem
           @turbo_frame ? { turbo_frame: @turbo_frame } : {}
         end
 
+        # The ordered list of page links to render: Integers, with :gap sentinels where a
+        # run of pages is truncated. First and last page are always present. Returns every
+        # page (no gaps) when max_links is nil or wide enough to fit them all.
         def pages
-          (1..@total_pages).to_a
+          return (1..@total_pages).to_a if @max_links.nil?
+
+          slots = @max_links.to_i
+          return (1..@total_pages).to_a if slots <= 0 || slots >= @total_pages
+
+          slots = 5 if slots < 5
+          slots -= 1 if slots.even?
+          return (1..@total_pages).to_a if slots >= @total_pages
+
+          half  = (slots - 1) / 2
+          start = if @current_page <= half + 1
+                    1
+          elsif @current_page >= @total_pages - half
+                    @total_pages - slots + 1
+          else
+                    @current_page - half
+          end
+
+          series = (start...(start + slots)).to_a
+          if series.first != 1
+            series[0] = 1
+            series[1] = :gap unless series[1] == 2
+          end
+          if series.last != @total_pages
+            series[-1] = @total_pages
+            series[-2] = :gap unless series[-2] == @total_pages - 1
+          end
+          series
         end
       end
     end

--- a/catalog/components/pagination.md
+++ b/catalog/components/pagination.md
@@ -48,9 +48,10 @@ class MpiDesignSystem::Admin::Pagination::Component < ViewComponent::Base
   # @param per_page [Integer] Records per page (default: 25)
   # @param url_builder [Proc] Lambda that builds page URLs: ->(page) { "?page=#{page}" }
   # @param turbo_frame [String] Turbo Frame target for page loads
-  # @param max_links [Integer, nil] Max numeric page links before truncating with a
-  #   gap (…). First and last page are always shown. nil (default) shows every page
-  #   — unchanged for CRM. Set it (e.g. 7) on high-page-count lists (audit/log tables).
+  # @param max_links [Integer, nil] Max page slots (numeric links + gap markers) before
+  #   the middle truncates with a … gap. First and last page always show, so 7 slots on a
+  #   middle page is 5 numbers + 2 gaps. nil (default) shows every page — unchanged for CRM.
+  #   Set it (e.g. 7) on high-page-count lists (audit/log tables); values < 5 clamp to 5.
 end
 ```
 

--- a/catalog/components/pagination.md
+++ b/catalog/components/pagination.md
@@ -48,6 +48,9 @@ class MpiDesignSystem::Admin::Pagination::Component < ViewComponent::Base
   # @param per_page [Integer] Records per page (default: 25)
   # @param url_builder [Proc] Lambda that builds page URLs: ->(page) { "?page=#{page}" }
   # @param turbo_frame [String] Turbo Frame target for page loads
+  # @param max_links [Integer, nil] Max numeric page links before truncating with a
+  #   gap (…). First and last page are always shown. nil (default) shows every page
+  #   — unchanged for CRM. Set it (e.g. 7) on high-page-count lists (audit/log tables).
 end
 ```
 
@@ -81,7 +84,8 @@ end
 
 - **Use** below DataTable on all paginated list views
 - **Use** Turbo Frame navigation for page changes (no full page reload)
-- **Do not** show ellipsis (...) for now — show all page numbers (page counts are typically small in CRM)
+- **Default** shows all page numbers (page counts are typically small in CRM) — no ellipsis
+- **On high-page-count lists** (e.g. audit/log tables, first adopted in `harvest#769`), pass `max_links:` to window the numbers with a `…` gap; first and last page stay visible
 - **Do not** add a per-page selector unless explicitly requested
 - The results text always shows even on single-page results ("Showing 1–6 of 6 results")
 - Page buttons should be links (`<a>`) for proper URL state and back button support

--- a/lib/mpi_design_system/version.rb
+++ b/lib/mpi_design_system/version.rb
@@ -1,3 +1,3 @@
 module MpiDesignSystem
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
 end

--- a/spec/components/mpi_design_system/admin/pagination/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/pagination/component_spec.rb
@@ -99,4 +99,66 @@ RSpec.describe MpiDesignSystem::Admin::Pagination::Component, type: :component d
 
     expect(page).to have_css("a[data-turbo-frame='contacts_list']")
   end
+
+  describe "windowing (max_links)" do
+    # The ordered sequence of rendered page items: numeric page labels in document order,
+    # with :gap for each non-interactive ellipsis. Excludes the prev/next arrows (their
+    # aria-labels are "Previous page" / "Next page", not "Page N").
+    def rendered_series
+      page.all("[aria-label^='Page '], span[aria-hidden='true']").map do |el|
+        el["aria-hidden"] == "true" ? :gap : el.text.strip
+      end
+    end
+
+    it "renders every page (no gap) when max_links is nil — unchanged default" do
+      render_inline(described_class.new(current_page: 3, total_pages: 6, total_count: 150, url_builder: url_builder, max_links: nil))
+
+      expect(rendered_series).to eq(%w[1 2 3 4 5 6])
+      expect(page).not_to have_css("span[aria-hidden='true']")
+    end
+
+    it "renders every page when total_pages <= max_links" do
+      render_inline(described_class.new(current_page: 2, total_pages: 5, total_count: 120, url_builder: url_builder, max_links: 7))
+
+      expect(rendered_series).to eq(%w[1 2 3 4 5])
+      expect(page).not_to have_css("span[aria-hidden='true']")
+    end
+
+    it "windows a middle page symmetrically with gaps on both sides" do
+      render_inline(described_class.new(current_page: 20, total_pages: 47, total_count: 1175, url_builder: url_builder, max_links: 7))
+
+      expect(rendered_series).to eq([ "1", :gap, "19", "20", "21", :gap, "47" ])
+    end
+
+    it "windows a near-first page with a single trailing gap" do
+      render_inline(described_class.new(current_page: 2, total_pages: 47, total_count: 1175, url_builder: url_builder, max_links: 7))
+
+      expect(rendered_series).to eq([ "1", "2", "3", "4", "5", :gap, "47" ])
+    end
+
+    it "windows a near-last page with a single leading gap" do
+      render_inline(described_class.new(current_page: 46, total_pages: 47, total_count: 1175, url_builder: url_builder, max_links: 7))
+
+      expect(rendered_series).to eq([ "1", :gap, "43", "44", "45", "46", "47" ])
+    end
+
+    it "keeps first and last present and truncates the interior (deep-table regression guard)" do
+      render_inline(described_class.new(current_page: 20, total_pages: 47, total_count: 1175, url_builder: url_builder, max_links: 7))
+
+      expect(page).to have_css("[aria-label='Page 1']")
+      expect(page).to have_css("[aria-label='Page 47']")
+      expect(page).to have_css("span[aria-current='page']", text: "20")
+      # interior pages far from the window are NOT rendered — the whole point of windowing
+      expect(page).not_to have_css("[aria-label='Page 5']")
+      expect(page).not_to have_css("[aria-label='Page 35']")
+    end
+
+    it "renders the gap as a non-interactive ellipsis (no href)" do
+      render_inline(described_class.new(current_page: 20, total_pages: 47, total_count: 1175, url_builder: url_builder, max_links: 7))
+
+      gap = page.first("span[aria-hidden='true']")
+      expect(gap.text.strip).to eq("…")
+      expect(page).not_to have_css("a[aria-hidden='true']")
+    end
+  end
 end

--- a/spec/components/mpi_design_system/admin/pagination/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/pagination/component_spec.rb
@@ -124,6 +124,12 @@ RSpec.describe MpiDesignSystem::Admin::Pagination::Component, type: :component d
       expect(page).not_to have_css("span[aria-hidden='true']")
     end
 
+    it "clamps a below-minimum max_links (0/negative) to a five-slot window, not show-all" do
+      render_inline(described_class.new(current_page: 20, total_pages: 47, total_count: 1175, url_builder: url_builder, max_links: 0))
+
+      expect(rendered_series).to eq([ "1", :gap, "20", :gap, "47" ])
+    end
+
     it "windows a middle page symmetrically with gaps on both sides" do
       render_inline(described_class.new(current_page: 20, total_pages: 47, total_count: 1175, url_builder: url_builder, max_links: 7))
 

--- a/spec/components/previews/mpi_design_system/admin/pagination/component_preview.rb
+++ b/spec/components/previews/mpi_design_system/admin/pagination/component_preview.rb
@@ -44,4 +44,16 @@ class MpiDesignSystem::Admin::Pagination::ComponentPreview < ApplicationComponen
       url_builder: ->(page) { "?page=#{page}" }
     )
   end
+
+  # @label Windowed (many pages)
+  def windowed
+    render MpiDesignSystem::Admin::Pagination::Component.new(
+      current_page: 20,
+      total_pages: 47,
+      total_count: 1175,
+      per_page: 25,
+      url_builder: ->(page) { "?page=#{page}" },
+      max_links: 7
+    )
+  end
 end

--- a/spec/packaging/version_spec.rb
+++ b/spec/packaging/version_spec.rb
@@ -4,11 +4,12 @@ require "spec_helper"
 
 # Guards the released version constant. PR4 of #103 cut v0.2.0 (first adoption-ready
 # release); v0.3.0 (#121) tokenizes Admin::EmptyState; v0.4.0 (#124) tokenizes
-# Admin::BreadcrumbNav; v0.4.1 (#128) fixes Admin::Badge filled contrast. This spec
-# fails if the constant regresses, keeping lib/mpi_design_system/version.rb in lockstep
-# with CHANGELOG.md and the git tag.
+# Admin::BreadcrumbNav; v0.4.1 (#128) fixes Admin::Badge filled contrast; v0.5.0 adds
+# opt-in Admin::Pagination link windowing (harvest#769). This spec fails if the constant
+# regresses, keeping lib/mpi_design_system/version.rb in lockstep with CHANGELOG.md and
+# the git tag.
 RSpec.describe "MpiDesignSystem::VERSION" do
-  it "is 0.4.1" do
-    expect(MpiDesignSystem::VERSION).to eq("0.4.1")
+  it "is 0.5.0" do
+    expect(MpiDesignSystem::VERSION).to eq("0.5.0")
   end
 end


### PR DESCRIPTION
## What & why

Adds **opt-in link windowing** to `Admin::Pagination`, driven by the first real high-page-count adoption: Harvest's admin log/audit tables (`harvest#769`, epic `harvest#692`). The component previously rendered **every** page number — fine for small CRM lists, but it dumps thousands of `<a>` links on deep tables (Harvest's `data_logs` / `inbound_request_logs`).

## Change

- **`max_links:` (default `nil`)** — max numeric page links before truncating a run with a non-interactive `…` gap. Page 1 and the last page are always shown; the window stays centered on the current page (values `< 5` → `5`; even → nearest odd for symmetry). `nil` / `0` / `>= total_pages` renders every page — **unchanged behavior for existing consumers** (no CRM break).
- **`flex-wrap`** on the button row so a windowed row degrades gracefully on narrow viewports instead of forcing horizontal scroll.
- **Release v0.5.0** bundled in (`version.rb`, `CHANGELOG`, `spec/packaging/version_spec`) so the tag can be cut on merge — combined with the feature for expediency this round.

## Windowing contract (exact sequences, `max_links: 7`, `total_pages: 47`)

| current | rendered |
|---|---|
| near-first (2) | `1 2 3 4 5 … 47` |
| middle (20) | `1 … 19 20 21 … 47` |
| near-last (46) | `1 … 43 44 45 46 47` |

## Tests

- Extended `pagination/component_spec.rb`: exact windowed sequences at near-first / middle / near-last; `total_pages ≤ max_links` and `max_links: nil` both render all pages (regression pins for existing consumers); `:gap` is non-interactive; deep-table truncation guard.
- **Mutation-proved** the window guard: restoring the exhaustive `(1..total_pages)` implementation turns 5 of the 7 new specs red for the right reason.
- Added a `Windowed (many pages)` Lookbook preview (exercised by the preview-render sweep).
- Full suite green (`674 examples, 0 failures`); RuboCop clean.

## Consumer

Harvest PR (pin bump `v0.4.1 → v0.5.0` + `IndexPager` adoption passing `max_links: 7`) follows once this is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UC1fF2ZVraDDRnubR9suU
