### PR TITLE
docs(rules): name the prose guard that never runs

### DIFF
--- a/.claude/rules/self-review.md
+++ b/.claude/rules/self-review.md
@@ -22,6 +22,11 @@ HC the work is complete:
       (no invented colors, sizes, or spacing)?
 - [ ] **Accessibility pass** — keyboard access, ARIA roles/labels, 4.5:1 / 3:1 contrast,
       visible focus indicators
+- [ ] **Executed every check you wrote in prose** — a command, gate, or runbook step in a
+      PR description, comment, or doc is a check no suite will ever run for you. Paste it
+      into a shell, feed it the *failure* case, and confirm it aborts. Verifying only the
+      happy path cannot distinguish a working gate from one that always passes — see
+      `.claude/rules/testing.md` ("A check written in documentation is still a check")
 - [ ] **Both required checks green** — the engine has exactly two, and both must pass
       before any commit or push (no Brakeman or bundler-audit here):
       - `bundle exec rubocop -a` — zero offenses

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -195,8 +195,40 @@ script refuted it in seconds. The same script found two real defects reading had
 
 This is the spec-level twin of `.claude/rules/frontend.md`'s "prove a new build guard by
 breaking it" (#136) and its "verify a contrast rule against an external oracle, never against
-itself" (#130). Same failure, three layers: a check that grades its own homework, a check that
-never fails, and a claim nobody executed.
+itself" (#130). Same failure, four layers: a check that grades its own homework, a check that
+never fails, a claim nobody executed, and — the one that hides best — a check that never runs at
+all, because it lives in prose.
+
+### A check written in documentation is still a check
+
+Execute it before you publish it. The doctrine above is usually applied to specs, but a guard
+does not stop being a guard because it is written in a PR body, a runbook, or a comment. Those
+are the guards least likely to be run, because no suite ever touches them.
+
+#148's release PR documented a fail-closed tagging procedure whose CI gate read:
+
+```bash
+# NOT A GATE — reads as obviously correct, and is not.
+echo "$CONCLUSIONS" | grep -qv '^success$' && { echo "ABORT"; exit 1; }
+```
+
+Left to right that says "if any conclusion is not success, abort." Run it and both
+`success/failure` and `success/skipped` reach PROCEED: BSD `grep -qv` returns 1 on macOS even
+when a non-matching line is present. The gate could not fail — and nothing would ever have
+caught it, because it was a shell snippet in a PR description, destined to be run once by a
+human against a release tag that is awkward to retract.
+
+```bash
+# REAL — verified against success/success, success/failure, success/skipped, cancelled, and empty.
+[ -n "$CONCLUSIONS" ] || { echo "ABORT: no CI runs"; exit 1; }
+[ "$(printf '%s\n' "$CONCLUSIONS" | sort -u)" = "success" ] \
+  || { echo "ABORT: CI not all green -> $CONCLUSIONS"; exit 1; }
+```
+
+The method is the same as for a spec: paste the snippet into a shell, feed it the **failure**
+case, and watch it abort. A gate verified only on the happy path is indistinguishable from one
+that always passes. This applies with most force to anything gating an irreversible step —
+a tag push, a deploy, a destructive migration.
 
 ## Anti-Patterns
 
@@ -206,6 +238,9 @@ never fails, and a claim nobody executed.
 - Never describe part of an assertion as load-bearing without a test that reddens when it is
   removed, and never pin a literal that the artifact under test retains forever (a version, a
   date, an id) — see **A Guard Is Not Real Until You Have Watched It Fail** above
+- Never publish a command, gate, or runbook step you have not executed against its failure
+  case — a check in prose is still a check, and it is the kind no suite will ever run for you
+  — see **A check written in documentation is still a check** above
 - Never test private methods — test through the rendered output
 - Never reference models, the database, or request specs — the engine has none (browser
   feature specs exist, but only for genuine JS behavior — see Stack; default to `render_inline`)


### PR DESCRIPTION
## Summary

Adds a **fourth layer** to the "watch it fail" doctrine in `.claude/rules/testing.md`, plus a matching item on the `.claude/rules/self-review.md` checklist.

The doctrine already named three shapes of check that cannot catch what they claim:

