### PR TITLE
docs(rules): verify every snippet, not just the one you distrust

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -230,6 +230,20 @@ case, and watch it abort. A gate verified only on the happy path is indistinguis
 that always passes. This applies with most force to anything gating an irreversible step —
 a tag push, a deploy, a destructive migration.
 
+**Verify every snippet, not just the one you distrust.** The same #157 procedure carried a
+second prose guard that was never run, and it was broken too:
+
+```bash
+git show "$MERGE_SHA:lib/mpi_design_system/version.rb" | grep -q '"0.7.0"'   # dies under zsh
+git show "${MERGE_SHA}:lib/mpi_design_system/version.rb" | grep -q '"0.7.0"' # correct
+```
+
+`:l` is zsh's lowercase parameter modifier, so `"$MERGE_SHA:lib/…"` expands to `<sha>ib/…` and
+the command dies on an ambiguous argument — note this repo's shell is zsh. That one happens to
+fail *closed*, which is luck rather than design. The instructive part is the selection error:
+the author executed the gate whose logic he doubted and skipped the line that looked obvious,
+so the doubted line got fixed and the obvious one shipped broken. Run all of them.
+
 ## Anti-Patterns
 
 - Never assert only that a component "renders without error" — that is a false green


### PR DESCRIPTION
## Summary

Follow-up to #158, which merged at commit `34df558` while this second commit was still in flight — so it landed on the branch after the merge and never reached `main`. Same change, re-proposed cleanly off the current `main`. No new work; this is the orphaned commit.

## The case it adds

After #157 merged, I ran its documented tagging procedure against the real merge commit `70de580`. The CI gate — the part #158 was written about, and the part I *had* executed before publishing — worked correctly. The line immediately above it did not:

```bash
git show "$MERGE_SHA:lib/mpi_design_system/version.rb" | grep -q '"0.7.0"'
# fatal: ambiguous argument '70de580...332ib/mpi_design_system/version.rb'
```

`:l` is zsh's lowercase parameter modifier, so `"$MERGE_SHA:lib/…"` expands to `<sha>ib/…`. This repo's shell is zsh, so it would have failed on first use. Braced, it is correct:

```bash
git show "${MERGE_SHA}:lib/mpi_design_system/version.rb" | grep -q '"0.7.0"'
```

Verified against the real merge SHA — correctly reports `VERSION = "0.7.0"`.

## Why it is worth a separate rule

It **fails closed**, so the blast radius was noise rather than a bad tag. The instructive part is not the zsh bug — it is the *selection* error, which is a distinct failure from the one #158 documented:

> I executed the snippet whose logic I doubted, and skipped the one that looked obvious. The doubted line got fixed. The obvious line shipped broken.

"Execute what you publish" is not satisfied by executing the interesting bits. #158 taught *that* prose guards need running; this teaches *which* ones — all of them.

## Testing

Docs-only. Both required checks run anyway, on this branch off the post-release `main`:

```
bundle exec rubocop   →  157 files inspected, no offenses detected
bundle exec rspec     →  909 examples, 0 failures
```

Both forms in the new text were executed against the real merge commit — the broken one confirmed to die on the ambiguous argument, the braced one confirmed to report `0.7.0`.

## Checklist

- [x] Tests pass — 909 examples, 0 failures
- [x] Linting passes — 157 files, no offenses
- [x] Every snippet published in the new text was executed

No closing keyword — arises from #157 / #158.

— Claude Code (Fable 5)