### PR TITLE
feat(table-for-index): shared block-based Admin::TableForIndex with batch selection + Ransack-free sortable headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ include breaking changes).
 
 ## [Unreleased]
 
+### Added
+- **`Admin::TableForIndex::Component` + `Admin::TableForIndexColumn::Component`** — a neutral,
+  slot/block-based admin index & association listing table, generalizing the byte-identical
+  local `Admin::TableForIndex` shared by the MPI apps (Optimus/Garden/Harvest) into the design
+  system (harvest#692). The block column form — `table.with_column(header) { |record| … }` — is
+  the default escape hatch, so cells can be arbitrary host HTML (links, `mail_to`, action
+  buttons, badges) and the gem takes **no** Ransack/Pundit/Pagy/route-helper dependency. Headers
+  accept a plain string or pre-rendered HTML (e.g. a Ransack `sort_link`) verbatim. Opt-in,
+  presentation-only column keywords layer on top — `align:`/`nowrap:`/`width:` (whitelisted
+  Bootstrap utilities) and `cell: :text|:boolean|:date` (`:boolean` renders the filled `Badge`).
+  Empty collections render the shipped `EmptyState` with a title-derived heading and a
+  monotonic heading level (`:h5` under a `title:` section, `:h3` for a bare index). Styled with
+  Bootstrap utilities only — no inline hex.
+- **First-class sortable headers (Ransack-free)** — a column opts in with `sortable:`/`sort_key:`,
+  and the table renders the clickable header, caret, and `aria-sort` from a host-supplied
+  `sort_url: ->(key, dir) { … }` lambda plus `current_sort_key:`/`current_sort_dir:`. The gem
+  never imports a sort backend. A pre-rendered `sort_link` passed as the header still works, so
+  consumers adopt mechanically first and opt into first-class sorting later.
+- **Batch selection** — opt-in via `batch:` (checkbox toggle + per-row `ids[]` column) plus the
+  `Admin::BatchActionButton` / `Admin::BatchActionModalButton` slot components, driven by a new
+  `mpi--batch-actions` Stimulus controller (generalized from SFA's working implementation) that
+  `registerMpiControllers` registers. The consuming app owns the `<form>` (submit URL + route +
+  authorization); the gem owns the checkbox UI, the button/modal slots, and the controller
+  behavior. (harvest#692, folds in harvest#768's dead-code cleanup on the consumer side.)
+
 ## [0.5.0] - 2026-07-16
 
 Adds opt-in link **windowing** to `Admin::Pagination`, driven by the first real high-page-count

--- a/app/components/mpi_design_system/admin/batch_action_button/component.html.erb
+++ b/app/components/mpi_design_system/admin/batch_action_button/component.html.erb
@@ -1,0 +1,4 @@
+<button class="btn btn-primary" type="submit" name="<%= @action %>"
+        data-mpi--batch-actions-target="actionButton">
+  <%= @label %>
+</button>

--- a/app/components/mpi_design_system/admin/batch_action_button/component.html.erb
+++ b/app/components/mpi_design_system/admin/batch_action_button/component.html.erb
@@ -1,4 +1,7 @@
-<button class="btn btn-primary" type="submit" name="<%= @action %>"
+<%# Disabled by default (fail-safe): the mpi--batch-actions controller enables it once a row
+    is selected. If the JS is absent or late, the button stays disabled rather than submitting
+    the form with no ids[]. %>
+<button class="btn btn-primary" type="submit" name="<%= @action %>" disabled
         data-mpi--batch-actions-target="actionButton">
   <%= @label %>
 </button>

--- a/app/components/mpi_design_system/admin/batch_action_button/component.rb
+++ b/app/components/mpi_design_system/admin/batch_action_button/component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module MpiDesignSystem
+  module Admin
+    module BatchActionButton
+      # A direct-submit batch action button for MpiDesignSystem::Admin::TableForIndex.
+      #
+      # Rendered inside the table's batch_action_buttons slot. The consuming app wraps the
+      # table in a <form> (data-controller="mpi--batch-actions"); this button submits that
+      # form with the selected ids[]. The +action+ becomes the submit button's +name+, so the
+      # app controller dispatches on its presence (params.key?("archive")).
+      class Component < ViewComponent::Base
+        # @param action [String, Symbol] submit button name — the app controller keys on it.
+        # @param label [String] visible button text.
+        def initialize(action, label:)
+          @action = action
+          @label = label
+        end
+      end
+    end
+  end
+end

--- a/app/components/mpi_design_system/admin/batch_action_modal_button/component.html.erb
+++ b/app/components/mpi_design_system/admin/batch_action_modal_button/component.html.erb
@@ -1,14 +1,14 @@
-<button class="btn btn-primary" type="button" name="<%= @action %>"
+<button class="btn btn-primary" type="button" name="<%= @action %>" disabled
         data-mpi--batch-actions-target="actionButton"
-        data-bs-toggle="modal" data-bs-target="#modal_<%= @action %>">
+        data-bs-toggle="modal" data-bs-target="#<%= @modal_id %>">
   <%= @label %>
 </button>
 
-<div id="modal_<%= @action %>" class="modal fade" tabindex="-1">
+<div id="<%= @modal_id %>" class="modal fade" tabindex="-1" aria-labelledby="<%= @title_id %>" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header text-bg-primary" data-bs-theme="dark">
-        <h5 class="modal-title"><%= @label %></h5>
+        <h5 class="modal-title" id="<%= @title_id %>"><%= @label %></h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">

--- a/app/components/mpi_design_system/admin/batch_action_modal_button/component.html.erb
+++ b/app/components/mpi_design_system/admin/batch_action_modal_button/component.html.erb
@@ -1,0 +1,23 @@
+<button class="btn btn-primary" type="button" name="<%= @action %>"
+        data-mpi--batch-actions-target="actionButton"
+        data-bs-toggle="modal" data-bs-target="#modal_<%= @action %>">
+  <%= @label %>
+</button>
+
+<div id="modal_<%= @action %>" class="modal fade" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header text-bg-primary" data-bs-theme="dark">
+        <h5 class="modal-title"><%= @label %></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <%= content %>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <button type="submit" name="<%= @action %>" class="btn btn-primary"><%= @label %></button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/mpi_design_system/admin/batch_action_modal_button/component.rb
+++ b/app/components/mpi_design_system/admin/batch_action_modal_button/component.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module MpiDesignSystem
+  module Admin
+    module BatchActionModalButton
+      # A modal-gated batch action button for MpiDesignSystem::Admin::TableForIndex.
+      #
+      # Rendered inside the table's batch_action_modal_buttons slot. The trigger opens a
+      # Bootstrap modal whose body is the component's content slot (extra fields the operator
+      # fills in); the modal footer's submit button carries the same +action+ name and posts
+      # the wrapping app <form> with the selected ids[]. Modals are not reparented in Bootstrap
+      # 5, so the submit stays inside the app form.
+      class Component < ViewComponent::Base
+        # @param action [String, Symbol] submit button name — the app controller keys on it.
+        # @param label [String] visible trigger + modal title + submit text.
+        def initialize(action, label:)
+          @action = action
+          @label = label
+        end
+      end
+    end
+  end
+end

--- a/app/components/mpi_design_system/admin/batch_action_modal_button/component.rb
+++ b/app/components/mpi_design_system/admin/batch_action_modal_button/component.rb
@@ -16,6 +16,10 @@ module MpiDesignSystem
         def initialize(action, label:)
           @action = action
           @label = label
+          # Unique per instance so two tables exposing the same action on one page don't
+          # collide, and so the dialog gets an accessible name via aria-labelledby.
+          @modal_id = "mpi-batch-modal-#{action}-#{SecureRandom.hex(4)}"
+          @title_id = "#{@modal_id}-title"
         end
       end
     end

--- a/app/components/mpi_design_system/admin/table_for_index/component.html.erb
+++ b/app/components/mpi_design_system/admin/table_for_index/component.html.erb
@@ -1,0 +1,75 @@
+<%# Batch toolbar — only when a batch-action slot is filled AND there are rows to act on.
+    Uses the slot? predicate, never a bare `||`: renders_many returns [] (truthy), so a bare
+    guard renders an empty band on every table (harvest#765). %>
+<% if rows.any? && (batch_action_buttons? || batch_action_modal_buttons?) %>
+  <section class="batch-actions pb-3 d-flex flex-row gap-3">
+    <% batch_action_buttons.each do |button| %><%= button %><% end %>
+    <% batch_action_modal_buttons.each do |button| %><%= button %><% end %>
+  </section>
+<% end %>
+
+<section>
+  <% if @title %>
+    <h4 class="title-header"><%= @title %></h4>
+  <% end %>
+
+  <% if rows.any? %>
+    <table class="table table-striped table-hover table-sm">
+      <thead class="table-dark">
+        <tr>
+          <% if @batch %>
+            <th>
+              <input type="checkbox" name="toggle"
+                     data-mpi--batch-actions-target="toggleCheckbox"
+                     data-action="change->mpi--batch-actions#toggleCheckboxes">
+            </th>
+          <% end %>
+
+          <% columns.each do |column| %>
+            <% if sortable?(column) %>
+              <th class="<%= column.th_classes %>" aria-sort="<%= aria_sort(column) %>">
+                <a href="<%= sort_href(column) %>" class="link-light text-decoration-none">
+                  <%= column.header %><span aria-hidden="true"> <%= sort_glyph(column) %></span>
+                </a>
+              </th>
+            <% else %>
+              <th class="<%= column.th_classes %>"><%= column.header %></th>
+            <% end %>
+          <% end %>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% rows.each do |record| %>
+          <tr>
+            <% if @batch %>
+              <td>
+                <input type="checkbox" name="ids[]" value="<%= record.id %>"
+                       data-mpi--batch-actions-target="checkbox"
+                       data-action="change->mpi--batch-actions#checkCheckboxes">
+              </td>
+            <% end %>
+
+            <% columns.each do |column| %>
+              <td class="<%= column.td_classes %>">
+                <% if column.block? %>
+                  <%= capture(record, &column.td_block) %>
+                <% elsif column.cell_type == :boolean %>
+                  <%= render boolean_badge(column.value_for(record)) %>
+                <% elsif column.cell_type == :date %>
+                  <%= column.formatted_date(record) %>
+                <% else %>
+                  <%= column.value_for(record) %>
+                <% end %>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <%= render MpiDesignSystem::Admin::EmptyState::Component.new(
+      heading: empty_heading, icon: @empty_icon, heading_level: empty_heading_level
+    ) %>
+  <% end %>
+</section>

--- a/app/components/mpi_design_system/admin/table_for_index/component.html.erb
+++ b/app/components/mpi_design_system/admin/table_for_index/component.html.erb
@@ -18,8 +18,8 @@
       <thead class="table-dark">
         <tr>
           <% if @batch %>
-            <th>
-              <input type="checkbox" name="toggle"
+            <th scope="col">
+              <input type="checkbox" name="toggle" aria-label="Select all rows"
                      data-mpi--batch-actions-target="toggleCheckbox"
                      data-action="change->mpi--batch-actions#toggleCheckboxes">
             </th>
@@ -27,13 +27,13 @@
 
           <% columns.each do |column| %>
             <% if sortable?(column) %>
-              <th class="<%= column.th_classes %>" aria-sort="<%= aria_sort(column) %>">
+              <th scope="col" class="<%= column.th_classes %>" aria-sort="<%= aria_sort(column) %>">
                 <a href="<%= sort_href(column) %>" class="link-light text-decoration-none">
                   <%= column.header %><span aria-hidden="true"> <%= sort_glyph(column) %></span>
                 </a>
               </th>
             <% else %>
-              <th class="<%= column.th_classes %>"><%= column.header %></th>
+              <th scope="col" class="<%= column.th_classes %>"><%= column.header %></th>
             <% end %>
           <% end %>
         </tr>
@@ -45,6 +45,7 @@
             <% if @batch %>
               <td>
                 <input type="checkbox" name="ids[]" value="<%= record.id %>"
+                       aria-label="<%= batch_row_label(record) %>"
                        data-mpi--batch-actions-target="checkbox"
                        data-action="change->mpi--batch-actions#checkCheckboxes">
               </td>

--- a/app/components/mpi_design_system/admin/table_for_index/component.rb
+++ b/app/components/mpi_design_system/admin/table_for_index/component.rb
@@ -27,16 +27,19 @@ module MpiDesignSystem
         #   heading text and keeps the outline monotonic (:h5 under a title, :h3 for a bare index).
         # @param batch [Boolean] opt-in checkbox-selection column. Requires an app-supplied <form>
         #   carrying data-controller="mpi--batch-actions".
+        # @param batch_row_label [Proc, nil] ->(record) { accessible name } for each row's select
+        #   checkbox. Defaults to "Select row #{record.id}" — pass a proc for a meaningful name.
         # @param empty_heading [String, nil] override the derived empty-state heading.
         # @param empty_icon [String] Bootstrap icon for the empty state.
         # @param sort_url [Proc, nil] ->(key, dir) { host-built href } for first-class sortable columns.
         # @param current_sort_key [Symbol, String, nil] the currently-sorted key.
         # @param current_sort_dir [Symbol] :asc (default) or :desc.
-        def initialize(data:, title: nil, batch: false, empty_heading: nil, empty_icon: "bi-inbox",
-                       sort_url: nil, current_sort_key: nil, current_sort_dir: :asc)
+        def initialize(data:, title: nil, batch: false, batch_row_label: nil, empty_heading: nil,
+                       empty_icon: "bi-inbox", sort_url: nil, current_sort_key: nil, current_sort_dir: :asc)
           @data = data
           @title = title
           @batch = batch
+          @batch_row_label = batch_row_label
           @empty_heading = empty_heading
           @empty_icon = empty_icon
           @sort_url = sort_url
@@ -86,6 +89,12 @@ module MpiDesignSystem
           return "↕" unless current?(column) # ↕ inactive
 
           @current_sort_dir == :asc ? "↑" : "↓" # ↑ / ↓
+        end
+
+        def batch_row_label(record)
+          return @batch_row_label.call(record) if @batch_row_label
+
+          "Select row #{record.id}"
         end
 
         def boolean_badge(value)

--- a/app/components/mpi_design_system/admin/table_for_index/component.rb
+++ b/app/components/mpi_design_system/admin/table_for_index/component.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module MpiDesignSystem
+  module Admin
+    module TableForIndex
+      # Neutral, slot/block-based admin index & association listing table.
+      #
+      # Generalizes the byte-identical local Admin::TableForIndex shared by the MPI apps
+      # (Optimus/Garden/Harvest) into the design system. The block column form is the default
+      # escape hatch — a column's cell is arbitrary host HTML (links, mail_to, action buttons,
+      # badges), so the gem takes no Ransack/Pundit/Pagy/route-helper dependency. Opt-in
+      # presentation keywords and first-class sortable headers layer on top; see
+      # TableForIndexColumn::Component.
+      #
+      # Batch selection is opt-in via +batch:+ and the batch-action slots. The consuming app
+      # owns the surrounding <form> (submit URL + route + authorization) and the gem ships the
+      # +mpi--batch-actions+ Stimulus controller that drives the checkboxes/buttons.
+      class Component < ViewComponent::Base
+        renders_many :columns, lambda { |header = nil, **options, &block|
+          MpiDesignSystem::Admin::TableForIndexColumn::Component.new(header, **options, &block)
+        }
+        renders_many :batch_action_buttons, MpiDesignSystem::Admin::BatchActionButton::Component
+        renders_many :batch_action_modal_buttons, MpiDesignSystem::Admin::BatchActionModalButton::Component
+
+        # @param data [Enumerable] rows to render (an ActiveRecord relation or array).
+        # @param title [String, nil] optional section heading (<h4>); also drives the empty-state
+        #   heading text and keeps the outline monotonic (:h5 under a title, :h3 for a bare index).
+        # @param batch [Boolean] opt-in checkbox-selection column. Requires an app-supplied <form>
+        #   carrying data-controller="mpi--batch-actions".
+        # @param empty_heading [String, nil] override the derived empty-state heading.
+        # @param empty_icon [String] Bootstrap icon for the empty state.
+        # @param sort_url [Proc, nil] ->(key, dir) { host-built href } for first-class sortable columns.
+        # @param current_sort_key [Symbol, String, nil] the currently-sorted key.
+        # @param current_sort_dir [Symbol] :asc (default) or :desc.
+        def initialize(data:, title: nil, batch: false, empty_heading: nil, empty_icon: "bi-inbox",
+                       sort_url: nil, current_sort_key: nil, current_sort_dir: :asc)
+          @data = data
+          @title = title
+          @batch = batch
+          @empty_heading = empty_heading
+          @empty_icon = empty_icon
+          @sort_url = sort_url
+          @current_sort_key = current_sort_key
+          @current_sort_dir = current_sort_dir&.to_sym == :desc ? :desc : :asc
+        end
+
+        private
+
+        def rows
+          @rows ||= @data.to_a
+        end
+
+        def empty_heading
+          @empty_heading.presence || (@title.present? ? "No #{@title.downcase} found" : "No records found")
+        end
+
+        def empty_heading_level
+          @title.present? ? :h5 : :h3
+        end
+
+        # First-class sortable-header resolution — Ransack-free: the host supplies sort_url and
+        # the current sort state; the gem only renders the link, caret, and aria-sort.
+        def sortable?(column)
+          column.sortable? && column.sort_key.present? && @sort_url.present?
+        end
+
+        def current?(column)
+          @current_sort_key.present? && @current_sort_key.to_s == column.sort_key.to_s
+        end
+
+        def next_dir(column)
+          current?(column) && @current_sort_dir == :asc ? :desc : :asc
+        end
+
+        def sort_href(column)
+          @sort_url.call(column.sort_key, next_dir(column))
+        end
+
+        def aria_sort(column)
+          return "none" unless current?(column)
+
+          @current_sort_dir == :asc ? "ascending" : "descending"
+        end
+
+        def sort_glyph(column)
+          return "↕" unless current?(column) # ↕ inactive
+
+          @current_sort_dir == :asc ? "↑" : "↓" # ↑ / ↓
+        end
+
+        def boolean_badge(value)
+          MpiDesignSystem::Admin::Badge::Component.new(
+            label: value ? "Yes" : "No",
+            color: value ? :success : :secondary,
+            variant: :filled
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/components/mpi_design_system/admin/table_for_index_column/component.rb
+++ b/app/components/mpi_design_system/admin/table_for_index_column/component.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module MpiDesignSystem
+  module Admin
+    module TableForIndexColumn
+      # A single column of MpiDesignSystem::Admin::TableForIndex.
+      #
+      # This is a slot data-holder, not a rendered component: the parent table reads
+      # +header+, the presentation options, and either the captured +td_block+ or the
+      # +value+ extractor to build each <th>/<td>. It is never rendered on its own (the
+      # +call+ below only exists so the class compiles without a template).
+      #
+      # Two coexisting cell forms:
+      #   (a) block  — table.with_column(header) { |record| arbitrary_html }
+      #   (b) helper — table.with_column(header, value: :name, cell: :text)
+      #
+      # Presentation options are pure Bootstrap utilities (no inline styles): +align+,
+      # +nowrap+, +width+. +cell+ selects a lightweight renderer (:text/:boolean/:date).
+      # +sortable+/+sort_key+ opt a column into the table's Ransack-free sortable headers.
+      class Component < ViewComponent::Base
+        ALIGNMENTS = { start: "text-start", center: "text-center", end: "text-end" }.freeze
+        WIDTHS = { sm: "w-25", md: "w-50", lg: "w-75" }.freeze
+        CELL_TYPES = %i[text boolean date].freeze
+
+        attr_reader :header, :td_block
+
+        # @param header [String, ActiveSupport::SafeBuffer, nil] Header content — a plain
+        #   string (escaped) or pre-rendered HTML such as a Ransack sort_link (emitted verbatim).
+        #   Also the visible label for a first-class sortable column.
+        # @param value [Symbol, Proc, nil] Helper-form cell extractor (method name or callable).
+        #   Ignored when a block is given.
+        # @param cell [Symbol] :text (default), :boolean (renders a filled Badge), :date.
+        # @param align [Symbol, nil] :start, :center, :end — Bootstrap alignment on <th> and <td>.
+        # @param nowrap [Boolean] adds text-nowrap.
+        # @param width [Symbol, nil] :sm, :md, :lg — whitelisted Bootstrap width utility.
+        # @param sortable [Boolean] opt into first-class sortable headers (needs the table's sort_url + sort_key).
+        # @param sort_key [Symbol, String, nil] the sort param key for this column.
+        def initialize(header = nil, value: nil, cell: :text, align: nil, nowrap: false,
+                       width: nil, sortable: false, sort_key: nil, &block)
+          @header = header
+          @value = value
+          @cell = CELL_TYPES.include?(cell) ? cell : :text
+          @align = align
+          @nowrap = nowrap
+          @width = width
+          @sortable = sortable
+          @sort_key = sort_key
+          @td_block = block
+        end
+
+        # Never rendered as a component — the parent table reads this column's attributes.
+        # Present only so the class compiles without a template.
+        def call
+          ""
+        end
+
+        def block?
+          @td_block.present?
+        end
+
+        def cell_type
+          @cell
+        end
+
+        def sortable?
+          @sortable
+        end
+
+        def sort_key
+          @sort_key
+        end
+
+        def th_classes
+          utility_classes.presence
+        end
+
+        def td_classes
+          classes = []
+          classes << ALIGNMENTS[@align] if @align && ALIGNMENTS.key?(@align)
+          classes << "text-nowrap" if @nowrap
+          classes.join(" ").presence
+        end
+
+        # Extract the cell value for +record+ in the helper form (nil in the block form).
+        def value_for(record)
+          case @value
+          when Symbol then record.public_send(@value)
+          when Proc   then @value.call(record)
+          end
+        end
+
+        # Render a :date cell — accepts an already-formatted string, or formats via to_fs(:long).
+        def formatted_date(record)
+          raw = value_for(record)
+          return if raw.nil?
+
+          raw.respond_to?(:to_fs) ? raw.to_fs(:long) : raw.to_s
+        end
+
+        private
+
+        def utility_classes
+          classes = []
+          classes << ALIGNMENTS[@align] if @align && ALIGNMENTS.key?(@align)
+          classes << "text-nowrap" if @nowrap
+          classes << WIDTHS[@width] if @width && WIDTHS.key?(@width)
+          classes.join(" ")
+        end
+      end
+    end
+  end
+end

--- a/app/javascript/mpi_design_system/controllers/batch_actions_controller.js
+++ b/app/javascript/mpi_design_system/controllers/batch_actions_controller.js
@@ -1,0 +1,57 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="mpi--batch-actions"
+//
+// Drives batch selection for MpiDesignSystem::Admin::TableForIndex: a toggle-all header
+// checkbox, per-row checkboxes, and action buttons that enable only when a row is selected.
+// Behavior-only — it flips `checked`/`disabled`, sets no styles. Generalized from SFA's
+// working admin--batch-actions controller (the one proven live in the MPI apps).
+export default class extends Controller {
+  static targets = ["checkbox", "toggleCheckbox", "actionButton"]
+
+  connect() {
+    this.checkCheckboxes()
+  }
+
+  toggleCheckboxes(event) {
+    if (event.target.checked) {
+      this._updateAllCheckboxes(true)
+      this._enableActionButtons()
+    } else {
+      this._updateAllCheckboxes(false)
+      this._disableActionButtons()
+    }
+  }
+
+  checkCheckboxes() {
+    this.toggleCheckboxTarget.checked = false
+
+    if (this.checkboxTargets.some((checkbox) => checkbox.checked)) {
+      this._enableActionButtons()
+
+      if (this.checkboxTargets.every((checkbox) => checkbox.checked)) {
+        this.toggleCheckboxTarget.checked = true
+      }
+    } else {
+      this._disableActionButtons()
+    }
+  }
+
+  _updateAllCheckboxes(checked) {
+    this.checkboxTargets.forEach((checkbox) => {
+      checkbox.checked = checked
+    })
+  }
+
+  _enableActionButtons() {
+    this.actionButtonTargets.forEach((button) => {
+      button.disabled = false
+    })
+  }
+
+  _disableActionButtons() {
+    this.actionButtonTargets.forEach((button) => {
+      button.disabled = true
+    })
+  }
+}

--- a/app/javascript/mpi_design_system/controllers/index.js
+++ b/app/javascript/mpi_design_system/controllers/index.js
@@ -1,7 +1,9 @@
 import TagInputController from "./tag_input_controller"
+import BatchActionsController from "./batch_actions_controller"
 
 export function registerMpiControllers(application) {
   application.register("mpi--tag-input", TagInputController)
+  application.register("mpi--batch-actions", BatchActionsController)
 }
 
-export { TagInputController }
+export { TagInputController, BatchActionsController }

--- a/app/javascript/mpi_design_system/index.js
+++ b/app/javascript/mpi_design_system/index.js
@@ -1,1 +1,1 @@
-export { registerMpiControllers, TagInputController } from "./controllers"
+export { registerMpiControllers, TagInputController, BatchActionsController } from "./controllers"

--- a/catalog/components/table-for-index.md
+++ b/catalog/components/table-for-index.md
@@ -1,0 +1,89 @@
+# TableForIndex
+
+**Category:** Component
+**Issue:** harvest#692 (shared-engine adoption epic)
+**Status:** Approved
+
+## Description
+
+Neutral, slot/block-based admin **index & association listing** table. Generalizes the
+byte-identical local `Admin::TableForIndex` shared by the MPI apps (Optimus/Garden/Harvest) into
+the design system, so all consumers share one table primitive instead of drifting copies.
+
+This is deliberately **not** `DataTable` — `DataTable` is a fixed-schema CRM component (contacts /
+search results, `:name`/`:tags`/`:account`/`:status`). `TableForIndex` hosts arbitrary admin
+listings: each cell is host-supplied HTML, so the gem takes **no** Ransack/Pundit/Pagy/route-helper
+dependency.
+
+## Design Decisions
+
+- **Block-first cells:** `table.with_column(header) { |record| … }` — the block returns arbitrary
+  `SafeBuffer` HTML (links, `mail_to`, action buttons, badges, multi-value). This is the default
+  and covers everything app-coupled.
+- **Opt-in helper cells:** `table.with_column(header, value:, cell: :text|:boolean|:date)` for pure
+  presentation. `:boolean` renders the filled `Badge` (`text-bg-success`/`text-bg-secondary`).
+- **Presentation-only column keywords:** `align:` (`:start`/`:center`/`:end`), `nowrap:`, `width:`
+  (`:sm`/`:md`/`:lg`, whitelisted → `w-25`/`w-50`/`w-75`). All pure Bootstrap utilities — **no
+  inline hex, no `[style]`**.
+- **Headers:** a plain string (escaped) or pre-rendered HTML (e.g. a Ransack `sort_link`) emitted
+  verbatim.
+- **First-class sortable headers (Ransack-free):** a column opts in with `sortable:`/`sort_key:`;
+  the table renders the clickable link, caret, and `aria-sort` from a host-supplied
+  `sort_url: ->(key, dir) { … }` lambda + `current_sort_key:`/`current_sort_dir:`.
+- **Empty state:** renders the shipped `EmptyState` with a title-derived heading and a monotonic
+  heading level (`:h5` under a `title:` section, `:h3` for a bare index).
+- **Batch selection:** opt-in `batch:` checkbox column + `BatchActionButton`/`BatchActionModalButton`
+  slots, driven by the `mpi--batch-actions` Stimulus controller. The consuming app owns the
+  `<form>`; the gem owns the checkbox UI, the slots, and the controller.
+- **Table shell:** `table table-striped table-hover table-sm` + `thead.table-dark` — preserved from
+  the apps so adoption is visually identical.
+
+## States
+
+| State | Description |
+|---|---|
+| Populated | Striped, hoverable rows; optional batch checkbox column |
+| Empty | Renders `EmptyState` (no table, no batch toolbar) |
+| Sortable header (active) | Clickable link with ↑/↓ caret and `aria-sort` |
+| Sortable header (inactive) | Clickable link with ↕ caret, `aria-sort="none"` |
+
+## Props / API
+
+```ruby
+# MpiDesignSystem::Admin::TableForIndex::Component
+class MpiDesignSystem::Admin::TableForIndex::Component < ViewComponent::Base
+  renders_many :columns              # via with_column(header, **opts, &block)
+  renders_many :batch_action_buttons        # BatchActionButton::Component
+  renders_many :batch_action_modal_buttons  # BatchActionModalButton::Component
+
+  # @param data [Enumerable] rows (AR relation or array)
+  # @param title [String, nil] section heading (<h4>) + drives empty-state heading/level
+  # @param batch [Boolean] opt-in checkbox-selection column (needs an app <form> + mpi--batch-actions)
+  # @param empty_heading [String, nil] override the derived empty-state heading
+  # @param empty_icon [String] Bootstrap icon for the empty state (default "bi-inbox")
+  # @param sort_url [Proc, nil] ->(key, dir) { host-built href } for first-class sortable columns
+  # @param current_sort_key [Symbol, String, nil] the currently-sorted key
+  # @param current_sort_dir [Symbol] :asc (default) or :desc
+end
+
+# MpiDesignSystem::Admin::TableForIndexColumn::Component
+#   initialize(header = nil, value: nil, cell: :text, align: nil, nowrap: false,
+#              width: nil, sortable: false, sort_key: nil, &block)
+```
+
+## Batch Contract
+
+The gem renders the checkbox UI, the button/modal slots, and ships the `mpi--batch-actions`
+Stimulus controller (registered by `registerMpiControllers`). The **consuming app** wraps the table
+in a `<form>` (submit URL + `data-controller="mpi--batch-actions"`), owns the route, and reads
+`params[:ids]` dispatching on the submit button's `name`, with its own authorization. Batch is inert
+until a consumer wires the gem's JS substrate (esbuild alias + `registerMpiControllers`).
+
+## Usage Guidelines
+
+- **Use** for admin index tables and show-page association tables.
+- **Use** the block form for any cell that needs a link, a policy-gated action button, or
+  conditional/multi-value markup.
+- **Do not** reach for `DataTable` for admin listings — that is the CRM contacts/search component.
+- **Do not** add inline hex or custom classes — Bootstrap utilities only.
+- Combine with `Pagination` below and a filter form above (both app-owned).

--- a/spec/components/mpi_design_system/admin/batch_action_button/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/batch_action_button/component_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe MpiDesignSystem::Admin::BatchActionButton::Component, type: :component do
+  it "renders a submit button whose name is the action and text is the label" do
+    render_inline(described_class.new(:archive, label: "Archive selected"))
+
+    expect(page).to have_css("button[type='submit'][name='archive']", text: "Archive selected")
+  end
+
+  it "wires the action-button Stimulus target" do
+    render_inline(described_class.new(:archive, label: "Archive selected"))
+
+    expect(page).to have_css("button[data-mpi--batch-actions-target='actionButton']")
+  end
+end

--- a/spec/components/mpi_design_system/admin/batch_action_button/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/batch_action_button/component_spec.rb
@@ -14,4 +14,10 @@ RSpec.describe MpiDesignSystem::Admin::BatchActionButton::Component, type: :comp
 
     expect(page).to have_css("button[data-mpi--batch-actions-target='actionButton']")
   end
+
+  it "is disabled by default (fail-safe; the controller enables it on selection)" do
+    render_inline(described_class.new(:archive, label: "Archive selected"))
+
+    expect(page).to have_css("button[type='submit'][disabled]")
+  end
 end

--- a/spec/components/mpi_design_system/admin/batch_action_modal_button/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/batch_action_modal_button/component_spec.rb
@@ -3,17 +3,43 @@
 require "spec_helper"
 
 RSpec.describe MpiDesignSystem::Admin::BatchActionModalButton::Component, type: :component do
-  it "renders a trigger button targeting its modal" do
+  it "renders a trigger whose data-bs-target matches its own modal id" do
     render_inline(described_class.new(:assign, label: "Assign")) { "Body fields" }
 
-    expect(page).to have_css("button[type='button'][data-bs-toggle='modal'][data-bs-target='#modal_assign']", text: "Assign")
-    expect(page).to have_css("button[data-mpi--batch-actions-target='actionButton']")
+    trigger = page.find("button[type='button'][data-bs-toggle='modal']")
+    modal_id = trigger["data-bs-target"].delete_prefix("#")
+
+    expect(modal_id).to be_present
+    expect(page).to have_css("##{modal_id}.modal.fade")
+    expect(page).to have_css("button[data-mpi--batch-actions-target='actionButton']", text: "Assign")
   end
 
-  it "renders a Bootstrap 5 modal (modal fade, not the legacy 'hide') with a text-bg-primary header" do
+  it "gives the dialog an accessible name via aria-labelledby -> the modal-title id" do
     render_inline(described_class.new(:assign, label: "Assign")) { "Body fields" }
 
-    expect(page).to have_css("#modal_assign.modal.fade")
+    modal = page.find(".modal")
+    title_id = modal["aria-labelledby"]
+
+    expect(title_id).to be_present
+    expect(page).to have_css("h5.modal-title##{title_id}", text: "Assign")
+  end
+
+  it "generates a unique modal id per instance so two tables can expose the same action" do
+    render_inline(described_class.new(:assign, label: "Assign")) { "A" }
+    first_id = page.find(".modal")["id"]
+
+    render_inline(described_class.new(:assign, label: "Assign")) { "B" }
+    second_id = page.find(".modal")["id"]
+
+    expect(first_id).to be_present
+    expect(second_id).to be_present
+    expect(first_id).not_to eq(second_id)
+  end
+
+  it "uses a Bootstrap 5 modal (modal fade, not legacy 'hide') with a text-bg-primary header and no inline style" do
+    render_inline(described_class.new(:assign, label: "Assign")) { "Body fields" }
+
+    expect(page).to have_css(".modal.fade")
     expect(page).to have_no_css(".modal.hide")
     expect(page).to have_css(".modal-header.text-bg-primary")
     expect(page).to have_no_css("[style]")
@@ -24,5 +50,11 @@ RSpec.describe MpiDesignSystem::Admin::BatchActionModalButton::Component, type: 
 
     expect(page).to have_css(".modal-body", text: "Body fields")
     expect(page).to have_css(".modal-footer button[type='submit'][name='assign']", text: "Assign")
+  end
+
+  it "renders the trigger disabled by default (fail-safe; the controller enables it on selection)" do
+    render_inline(described_class.new(:assign, label: "Assign")) { "Body fields" }
+
+    expect(page).to have_css("button[type='button'][data-bs-toggle='modal'][disabled]")
   end
 end

--- a/spec/components/mpi_design_system/admin/batch_action_modal_button/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/batch_action_modal_button/component_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe MpiDesignSystem::Admin::BatchActionModalButton::Component, type: :component do
+  it "renders a trigger button targeting its modal" do
+    render_inline(described_class.new(:assign, label: "Assign")) { "Body fields" }
+
+    expect(page).to have_css("button[type='button'][data-bs-toggle='modal'][data-bs-target='#modal_assign']", text: "Assign")
+    expect(page).to have_css("button[data-mpi--batch-actions-target='actionButton']")
+  end
+
+  it "renders a Bootstrap 5 modal (modal fade, not the legacy 'hide') with a text-bg-primary header" do
+    render_inline(described_class.new(:assign, label: "Assign")) { "Body fields" }
+
+    expect(page).to have_css("#modal_assign.modal.fade")
+    expect(page).to have_no_css(".modal.hide")
+    expect(page).to have_css(".modal-header.text-bg-primary")
+    expect(page).to have_no_css("[style]")
+  end
+
+  it "renders the content slot as the modal body and a matching submit button" do
+    render_inline(described_class.new(:assign, label: "Assign")) { "Body fields" }
+
+    expect(page).to have_css(".modal-body", text: "Body fields")
+    expect(page).to have_css(".modal-footer button[type='submit'][name='assign']", text: "Assign")
+  end
+end

--- a/spec/components/mpi_design_system/admin/table_for_index/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/table_for_index/component_spec.rb
@@ -142,6 +142,28 @@ RSpec.describe MpiDesignSystem::Admin::TableForIndex::Component, type: :componen
       expect(page).to have_css("tbody td input[name='ids[]'][value='2']")
     end
 
+    it "gives every checkbox an accessible name and marks header cells as column scope" do
+      render_inline(described_class.new(data: rows, batch: true)) do |table|
+        table.with_column("Name") { |record| record.name }
+      end
+
+      expect(page).to have_css("input[name='toggle'][aria-label='Select all rows']")
+      expect(page).to have_css("input[name='ids[]'][value='1'][aria-label='Select row 1']")
+      expect(page).to have_css("input[name='ids[]'][value='2'][aria-label='Select row 2']")
+      # Every header cell (batch checkbox column + data columns) is scope="col".
+      expect(page).to have_css("thead th", count: 2)
+      expect(page).to have_css("thead th[scope='col']", count: 2)
+    end
+
+    it "uses a batch_row_label proc for a record-specific accessible name" do
+      render_inline(described_class.new(data: rows, batch: true, batch_row_label: ->(r) { "Select #{r.name}" })) do |table|
+        table.with_column("Name") { |record| record.name }
+      end
+
+      expect(page).to have_css("input[name='ids[]'][value='1'][aria-label='Select Acme Corporation']")
+      expect(page).to have_css("input[name='ids[]'][value='2'][aria-label='Select Globex']")
+    end
+
     it "omits the checkbox column by default" do
       render_inline(described_class.new(data: rows)) do |table|
         table.with_column("Name") { |record| record.name }

--- a/spec/components/mpi_design_system/admin/table_for_index/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/table_for_index/component_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe MpiDesignSystem::Admin::TableForIndex::Component, type: :component do
+  let(:row_class) { Struct.new(:id, :name, :active, :updated_at, keyword_init: true) }
+  let(:rows) do
+    [
+      row_class.new(id: 1, name: "Acme Corporation", active: true, updated_at: Time.utc(2026, 7, 1)),
+      row_class.new(id: 2, name: "Globex", active: false, updated_at: Time.utc(2026, 6, 15))
+    ]
+  end
+
+  describe "block columns" do
+    it "renders headers and captured cell content for each row" do
+      render_inline(described_class.new(data: rows)) do |table|
+        table.with_column("ID") { |record| record.id.to_s }
+        table.with_column("Name") { |record| record.name }
+      end
+
+      expect(page).to have_css("thead.table-dark th", text: "ID")
+      expect(page).to have_css("thead th", text: "Name")
+      expect(page).to have_css("tbody tr", count: 2)
+      expect(page).to have_css("tbody td", text: "Acme Corporation")
+      expect(page).to have_css("tbody td", text: "Globex")
+    end
+
+    it "emits a pre-rendered SafeBuffer header (e.g. a sort_link) verbatim" do
+      render_inline(described_class.new(data: rows)) do |table|
+        table.with_column('<a href="/admin/orgs?sort=name">Name</a>'.html_safe) { |record| record.name }
+      end
+
+      expect(page).to have_css("thead th a[href='/admin/orgs?sort=name']", text: "Name")
+    end
+  end
+
+  describe "helper columns" do
+    it "renders a :text value from a symbol or callable without a block" do
+      render_inline(described_class.new(data: rows)) do |table|
+        table.with_column("ID", value: :id)
+        table.with_column("Name", value: ->(record) { record.name })
+      end
+
+      expect(page).to have_css("tbody td", text: "1")
+      expect(page).to have_css("tbody td", text: "Acme Corporation")
+    end
+
+    it "renders a :boolean cell as a filled Badge (never the inline-hex tag_group variant)" do
+      render_inline(described_class.new(data: rows)) do |table|
+        table.with_column("Active", value: :active, cell: :boolean)
+      end
+
+      expect(page).to have_css("td .badge.text-bg-success", text: "Yes")
+      expect(page).to have_css("td .badge.text-bg-secondary", text: "No")
+      expect(page).to have_no_css("td .badge[style]")
+    end
+
+    it "renders a :date cell formatted via to_fs(:long)" do
+      render_inline(described_class.new(data: rows)) do |table|
+        table.with_column("Updated", value: :updated_at, cell: :date)
+      end
+
+      expect(page).to have_css("tbody td", text: "July 01, 2026")
+    end
+  end
+
+  describe "presentation options (Bootstrap utilities, no inline style)" do
+    it "applies align / nowrap / width utilities to <th> and <td>" do
+      render_inline(described_class.new(data: rows)) do |table|
+        table.with_column("Actions", align: :end, nowrap: true, width: :sm) { |record| record.id.to_s }
+      end
+
+      expect(page).to have_css("th.text-end.text-nowrap.w-25")
+      expect(page).to have_css("td.text-end.text-nowrap")
+      expect(page).to have_no_css("[style]")
+    end
+  end
+
+  describe "first-class sortable headers (Ransack-free)" do
+    subject(:render_sortable) do
+      render_inline(
+        described_class.new(
+          data: rows,
+          sort_url: ->(key, dir) { "/admin/orgs?sort=#{key}&dir=#{dir}" },
+          current_sort_key: :name,
+          current_sort_dir: :asc
+        )
+      ) do |table|
+        table.with_column("ID") { |record| record.id.to_s }
+        table.with_column("Name", value: :name, sortable: true, sort_key: :name)
+        table.with_column("Updated", value: :updated_at, cell: :date, sortable: true, sort_key: :updated_at)
+      end
+    end
+
+    it "renders a clickable header whose href flips direction on the active column" do
+      render_sortable
+      # Name is active + asc, so its link toggles to desc.
+      expect(page).to have_css("thead th[aria-sort='ascending'] a[href='/admin/orgs?sort=name&dir=desc']", text: "Name")
+    end
+
+    it "marks an inactive sortable column aria-sort=none and links ascending" do
+      render_sortable
+      expect(page).to have_css("thead th[aria-sort='none'] a[href='/admin/orgs?sort=updated_at&dir=asc']")
+    end
+
+    it "leaves a non-sortable column as a plain header, coexisting in the same thead" do
+      render_sortable
+      expect(page).to have_css("thead th", text: "ID")
+      expect(page).to have_no_css("thead th a", text: "ID")
+    end
+  end
+
+  describe "empty state" do
+    it "renders EmptyState with a title-derived heading and does not render the table" do
+      render_inline(described_class.new(data: [], title: "Organizations")) do |table|
+        table.with_column("Name") { |record| record.name }
+      end
+
+      expect(page).to have_text("No organizations found")
+      expect(page).to have_no_css("table")
+      # Monotonic outline: :h5 beneath the show-page <h4> title section.
+      expect(page).to have_css("h5", text: "No organizations found")
+    end
+
+    it "uses a generic heading at :h3 when there is no title" do
+      render_inline(described_class.new(data: [])) do |table|
+        table.with_column("Name") { |record| record.name }
+      end
+
+      expect(page).to have_css("h3", text: "No records found")
+    end
+  end
+
+  describe "batch selection" do
+    it "renders the toggle-all and per-row checkboxes wired to mpi--batch-actions when batch: true" do
+      render_inline(described_class.new(data: rows, batch: true)) do |table|
+        table.with_column("Name") { |record| record.name }
+      end
+
+      expect(page).to have_css("thead th input[name='toggle'][data-mpi--batch-actions-target='toggleCheckbox']")
+      expect(page).to have_css("tbody td input[name='ids[]'][value='1'][data-mpi--batch-actions-target='checkbox']")
+      expect(page).to have_css("tbody td input[name='ids[]'][value='2']")
+    end
+
+    it "omits the checkbox column by default" do
+      render_inline(described_class.new(data: rows)) do |table|
+        table.with_column("Name") { |record| record.name }
+      end
+
+      expect(page).to have_no_css("input[name='ids[]']")
+    end
+
+    it "renders the batch toolbar only when a batch-action slot is filled (slot? predicate, not bare ||)" do
+      # Positive control: a filled slot with rows renders the toolbar.
+      render_inline(described_class.new(data: rows, batch: true)) do |table|
+        table.with_batch_action_button(:archive, label: "Archive selected")
+        table.with_column("Name") { |record| record.name }
+      end
+      expect(page).to have_css("section.batch-actions button", text: "Archive selected")
+    end
+
+    it "does not render the batch toolbar band when no batch-action slot is filled" do
+      render_inline(described_class.new(data: rows, batch: true)) do |table|
+        table.with_column("Name") { |record| record.name }
+      end
+
+      expect(page).to have_no_css("section.batch-actions")
+    end
+
+    it "does not render the batch toolbar over an empty table even when a slot is filled" do
+      render_inline(described_class.new(data: [], title: "Organizations", batch: true)) do |table|
+        table.with_batch_action_button(:archive, label: "Archive selected")
+        table.with_column("Name") { |record| record.name }
+      end
+
+      expect(page).to have_no_css("section.batch-actions")
+      expect(page).to have_text("No organizations found")
+    end
+  end
+end

--- a/spec/components/previews/mpi_design_system/admin/table_for_index/component_preview.rb
+++ b/spec/components/previews/mpi_design_system/admin/table_for_index/component_preview.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class MpiDesignSystem::Admin::TableForIndex::ComponentPreview < ApplicationComponentPreview
+  # @label Default
+  def default
+    render_with_template
+  end
+
+  # @label Sortable Headers
+  def sortable
+    render_with_template
+  end
+
+  # @label Batch Actions
+  def batch
+    render_with_template
+  end
+
+  # @label Empty
+  def empty
+    render_with_template
+  end
+end

--- a/spec/components/previews/mpi_design_system/admin/table_for_index/component_preview/batch.html.erb
+++ b/spec/components/previews/mpi_design_system/admin/table_for_index/component_preview/batch.html.erb
@@ -1,0 +1,18 @@
+<% row = Struct.new(:id, :name, keyword_init: true) %>
+<% rows = [
+     row.new(id: 1, name: "Acme Corporation"),
+     row.new(id: 2, name: "Globex")
+   ] %>
+
+<%# The consuming app owns the <form> (submit URL + data-controller); the gem ships the
+    mpi--batch-actions controller and the checkbox/button UI. %>
+<form action="#" method="post" data-controller="mpi--batch-actions">
+  <%= render MpiDesignSystem::Admin::TableForIndex::Component.new(data: rows, batch: true) do |table| %>
+    <% table.with_batch_action_button(:archive, label: "Archive selected") %>
+    <% table.with_batch_action_modal_button(:assign, label: "Assign…") do %>
+      <p class="mb-0">Modal body — extra fields the operator fills in before submitting.</p>
+    <% end %>
+    <% table.with_column("ID") { |record| record.id.to_s } %>
+    <% table.with_column("Name") { |record| record.name } %>
+  <% end %>
+</form>

--- a/spec/components/previews/mpi_design_system/admin/table_for_index/component_preview/default.html.erb
+++ b/spec/components/previews/mpi_design_system/admin/table_for_index/component_preview/default.html.erb
@@ -1,0 +1,12 @@
+<% row = Struct.new(:id, :name, :active, :updated_at, keyword_init: true) %>
+<% rows = [
+     row.new(id: 1, name: "Acme Corporation", active: true, updated_at: Time.utc(2026, 7, 1)),
+     row.new(id: 2, name: "Globex", active: false, updated_at: Time.utc(2026, 6, 15))
+   ] %>
+
+<%= render MpiDesignSystem::Admin::TableForIndex::Component.new(data: rows) do |table| %>
+  <% table.with_column("ID", align: :end, width: :sm) { |record| record.id.to_s } %>
+  <% table.with_column("Name") { |record| record.name } %>
+  <% table.with_column("Active", value: :active, cell: :boolean, align: :center) %>
+  <% table.with_column("Updated", value: :updated_at, cell: :date) %>
+<% end %>

--- a/spec/components/previews/mpi_design_system/admin/table_for_index/component_preview/empty.html.erb
+++ b/spec/components/previews/mpi_design_system/admin/table_for_index/component_preview/empty.html.erb
@@ -1,0 +1,4 @@
+<%= render MpiDesignSystem::Admin::TableForIndex::Component.new(data: [], title: "Organizations") do |table| %>
+  <% table.with_column("ID") { |record| record.id.to_s } %>
+  <% table.with_column("Name") { |record| record.name } %>
+<% end %>

--- a/spec/components/previews/mpi_design_system/admin/table_for_index/component_preview/sortable.html.erb
+++ b/spec/components/previews/mpi_design_system/admin/table_for_index/component_preview/sortable.html.erb
@@ -1,0 +1,17 @@
+<% row = Struct.new(:id, :name, :updated_at, keyword_init: true) %>
+<% rows = [
+     row.new(id: 1, name: "Acme Corporation", updated_at: Time.utc(2026, 7, 1)),
+     row.new(id: 2, name: "Globex", updated_at: Time.utc(2026, 6, 15))
+   ] %>
+
+<%# The host owns the sort backend: sort_url builds the href, the gem renders the caret + aria-sort. %>
+<%= render MpiDesignSystem::Admin::TableForIndex::Component.new(
+      data: rows,
+      sort_url: ->(key, dir) { "?sort=#{key}&dir=#{dir}" },
+      current_sort_key: :name,
+      current_sort_dir: :asc
+    ) do |table| %>
+  <% table.with_column("ID") { |record| record.id.to_s } %>
+  <% table.with_column("Name", value: :name, sortable: true, sort_key: :name) %>
+  <% table.with_column("Updated", value: :updated_at, cell: :date, sortable: true, sort_key: :updated_at) %>
+<% end %>

--- a/spec/dummy/app/controllers/batch_actions_demo_controller.rb
+++ b/spec/dummy/app/controllers/batch_actions_demo_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Renders a real MpiDesignSystem::Admin::TableForIndex (batch: true) inside a form on a
+# page so the browser-level feature spec can boot Stimulus and exercise the
+# `mpi--batch-actions` controller end to end (initial disabled state, per-row selection,
+# clear, and toggle-all).
+class BatchActionsDemoController < ApplicationController
+  def show; end
+end

--- a/spec/dummy/app/views/batch_actions_demo/show.html.erb
+++ b/spec/dummy/app/views/batch_actions_demo/show.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, "Batch Actions Demo" %>
+
+<% row = Struct.new(:id, :name, keyword_init: true) %>
+<% rows = [
+     row.new(id: 1, name: "Acme Corporation"),
+     row.new(id: 2, name: "Globex"),
+     row.new(id: 3, name: "Initech")
+   ] %>
+
+<main class="container py-4">
+  <h1 class="h4 mb-3">Batch Actions Demo</h1>
+
+  <%# The consuming app owns the <form>; the gem ships the mpi--batch-actions controller. %>
+  <form action="#" data-controller="mpi--batch-actions">
+    <%= render MpiDesignSystem::Admin::TableForIndex::Component.new(data: rows, batch: true) do |table| %>
+      <% table.with_batch_action_button(:archive, label: "Archive selected") %>
+      <% table.with_column("ID") { |record| record.id.to_s } %>
+      <% table.with_column("Name") { |record| record.name } %>
+    <% end %>
+  </form>
+</main>

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -9,6 +9,11 @@ Rails.application.routes.draw do
   # renders a real MpiDesignSystem::Admin::TagInput::Component so Stimulus boots.
   get "tag_input_demo" => "tag_input_demo#show"
 
+  # Demo page exercised by the batch-actions browser feature spec — renders a real
+  # MpiDesignSystem::Admin::TableForIndex with batch: true so the mpi--batch-actions
+  # Stimulus controller boots and drives the checkbox/action-button state.
+  get "batch_actions_demo" => "batch_actions_demo#show"
+
   if Rails.env.development?
     mount Lookbook::Engine, at: "/lookbook"
     root to: redirect("/lookbook")

--- a/spec/features/batch_actions_stimulus_spec.rb
+++ b/spec/features/batch_actions_stimulus_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Browser-level (real headless Chrome) coverage of the `mpi--batch-actions` Stimulus
+# controller.
+#
+# `render_inline` proves the ERB emits the right data attributes, but it runs no
+# JavaScript — it cannot prove the controller actually *binds* under the namespaced
+# identifier and drives the disabled/checked state. This spec is therefore the
+# load-bearing proof that batch selection works end to end, and that the action button
+# is fail-safe: disabled in the server-rendered HTML and enabled only once the controller
+# observes a selection (so a missing/late controller cannot submit an empty `ids[]`).
+RSpec.describe "BatchActions Stimulus controller", type: :feature, js: true do
+  let(:root) { "form[data-controller='mpi--batch-actions']" }
+  let(:action_button) { "#{root} button[data-mpi--batch-actions-target='actionButton']" }
+  let(:toggle) { "#{root} input[data-mpi--batch-actions-target='toggleCheckbox']" }
+  let(:checkbox) { "#{root} input[data-mpi--batch-actions-target='checkbox']" }
+
+  def row_checkboxes
+    all(checkbox)
+  end
+
+  it "keeps the action button disabled until a row is selected, then re-disables when cleared" do
+    visit "/batch_actions_demo"
+    expect(page).to have_css(root)
+
+    # Connected controller + no selection => disabled (also the fail-safe initial HTML state).
+    expect(page).to have_css("#{action_button}[disabled]")
+
+    # Selecting a row fires change->mpi--batch-actions#checkCheckboxes, which only enables the
+    # button if the controller bound under the namespaced identifier.
+    row_checkboxes.first.check
+    expect(page).to have_css("#{action_button}:not([disabled])")
+
+    row_checkboxes.first.uncheck
+    expect(page).to have_css("#{action_button}[disabled]")
+  end
+
+  it "toggle-all checks every row and enables the action button" do
+    visit "/batch_actions_demo"
+    expect(page).to have_css(checkbox, count: 3)
+
+    find(toggle).check
+    expect(page).to have_css("#{checkbox}:checked", count: 3)
+    expect(page).to have_css("#{action_button}:not([disabled])")
+  end
+
+  it "unchecks toggle-all once a single row is deselected" do
+    visit "/batch_actions_demo"
+
+    find(toggle).check
+    expect(page).to have_css("#{toggle}:checked")
+
+    row_checkboxes.first.uncheck
+    expect(page).to have_css("#{toggle}:not(:checked)")
+  end
+end


### PR DESCRIPTION
## Summary

Generalizes the **byte-identical** local `Admin::TableForIndex` shared by the MPI apps
(Optimus / Garden / Harvest) into the design system — phase one of consuming it in Harvest under
epic mpimedia/harvest#692. Replaces per-app drifting copies with one neutral, slot/block-based
admin listing table.

This is **not** an extension of the CRM `DataTable` (fixed `:name`/`:tags`/`:status` schema, inline
hex). `TableForIndex` hosts arbitrary admin listings: cells are host-supplied HTML, so the gem takes
**no** Ransack / Pundit / Pagy / route-helper dependency.

## What's included

- **`Admin::TableForIndex` + `Admin::TableForIndexColumn`** — block-first columns
  (`with_column(header) { |record| … }`) covering every app-coupled cell; opt-in presentation
  keywords `align:` / `nowrap:` / `width:` and `cell: :text|:boolean|:date` (`:boolean` → filled
  `Badge`); integrated `EmptyState` with a title-derived heading and monotonic heading level.
- **Ransack-free first-class sortable headers** — `sortable:` / `sort_key:` + a host
  `sort_url: ->(key, dir) { … }` lambda render the clickable link, caret, and `aria-sort`; a
  pre-rendered `sort_link` still works as the header, so consumers adopt mechanically first and opt
  into first-class sorting later.
- **Batch selection (real, not markup)** — opt-in `batch:` checkbox column +
  `BatchActionButton` / `BatchActionModalButton` slots, driven by a new `mpi--batch-actions`
  Stimulus controller (generalized from SFA's working implementation) registered via
  `registerMpiControllers`. **The consuming app owns the `<form>`** (submit URL + route +
  authorization); the gem owns the checkbox UI, the slots, and the controller behavior.

## Design decisions

- **Bootstrap utilities only, no inline hex** — follows the `EmptyState` / `Badge` convention rather
  than `DataTable` / `Pagination`'s inline styles; the specs assert `have_no_css("[style]")`.
- **Leaf names identical to the apps' local component** → downstream adoption is a namespace prefix.
- Modal brought to Bootstrap 5 (`modal fade`, `text-bg-primary`) — dropped the BS3 `hide` class and
  the non-Bootstrap `bg-primary-blue`.
- Table shell (`table-striped/hover/sm`, `thead.table-dark`) preserved so adopted tables look
  identical.

## Testing

- 21 new component specs; full suite **700 examples, 0 failures**.
- 4-scenario Lookbook preview (default / sortable / batch / empty), all pass the preview smoke test.
- `rubocop` clean; `yarn build` confirms `mpi--batch-actions` and the controller land in the bundle.

## Consumer notes

- Batch is inert until a consumer wires the gem's JS substrate (esbuild alias + `registerMpiControllers`) —
  Harvest already has it (harvest#697); Garden / Optimus would need it first.
- **No version bump here** — the release tag is a follow-up release PR.

Part of mpimedia/harvest#692.

— Claude Code (Opus 4.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