1. a check that **grades its own homework** (#130 — a contrast spec calling the code under test on both sides)
2. a check that **never fails** (#136 — `! grep "#0dcaf0"`, which Bootstrap emits unconditionally)
3. a **claim nobody executed** (#127 — a `^` anchor documented as load-bearing, whose removal left the suite green)

Cutting v0.7.0 (#148 / #157) produced a fourth, and it is the one that hides best: **a check that never runs at all, because it lives in prose.**

## The defect this came from

#157's description documented a fail-closed tagging procedure — the gate standing between a green CI run and an **irreversible tag push**. Its CI check was:

```bash
echo "$CONCLUSIONS" | grep -qv '^success$' && { echo "ABORT"; exit 1; }
```

Read left to right, that says *"if any conclusion is not success, abort."* Run it, and both `success/failure` and `success/skipped` reach **PROCEED** — BSD `grep -qv` returns 1 on macOS even when a non-matching line is present.

So the gate could not fail. And nothing existing would have caught it: no suite touches a shell snippet in a PR body. It was destined to be run once, by a human, weeks later, against a release tag that is awkward to retract. It was caught only because it was pasted into a shell and fed its failure case before being published.

The corrected form now in the rules:

```bash
[ -n "$CONCLUSIONS" ] || { echo "ABORT: no CI runs"; exit 1; }
[ "$(printf '%s\n' "$CONCLUSIONS" | sort -u)" = "success" ] \
  || { echo "ABORT: CI not all green -> $CONCLUSIONS"; exit 1; }
```

## Changes Made

| File | Change |
|------|--------|
| `.claude/rules/testing.md` | "Same failure, three layers" → **four**; new subsection **"A check written in documentation is still a check"** with the broken and corrected snippets side by side; new anti-pattern bullet |
| `.claude/rules/self-review.md` | New checklist item — *"Executed every check you wrote in prose"* — placed where PR bodies actually get written, cross-referencing the testing rule |

## Technical Approach

**Why the substance lives in `testing.md` and the trigger in `self-review.md`.** `testing.md` is where the whole "watch it fail" doctrine is articulated, and it already reaches beyond `spec/**` by cross-referencing `frontend.md`'s build-level guards — so the fourth layer belongs alongside the other three rather than in isolation. But the *moment* this failure occurs is PR-authoring time, not spec-writing time, which is `self-review.md`'s domain. Splitting it keeps each file's "Applies to" honest while keeping the explanation in one place.

**The corrective emphasis is on the failure case, not the snippet.** The generalisable lesson is not "beware `grep -qv`" — it is that a gate verified only on its happy path is indistinguishable from one that always passes. The rule says to feed it the failure case, and flags that this matters most for anything gating an irreversible step (a tag push, a deploy, a destructive migration).

## Testing

No code changes — rules/docs only. Both required checks run anyway:

```
bundle exec rubocop   →  157 files inspected, no offenses detected
bundle exec rspec     →  909 examples, 0 failures
```

**Both snippets in the new section were executed, not reasoned about** — per the rule they document. It would be a poor look to add a rule about unexecuted prose guards using an unexecuted prose guard.

- **Corrected form** verified against all six inputs, in the exact line-continuation form as published: `success` → PROCEED; `success/success` → PROCEED; `success/failure` → ABORT; `success/skipped` → ABORT; `cancelled` → ABORT; empty → ABORT.
- **Broken form** confirmed to reach PROCEED on both cases the text names (`success/failure` and `success/skipped`), so the document's claim about it is accurate rather than assumed.

## Checklist

- [x] Tests pass — 909 examples, 0 failures
- [x] Linting passes — 157 files, no offenses
- [x] Every snippet published in the new rule was executed against its failure case

## Notes

- **No closing keyword.** This is not scoped to an existing issue; it arises from #148 / #157. Both remain unaffected.
- **Independent of #157.** Branched from `main`, so it can merge in either order.
- Deliberately **not** included: documenting the four-edit release-CHANGELOG shape that #157 surfaced. That belongs to **#156** (Phase 8 of epic #147), which already owns the release runbook. Happy to fold it in there.

— Claude Code (Fable 5)
