### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ include breaking changes).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-21
+
 ### Added
 - **`MpiDesignSystem::ColorContrast`** — WCAG 2.1 relative-luminance and contrast-ratio math,
   plus `accessible_foreground`, the Ruby counterpart of Bootstrap's SCSS `color-contrast()`.
@@ -46,18 +48,6 @@ include breaking changes).
   `text-bg-info` in MPI blue with Bootstrap's derived foreground. Unknown colors still coerce
   silently to `:primary` — unchanged. (#136 — harvest#776, harvest#778)
 
-### Fixed
-- **`$mpi-info` is now a real token, so `:info` is MPI blue on *both* consumer paths.** The value
-  was previously hardcoded as `$info: $mpi-primary` in `_tokens.scss`, which covers only the legacy
-  `@import` pipeline. Modern Sass-module consumers (`@use "mpi_design_system/tokens_values"`) had no
-  `$mpi-info` to map at all, so Bootstrap's default cyan (`#0DCAF0`) reached `btn-info` /
-  `text-bg-info` — a color outside the MPI palette. `_tokens_values.scss` now declares
-  `$mpi-info: $mpi-primary !default` and `_tokens.scss` routes through it, so both pipelines emit
-  `--bs-info: #2E75B6`, and a `@use … with ($mpi-primary: …)` override carries through to info.
-  No rendered value changes for existing legacy consumers. The `build:css:compat` script now
-  asserts `--bs-info` on both compiled fixtures, so a future regression fails the build rather than
-  shipping cyan. (#136)
-
 ### Changed
 - **Visible design change:** avatars whose name hashes to one of the seven failing colours now
   render **dark initials** instead of white. The palette itself is unchanged. This reverses a
@@ -69,6 +59,16 @@ include breaking changes).
   `$primary` override instead of silently desynchronising from it. Pill geometry is unchanged.
 
 ### Fixed
+- **`$mpi-info` is now a real token, so `:info` is MPI blue on *both* consumer paths.** The value
+  was previously hardcoded as `$info: $mpi-primary` in `_tokens.scss`, which covers only the legacy
+  `@import` pipeline. Modern Sass-module consumers (`@use "mpi_design_system/tokens_values"`) had no
+  `$mpi-info` to map at all, so Bootstrap's default cyan (`#0DCAF0`) reached `btn-info` /
+  `text-bg-info` — a color outside the MPI palette. `_tokens_values.scss` now declares
+  `$mpi-info: $mpi-primary !default` and `_tokens.scss` routes through it, so both pipelines emit
+  `--bs-info: #2E75B6`, and a `@use … with ($mpi-primary: …)` override carries through to info.
+  No rendered value changes for existing legacy consumers. The `build:css:compat` script now
+  asserts `--bs-info` on both compiled fixtures, so a future regression fails the build rather than
+  shipping cyan. (#136)
 - **WCAG AA contrast in four inline-styled components** (#130) — the inline-style siblings of
   the `Badge` fix in #128. `Admin::AvatarCircle` paired a name-hashed background with a
   hardcoded `color: #fff`; **7 of its 10 palette colours failed the 4.5:1 AA floor**, worst
@@ -288,7 +288,8 @@ Initial internal version: the ViewComponent library, design tokens, Stimulus con
 and Lookbook previews, prior to the adoption-prep packaging corrections above. (No release
 tag was cut for 0.1.0.)
 
-[Unreleased]: https://github.com/mpimedia/mpi-design-system/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/mpimedia/mpi-design-system/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/mpimedia/mpi-design-system/compare/v0.4.0...v0.4.1

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ on where Bundler unpacks the gem.
 
 ```ruby
 # Gemfile
-gem "mpi_design_system", git: "git@github.com:mpimedia/mpi-design-system.git", tag: "v0.2.0"
+gem "mpi_design_system", git: "git@github.com:mpimedia/mpi-design-system.git", tag: "v0.7.0"
 ```
 
-Pin to a release tag (`tag: "v0.2.0"`) so upgrades are deliberate. Then:
+Pin to a release tag (`tag: "v0.7.0"`) so upgrades are deliberate. Then:
 
 ```bash
 bundle install

--- a/lib/mpi_design_system/version.rb
+++ b/lib/mpi_design_system/version.rb
@@ -1,3 +1,3 @@
 module MpiDesignSystem
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 end

--- a/spec/packaging/version_spec.rb
+++ b/spec/packaging/version_spec.rb
@@ -7,10 +7,13 @@ require "spec_helper"
 # Admin::BreadcrumbNav; v0.4.1 (#128) fixes Admin::Badge filled contrast; v0.5.0 adds
 # opt-in Admin::Pagination link windowing (harvest#769); v0.6.0 (#134) adds the
 # slot/block-based Admin::TableForIndex with batch selection + Ransack-free sortable
-# headers (harvest#692). This spec fails if the constant regresses, keeping
-# lib/mpi_design_system/version.rb in lockstep with CHANGELOG.md and the git tag.
+# headers (harvest#692); v0.7.0 (#148) releases Admin::ActionButton's classes_append: /
+# verb-gated role: / :info color (#136), AA foreground derivation for the inline-styled
+# components (#130), and the changelog release guard (#127). This spec fails if the
+# constant regresses, keeping lib/mpi_design_system/version.rb in lockstep with
+# CHANGELOG.md and the git tag.
 RSpec.describe "MpiDesignSystem::VERSION" do
-  it "is 0.6.0" do
-    expect(MpiDesignSystem::VERSION).to eq("0.6.0")
+  it "is 0.7.0" do
+    expect(MpiDesignSystem::VERSION).to eq("0.7.0")
   end
 end


### PR DESCRIPTION
## Summary

Cuts **v0.7.0**, making the work merged on 2026-07-21 reachable by consuming apps. Everything since `v0.6.0` has been sitting on `main` unreleased — and because the gem resolves by `github:` + git tag, **none of it is downstream-reachable today.** Harvest is the blocked consumer (its Gemfile is pinned to `v0.6.0`; mpimedia/harvest#778 collapses its ActionButton hybrid-wrapper workarounds once the pin moves).

Part of #147 (Track 2 epic), Phase 0.

## Changes Made

| File | Change |
|------|--------|
| `lib/mpi_design_system/version.rb` | `0.6.0` → `0.7.0` |
| `spec/packaging/version_spec.rb` | Pinned literal bumped; release-lineage comment extended |
| `CHANGELOG.md` | Four edits — see below |
| `README.md` | Install snippet `tag: "v0.2.0"` → `v0.7.0` (both occurrences) |

The gemspec is deliberately untouched — `mpi_design_system.gemspec:5` reads `MpiDesignSystem::VERSION`, so the bump propagates on its own.

## Technical Approach

### The CHANGELOG diff is four edits, not the usual one

**This is the first release cut since #146 landed its changelog guard, and the prior release shape no longer passes.** PRs #126/#132/#135 each changed `CHANGELOG.md` with a single two-line heading insertion. That would now red CI, because `spec/packaging/changelog_spec.rb:162` asserts:

```ruby
expect(reference_definitions).to match_array(bracketed_headings)
```

an **exact multiset match**. Verified against the real file with the spec's own regexes:

```
bracketed_headings    = ["Unreleased","0.6.0","0.5.0","0.4.1","0.4.0","0.3.0","0.2.0"]   # 7
reference_definitions = ["Unreleased","0.6.0","0.5.0","0.4.1","0.4.0","0.3.0","0.2.0"]   # 7
# heading alone -> 8 headings / 7 definitions -> exact_multiset_match = false
```

So this PR makes all four:

1. Insert `## [0.7.0] - 2026-07-21` beneath `## [Unreleased]` (which **stays** — `changelog_spec.rb:160` asserts it)
2. Consolidate the two duplicate `### Fixed` subsections into one — see below
3. **Add `[0.7.0]: …/compare/v0.6.0...v0.7.0`** to the footer — mandatory, or CI reds
4. Re-aim `[Unreleased]` to `compare/v0.7.0...HEAD`

**Edit 4 is caught by no test.** `changelog_spec.rb:64-65` documents the limit explicitly: *"It validates label coverage, not URL correctness: a definition pointing at the wrong compare range still passes."* Reviewer attention welcome there — it ships green either way.

### Duplicate `### Fixed` consolidated before the content froze

`[Unreleased]` carried **two** `### Fixed` subsections (the `$mpi-info` entry and the WCAG AA entry) with `### Changed` between them. No spec enforces subsection uniqueness, so promoting as-is would have passed green and permanently shipped a released section with duplicated headings. Final order is `Added → Changed → Fixed → Internal`.

**Bullet text was moved byte-for-byte** — the diff is pure relocation. Verified as a multiset, not a line count: the sorted content lines of the old `[Unreleased]` block and the new `[0.7.0]` block have **identical sha1** (`8af9bce8…`).

### Semver

`0.7.0`, not a patch and not `1.0.0`. #137 adds new public API and #140 adds the public `MpiDesignSystem::ColorContrast` class, so a patch is out. The two behavior changes — `role="button"` newly emitted for non-GET link consumers, and dark avatar initials on 7 of 10 palette colors — are visual/ARIA output rather than signature breaks, and `CHANGELOG.md:5` explicitly licenses this: *"pre-1.0: minor bumps may include breaking changes."*

## Testing

No code under `app/` changes, so no component specs or Lookbook previews are in scope. The release is gated by the existing packaging specs, which re-aim off `MpiDesignSystem::VERSION`.

### Three guards removed and watched to fail

Per `.claude/rules/testing.md` — *"for every element you call load-bearing, remove it and watch a test go red. Not 'reason that it would' — run it."* All three were mutated, run in isolation against `spec/packaging/changelog_spec.rb`, then restored to green. No `git stash` (shared stack).

**M1 — removed the `## [0.7.0]` heading** → 2 failures:
```
1) CHANGELOG.md documents the current release under its own heading
   expected … to match /^## \[0\.7\.0\](?:[ \t]|$)/
2) CHANGELOG.md defines a link reference for every bracketed heading
   expected [...] to include "0.7.0"
```

**M2 — removed `## [Unreleased]`** → 1 failure at `changelog_spec.rb:160`:
```
expected ["0.7.0","0.6.0","0.5.0","0.4.1","0.4.0","0.3.0","0.2.0"] to include "Unreleased"
```

**M3 — removed the `[0.7.0]:` link definition** → 1 failure at `changelog_spec.rb:162`:
```
expected collection contained: [..., "0.7.0", "Unreleased"]
actual collection contained:   [..., "0.6.0", "Unreleased"]
the missing elements were:     ["0.7.0"]
```

Each restored → `11 examples, 0 failures`.

### Required checks

```
bundle exec rubocop -a   →  157 files inspected, no offenses detected
bundle exec rspec        →  909 examples, 0 failures
```

Note: on a fresh worktree the ~41 `spec/features/` browser specs fail on `yarn build` until `yarn install` runs (`node_modules` absent). That was the case here initially; after `yarn install --immutable` the full suite is genuinely green at **909 / 0**. CI builds assets itself and sets `MDS_ASSETS_PREBUILT=1`.

## Reviewer notes

- **The `[Unreleased]` compare-range update (edit 4) is untested** — please eyeball it.
- **A correction to my own plan:** I originally attributed the release precedent as #126=v0.4.1, #132=v0.5.0. That was wrong. Verified: **#126 cut v0.4.0, #132 cut v0.4.1, #133 bundled v0.5.0 into a feature PR, #135 cut v0.6.0.** The standalone three-file shape is still the precedent, but #133 shows it is not universal.
- **Out of scope, worth a follow-up:** `README.md:11` claims "33 shared UI components"; there are **37** directories under `app/components/mpi_design_system/admin/`. Left alone to keep this diff a release cut — happy to file it.

## After merge — the tag is the actual release

**This PR releases nothing on its own.** `.github/workflows/ci.yml:15` triggers on `push: branches: ["**"]` with **no `tags:` filter**, so pushing a tag runs no CI, and `main` has no branch protection. Gate the tag on CI having passed for the exact merge SHA:

The procedure below **fails closed** — every check aborts rather than printing and continuing. It also resolves *this PR's own* merge commit rather than whatever `origin/main` happens to point at, because `git rev-parse origin/main` is mutable: if any other PR merges between this merge and the tag, `v0.7.0` would silently capture unrelated, unchangelogged work, and the version check would still pass. (Caught by Codex review.)

```bash
git fetch origin main --tags

# This PR's immutable merge commit — NOT the mutable origin/main tip
MERGE_SHA=$(gh pr view 157 --json mergeCommit --jq '.mergeCommit.oid')
[ -n "$MERGE_SHA" ] || { echo "ABORT: PR #157 is not merged"; exit 1; }

git merge-base --is-ancestor "$MERGE_SHA" origin/main \
  || { echo "ABORT: $MERGE_SHA is not on origin/main"; exit 1; }

git show "$MERGE_SHA:lib/mpi_design_system/version.rb" | grep -q '"0.7.0"' \
  || { echo "ABORT: $MERGE_SHA does not carry VERSION 0.7.0"; exit 1; }

# CI must have actually RUN and EVERY run must have SUCCEEDED for that exact SHA
CONCLUSIONS=$(gh run list --commit "$MERGE_SHA" --json conclusion --jq '.[].conclusion')
[ -n "$CONCLUSIONS" ] || { echo "ABORT: no CI runs for $MERGE_SHA"; exit 1; }
[ "$(printf '%s\n' "$CONCLUSIONS" | sort -u)" = "success" ] \
  || { echo "ABORT: CI not all green -> $CONCLUSIONS"; exit 1; }

[ -z "$(git ls-remote --tags origin v0.7.0)" ] \
  || { echo "ABORT: v0.7.0 already exists on the remote"; exit 1; }

git tag v0.7.0 "$MERGE_SHA"        # lightweight, on the MERGE commit
git push origin v0.7.0

git ls-remote --tags origin v0.7.0 # must now print $MERGE_SHA
```

Do **not** use `rake release` — Bundler's stock gem task would create a tag *and* attempt a RubyGems push. This repo has no RubyGems publishing; the git tag is the sole release artifact.

## Checklist

- [x] Tests pass — 909 examples, 0 failures
- [x] Linting passes — 157 files, no offenses
- [x] All three load-bearing guards mutation-proven red, then restored
- [x] CHANGELOG content preserved byte-for-byte (sha1-verified)
- [x] `Closes #148` only — epic #147 carries no closing keyword

Closes #148

— Claude Code (Fable 5)
