### PR TITLE
docs(rules): document the token dual-pipeline, consumer-call-site checks, and two false-green spec patterns

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -32,6 +32,14 @@ routinely survive a narrow sweep and ship green:
   *path fragment* (e.g. `admin/`) separately from the old *constant*, and confirm with a full
   preview render sweep (see `.claude/rules/testing.md`). Zeitwerk rewires constant→path but
   will not flag a hard-coded template string pointing at the moved directory.
+- **`catalog/previews/*.html` are hand-written and drift silently.** They are static mockups with
+  their own inline `<style>` block and hardcoded hex — nothing compiles, renders, or tests them,
+  so they never fail a build no matter how stale they get. Sweep them alongside the `.md` catalog
+  entry, and treat a contradiction between the two as a defect in the sweep. (Reference: #136
+  rewrote `action-button.md`'s Accessibility section to describe Bootstrap's derived foregrounds;
+  the sibling `action-button.html` was still forcing `color: #fff` on warning at **3.24:1** and
+  success at **3.33:1** — both WCAG AA failures, and both the exact claim the `.md` had just
+  retired. `badge.html` still carries pre-#128 `bg-secondary` + inline hex.)
 - **The repo's own docs, not just code.** Sweep `CLAUDE.md`, `AGENTS.md`, `.claude/rules/**`,
   `catalog/**`, `references/**`, and `docs/standards/**` for the old token too — leaving the
   convention documented one way while the code does another tells the next agent to re-create
@@ -56,14 +64,70 @@ Before creating a new component, check the catalog for an existing spec:
 
 If a catalog entry exists, implement to that spec. If not, raise it with the HC before building.
 
+## Design a Public API Against Real Call Sites, Not the Issue Text
+
+Everything under `app/` ships to Markaz, SFA, Garden, and Harvest. When adding or changing a
+component parameter, **read how those apps actually call the component** before settling on the
+design. There are no local checkouts, but the call sites are one command away:
+
+```bash
+gh search code "ActionButton::Component" --owner mpimedia --limit 20 \
+  --json repository,path --jq '.[] | "\(.repository.nameWithOwner): \(.path)"'
+
+gh api "repos/mpimedia/harvest/contents/<path>" --jq '.content' | base64 -d > /tmp/x.rb
+```
+
+What this catches that reasoning alone does not:
+
+- **Defaults that make a conditional universal.** An API gated on "did the caller pass `method:`?"
+  is meaningless if the caller's own wrapper supplies a default for it
+- **Naming the ecosystem already settled.** If three apps have converged on a parameter name,
+  adopt it rather than inventing a better one — the engine exists to absorb those local
+  components, and a rename is migration friction with no user-visible payoff
+- **Which call shapes are load-bearing**, so specs pin the real ones
+
+(Reference: #136 proposed `role="button"` on any `href:` anchor and the plan narrowed it to
+`href:` + `method:` present. Harvest's local component defines `DEFAULT_METHOD = :get` and passes
+`method:` on *every* button, so that gate would have applied the role to 100% of its anchors —
+including plain navigation links, announcing them as buttons to assistive technology. Gating on a
+non-GET verb was only discoverable by reading the consumer. The same read showed Markaz and
+Harvest already used `classes_append:`, which the engine adopted over the issue's `extra_classes:`.)
+
 ## Styling and Tokens
 
 - Use Bootstrap utility and component classes — no arbitrary hex values, sizes, or spacing
-- Design tokens live in `app/assets/stylesheets/mpi_design_system/_tokens.scss` and override
-  Bootstrap variables before Bootstrap is imported (`$mpi-primary: #2E75B6`,
-  `$mpi-brand-navy: #1B2A4A`, `$mpi-brand-accent: #4EA8DE`)
 - Token documentation lives in `tokens/*.md` (colors, typography, spacing, components,
   navigation, bootstrap-overrides) — consult it before choosing values
+
+### Tokens ship through TWO pipelines — change both, verify both
+
+There are two SCSS entry points, and a token added to one is invisible to consumers on the
+other. This is the single easiest way to ship a wrong color to all four apps.
+
+| File | Consumer path | Role |
+|------|---------------|------|
+| `_tokens_values.scss` | modern — `@use "mpi_design_system/tokens_values"` | Raw `$mpi-*` values, every one `!default`, **no Bootstrap dependency** |
+| `_tokens.scss` | legacy — `@import "mpi_design_system/tokens"` | `@import`s the values, then maps them onto Bootstrap's `$primary`/`$success`/… |
+
+Rules:
+
+- **Declare the raw value in `_tokens_values.scss`, always.** `_tokens.scss` should only *map*
+  (`$info: $mpi-info;`), never hardcode a value or alias another token
+  (`$info: $mpi-primary;`). A value that exists only in `_tokens.scss` reaches legacy
+  consumers and silently leaves modern ones on Bootstrap's default
+- **Declaring it is not enough — modern consumers map tokens themselves.** Bootstrap keeps its
+  own default for anything an app does not map, so a new token also needs the README's modern
+  snippet and `spec/fixtures/scss/modern_use.scss` updated, or the documented path stays broken
+- **Verify with `yarn build:css:compat`**, which compiles the legacy, modern, and
+  `@use … with ()` override fixtures and asserts the palette reaches the compiled CSS. Adding a
+  semantic token means adding its assertion. Grep the emitted custom property
+  (`--bs-info: #2E75B6`), not just the hex — the hex may appear from an unrelated token
+- **Prove a new build guard by breaking it.** Revert the mapping, confirm the build actually
+  fails, restore. (Reference: #136 added `:info`. `$info` was hardcoded in `_tokens.scss` only,
+  so modern consumers got Bootstrap's cyan `#0DCAF0` on `btn-info` — a color outside the MPI
+  palette — and the engine's own `modern_use.scss` fixture demonstrated the broken path. The
+  obvious guard, `! grep "#0dcaf0"`, would have false-passed forever: Bootstrap emits
+  `--bs-cyan: #0dcaf0` unconditionally, independent of `$info`.)
 - Custom SCSS only when Bootstrap genuinely cannot express the design; keep it in a
   dedicated partial under `app/assets/stylesheets/mpi_design_system/` (existing example:
   `_nav_bar.scss`) and import it from `application.scss`

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -104,9 +104,51 @@ end
 - `it` — one outcome, with a description that states the expected behavior
 - Use `let` for setup, not instance variables
 
+## Two False Greens Worth Naming
+
+DoD #3 asks "if this test passed but the component was broken, would I know?" Two specific
+shapes answer *no* while looking thorough. Both shipped green in #136 and were caught only in
+review.
+
+**1. Asserting a value the implementation would produce by a different path.**
+
+```ruby
+# FALSE GREEN — "button" is also what the derivation emits, so an implementation
+# that ignored `role:` entirely passes this identically.
+render_inline(described_class.new(label: "X", href: "/x", method: :delete, role: "button"))
+expect(page).to have_css("a[role='button']")
+
+# REAL — a value the derivation can never produce, so only an echoed override passes.
+render_inline(described_class.new(label: "X", href: "/x", method: :delete, role: "menuitem"))
+expect(page).to have_css("a[role='menuitem']")
+```
+
+When testing an override, a fallback, or a passthrough, pick a value the *other* branch cannot
+generate. If the expected value is reachable two ways, the test does not distinguish them.
+
+**2. An absence assertion with nothing proving the element rendered.**
+
+```ruby
+# FALSE GREEN — passes if the anchor renders without the attribute, AND passes if
+# nothing rendered at all, AND passes if a <button> rendered instead.
+expect(page).not_to have_css("a[role]")
+
+# REAL — pins the element first, then the absence.
+expect(page).to have_css("a.btn.btn-primary[href='/contacts/1']", text: "View")
+expect(page).not_to have_css("a[role]")
+```
+
+Every `not_to have_css` needs a positive assertion beside it. The same applies to
+`not_to have_text`.
+
+**Related:** when a constant drives behavior (`ACTION_METHODS`, `COLORS`, `SIZES`), loop it
+rather than spot-checking one member — otherwise a typo in the constant ships green.
+
 ## Anti-Patterns
 
 - Never assert only that a component "renders without error" — that is a false green
+- Never assert a value the implementation could produce by another path, and never leave a
+  `not_to have_css` unpaired with a positive assertion — see **Two False Greens** above
 - Never test private methods — test through the rendered output
 - Never reference models, the database, or request specs — the engine has none (browser
   feature specs exist, but only for genuine JS behavior — see Stack; default to `render_inline`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,8 @@ app/
 │   ├── config/manifest.js
 │   ├── stylesheets/mpi_design_system/
 │   │   ├── application.scss          # Main engine stylesheet
-│   │   └── _tokens.scss              # Design token overrides
+│   │   ├── _tokens_values.scss       # Raw $mpi-* token values (modern @use entry point)
+│   │   └── _tokens.scss              # Maps values onto Bootstrap vars (legacy @import)
 │   └── images/mpi_design_system/
 ├── components/mpi_design_system/admin/  # ViewComponents (MpiDesignSystem::Admin::Name::Component)
 │   ├── badge/
@@ -148,7 +149,10 @@ Reference these tokens when choosing values. Do not invent arbitrary colors, siz
 ### Colors
 
 - Use semantic color classes (`btn-primary`, `text-danger`, `bg-success`) rather than custom hex values
-- Custom tokens are defined in `app/assets/stylesheets/mpi_design_system/_tokens.scss`
+- Custom token **values** are defined in `_tokens_values.scss`; `_tokens.scss` maps them onto
+  Bootstrap's variables for legacy `@import` consumers. Adding a token means touching both, plus
+  the README snippet and the compat fixture — see `.claude/rules/frontend.md` ("Tokens ship
+  through TWO pipelines")
 - Primary: `#2E75B6`, Navy: `#1B2A4A`, Accent: `#4EA8DE`
 - See `tokens/colors.md` for full documentation
 


### PR DESCRIPTION
## Summary

Agent-config maintenance. PR #137 (#136) surfaced four conventions the repo relies on but no rule stated — each one let a real defect ship green, or nearly did. This writes them down.

Docs only: no `app/`, `lib/`, or `spec/` code changes. Based on `main` and independent of #137, though it reads best merged after it, since every reference points at that work.

## Changes Made

### `.claude/rules/frontend.md`

**New — "Tokens ship through TWO pipelines — change both, verify both."** The Styling and Tokens section named only `_tokens.scss` and never mentioned `_tokens_values.scss`, so nothing told an agent a token must exist in both. That omission is exactly why `:info` was shippable while modern `@use` consumers still resolved Bootstrap's cyan `#0DCAF0` on `btn-info`. Adds:
- a file → consumer-path → role table for the two entry points
- the rule that `_tokens.scss` may only *map* (`$info: $mpi-info;`), never hardcode a value or alias another token
- the reminder that declaring a token is not enough — modern consumers map tokens themselves, so the README snippet and `spec/fixtures/scss/modern_use.scss` need updating too, or the documented path stays broken
- verify with `yarn build:css:compat`, grepping the emitted custom property rather than the bare hex
- **prove a new build guard by breaking it.** Worth the space: the obvious guard here (`! grep "#0dcaf0"`) would have false-passed forever, because Bootstrap emits `--bs-cyan: #0dcaf0` unconditionally, independent of `$info`.

**New — "Design a Public API Against Real Call Sites, Not the Issue Text."** The consuming apps have no local checkouts, so this includes the `gh search code` / `gh api` recipe that works. Names what reasoning alone misses: defaults that make a conditional universal, naming the ecosystem already settled on, and which call shapes are load-bearing.

**Extended — the rename/convention sweep list now includes `catalog/previews/*.html`.** They are static mockups with their own inline `<style>` blocks and hardcoded hex; nothing compiles, renders, or tests them, so they never fail a build however stale they get.

### `.claude/rules/testing.md`

**New — "Two False Greens Worth Naming,"** with before/after code for each. DoD #3 already asks "if this test passed but the component was broken, would I know?", but these two shapes answer *no* while looking thorough, and both shipped green in #136:

1. **Asserting a value the implementation could produce by another path** — an override test passing `role: "button"`, the same literal the derivation emits, so an implementation ignoring the param passes identically.
2. **An absence assertion with nothing proving the element rendered** — a bare `not_to have_css("a[role]")` also passes when nothing rendered, or when a `<button>` rendered instead.

Plus a related note: loop a behavior-driving constant (`ACTION_METHODS`, `COLORS`, `SIZES`) rather than spot-checking one member, or a typo in the constant ships green. Two matching entries added to Anti-Patterns.

### `CLAUDE.md`

Design Tokens and the repo-structure tree pointed at `_tokens.scss` alone. Left alone, they would have contradicted the new rule the moment it landed — the precise failure `frontend.md`'s own sweep guidance warns about.

## Technical Approach

Every entry names the concrete defect it would have prevented, with file, value, and issue number, so a future agent can check the claim instead of taking it on faith. This matches the existing style of the rename section, which cites #103 and #128.

Scoped to what this cycle actually demonstrated. Deliberately not added: a general "audit all token docs" mandate, or process rules not exercised here.

## Testing

Documentation only — no runtime behavior.

- `mise exec -- bundle exec rubocop` — 152 files, **0 offenses**
- `mise exec -- bundle exec rspec` — **709 examples, 0 failures**

Verified the specific claims rather than restating them from memory: white on `$mpi-warning` `#D4772C` is **3.24:1** and on `$mpi-success` `#22A06B` is **3.33:1** (both fail AA; black is 6.48:1 and 6.31:1); white on `#2E75B6` is **4.84:1** (passes); and `--bs-cyan: #0dcaf0` is emitted in the compiled fixture regardless of `$info`, which is what makes the naive guard useless.

## Checklist

- [ ] Tests pass
- [ ] Linting passes

## Related

- Lessons from #137 / #136
- Follow-ups from the same cycle: #138, #139

— Claude Code (Fable 5)