### PR TITLE
docs(rules): cross-reference the #130 accessibility rules with the #136 guard rules

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -40,6 +40,13 @@ routinely survive a narrow sweep and ship green:
   the sibling `action-button.html` was still forcing `color: #fff` on warning at **3.24:1** and
   success at **3.33:1** — both WCAG AA failures, and both the exact claim the `.md` had just
   retired. `badge.html` still carries pre-#128 `bg-secondary` + inline hex.)
+- **A catalog entry's accessibility claims are assertions, not decoration — re-derive them when
+  you touch the component.** Three separate cycles found a catalog file asserting a contrast
+  property the code did not have: #128 (`Badge`), #130 (`avatar-circle.md` claimed "White text on
+  all background colors meets WCAG AA 4.5:1" — false for 7 of 10), and #136
+  (`action-button.md` claimed white text met AA on every button color). A prose claim about
+  contrast ages the moment a palette value or a foreground rule changes, and nothing in CI reads
+  it. Recompute the ratio rather than trusting the sentence.
 - **The repo's own docs, not just code.** Sweep `CLAUDE.md`, `AGENTS.md`, `.claude/rules/**`,
   `catalog/**`, `references/**`, and `docs/standards/**` for the old token too — leaving the
   convention documented one way while the code does another tells the next agent to re-create
@@ -127,7 +134,10 @@ Rules:
   so modern consumers got Bootstrap's cyan `#0DCAF0` on `btn-info` — a color outside the MPI
   palette — and the engine's own `modern_use.scss` fixture demonstrated the broken path. The
   obvious guard, `! grep "#0dcaf0"`, would have false-passed forever: Bootstrap emits
-  `--bs-cyan: #0dcaf0` unconditionally, independent of `$info`.)
+  `--bs-cyan: #0dcaf0` unconditionally, independent of `$info`.) This is the build-level twin of
+  the Accessibility section's "verify against an external oracle, never against itself" (#130):
+  there, the risk is a check that grades its own homework; here, it is a check that never fails.
+  Both are answered the same way — make the guard fail on purpose before you trust a pass.
 - Custom SCSS only when Bootstrap genuinely cannot express the design; keep it in a
   dedicated partial under `app/assets/stylesheets/mpi_design_system/` (existing example:
   `_nav_bar.scss`) and import it from `application.scss`


### PR DESCRIPTION
## Summary

Small follow-on to #141. That PR was authored before #140 (#130) landed, so the two sets of rules it now sits beside in `frontend.md` read as unrelated one-offs. This links them.

**Context on why this is a separate PR:** these two edits were pushed to #141's branch a few minutes after you merged it, so they never made it onto `main`. Cherry-picked onto a fresh branch rather than left orphaned. No new ideas beyond what #141 and #140 already established — this only connects them.

## Changes Made

Both in `.claude/rules/frontend.md`:

**1. Linked "prove a new build guard by breaking it" to #130's oracle rule.** The Accessibility section now says *verify a contrast rule against an external oracle, never against itself*; the Styling and Tokens section says *prove a new build guard by breaking it*. These are the same failure mode seen from two directions — a check that grades its own homework, and a check that never fails — and both are answered by making the guard fail on purpose before trusting a pass. Stating that once beats a future agent internalizing one and not the other.

**2. New sweep bullet: a catalog entry's accessibility claims are assertions, not decoration.** Three cycles have now found a catalog file asserting a contrast property the code did not have:

| Issue | File | False claim |
|---|---|---|
| #128 | Badge | white on `$mpi-success` at 3.33:1 |
| #130 | `avatar-circle.md` | "White text on all background colors meets WCAG AA 4.5:1" — false for **7 of 10** |
| #136 | `action-button.md` | white text meets AA on every button color |

Three independent instances is a pattern, not a coincidence. A prose claim about contrast ages the moment a palette value or a foreground rule changes, and nothing in CI reads it — so the rule is to recompute the ratio rather than trust the sentence.

## Technical Approach

Documentation only. No new rules invented — this connects two existing ones and generalizes an observation that three separate issues independently produced.

## Testing

- `mise exec -- bundle exec rubocop` — 157 files, **0 offenses**
- `mise exec -- bundle exec rspec` — **0 failures**

## Checklist

- [ ] Tests pass
- [ ] Linting passes

## Related

- Follows #141 (rules) and #140 / #130 (a11y)
- Sibling: #137, still open

— Claude Code (Fable 5)