### PR TITLE
chore(release): v0.6.0 — shared Admin::TableForIndex (batch + sortable headers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ include breaking changes).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-17
+
 ### Added
 - **`Admin::TableForIndex::Component` + `Admin::TableForIndexColumn::Component`** — a neutral,
   slot/block-based admin index & association listing table, generalizing the byte-identical

--- a/lib/mpi_design_system/version.rb
+++ b/lib/mpi_design_system/version.rb
@@ -1,3 +1,3 @@
 module MpiDesignSystem
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/spec/packaging/version_spec.rb
+++ b/spec/packaging/version_spec.rb
@@ -5,11 +5,12 @@ require "spec_helper"
 # Guards the released version constant. PR4 of #103 cut v0.2.0 (first adoption-ready
 # release); v0.3.0 (#121) tokenizes Admin::EmptyState; v0.4.0 (#124) tokenizes
 # Admin::BreadcrumbNav; v0.4.1 (#128) fixes Admin::Badge filled contrast; v0.5.0 adds
-# opt-in Admin::Pagination link windowing (harvest#769). This spec fails if the constant
-# regresses, keeping lib/mpi_design_system/version.rb in lockstep with CHANGELOG.md and
-# the git tag.
+# opt-in Admin::Pagination link windowing (harvest#769); v0.6.0 (#134) adds the
+# slot/block-based Admin::TableForIndex with batch selection + Ransack-free sortable
+# headers (harvest#692). This spec fails if the constant regresses, keeping
+# lib/mpi_design_system/version.rb in lockstep with CHANGELOG.md and the git tag.
 RSpec.describe "MpiDesignSystem::VERSION" do
-  it "is 0.5.0" do
-    expect(MpiDesignSystem::VERSION).to eq("0.5.0")
+  it "is 0.6.0" do
+    expect(MpiDesignSystem::VERSION).to eq("0.6.0")
   end
 end


### PR DESCRIPTION
## Release v0.6.0

Cuts the release for the shared `Admin::TableForIndex` component merged in #134, so Harvest
(epic mpimedia/harvest#692) can bump its `github:` pin from `v0.5.0` → `v0.6.0` and adopt it across
its 31 admin tables.

### Changes
- `lib/mpi_design_system/version.rb`: `0.5.0` → `0.6.0`
- `spec/packaging/version_spec.rb`: assert `0.6.0` + extend the release-lineage comment
- `CHANGELOG.md`: promote `[Unreleased]` → `## [0.6.0] - 2026-07-17`

### Release contents (from #134)
- `Admin::TableForIndex` + `Admin::TableForIndexColumn` — neutral, block-based admin listing table:
  arbitrary block cells (no Ransack/Pundit/Pagy dependency), opt-in `align`/`nowrap`/`width` +
  `cell: :text|:boolean|:date`, integrated `EmptyState`.
- **Ransack-free sortable headers** — host `sort_url:` lambda; a pre-rendered `sort_link` still works.
- **Real batch selection** — `mpi--batch-actions` Stimulus controller (generalized from SFA) +
  `BatchActionButton`/`BatchActionModalButton` slots; the app owns the `<form>`.

### Verification
`bundle exec rspec` → **709 examples, 0 failures** (packaging guards for version + changelog green).
`bundle exec rubocop` clean.

### After merge
Tag `v0.6.0` on the merge commit (matching the v0.2.0–v0.5.0 lightweight-tag convention), then
Harvest bumps its pin (Gate 3). This is a minor bump: existing components are unchanged and the new
component is additive.

Part of mpimedia/harvest#692.

— Claude Code (Opus 4.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
