### PR TITLE
Add NavBar logo_mark override and subsection visible: filtering

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -156,6 +156,23 @@ Rules:
 - Custom SCSS only when Bootstrap genuinely cannot express the design; keep it in a
   dedicated partial under `app/assets/stylesheets/mpi_design_system/` (existing example:
   `_nav_bar.scss`) and import it from `application.scss`
+- **Moving a component's colour from inline to CSS makes it depend on the component partial being
+  loaded — and that partial is not on the documented consumer path.** The engine ships SCSS as
+  source (`lib/mpi_design_system/engine.rb` — "No asset-pipeline initializer by design"); the
+  README's install snippet and the dummy app both import only `mpi_design_system/tokens` +
+  Bootstrap, **not** `_nav_bar.scss` (the only component partial). So converting an inline colour
+  (an SVG `fill="#…"`, an inline `style`) to token-sourced classes silently regresses to its
+  fallback anywhere the partial isn't imported — including the dev Lookbook until the dummy
+  stylesheet imports it. Two consequences: (1) verify the compiled colour against a stylesheet that
+  *actually imports the partial* — the engine `application.scss`, or the dummy `application.scss`
+  once it imports the component — **not** bare `yarn build:css`, which compiles the dummy app and
+  never saw the partial; grep the specific `selector{property:value}`, since Bootstrap emits the
+  token hex elsewhere (`--bs-primary: #2E75B6`). (2) Add a browser computed-style spec (the
+  `contrast_demo`/`contrast_spec` pattern) asserting a *painted* value only the correct rule can
+  produce — e.g. a two-tone mark whose centre must compute `$mpi-primary`, since a `currentColor`
+  fallback would paint it the arms' navy. (Reference: #155 tokenised the NavBar mark's fills;
+  without importing `_nav_bar.scss` in the dummy app the mark rendered monochrome in Lookbook, and
+  `yarn build:css` could not see the rule at all — a grep guard against it would have false-passed.)
 
 ## Stimulus Controllers
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -170,6 +170,18 @@ element still emits and pin it, or the next edit that removes it ships green.
 **Related:** when a constant drives behavior (`ACTION_METHODS`, `COLORS`, `SIZES`), loop it
 rather than spot-checking one member — otherwise a typo in the constant ships green.
 
+**Related — `render_inline` lowercases SVG attribute names, so a camelCase selector silently
+matches nothing.** ViewComponent's `render_inline` parses output through Nokogiri's HTML parser,
+which downcases attribute *names* (`viewBox` → `viewbox`, `preserveAspectRatio` →
+`preserveaspectratio`). CSS attribute-name matching is case-sensitive, so
+`have_css("svg[viewBox='0 0 22 26']")` matches **nothing** — and a `not_to` paired with it is a
+guard that can never fail (False Green #2's cousin: the *selector*, not the DOM, is what's empty).
+Use lowercase: `have_css("svg[viewbox='0 0 22 26']")`. Attribute *values* and element/class
+selectors are unaffected. Confirm which form the parser emits with a one-line probe
+(`puts page.native.to_html`) before trusting any camelCase attribute selector. (#155 — a
+`not_to have_css("svg[viewBox=…]")` guard on the logo-mark override passed only because the
+camelCase selector never matched; lowercasing it turned the guard real.)
+
 ## A Guard Is Not Real Until You Have Watched It Fail
 
 The two shapes above are assertions that *can* fail but don't discriminate. This is the

--- a/app/assets/stylesheets/mpi_design_system/_nav_bar.scss
+++ b/app/assets/stylesheets/mpi_design_system/_nav_bar.scss
@@ -36,6 +36,15 @@
   }
 }
 
+// Brand mark diamond fills — token-sourced (currentColor fallback in markup)
+.mds-navbar__brand-arm {
+  fill: $mpi-brand-navy;
+}
+
+.mds-navbar__brand-center {
+  fill: $mpi-primary;
+}
+
 // Section navigation links
 .mds-navbar__section-link {
   font-size: 14px;

--- a/app/components/mpi_design_system/admin/app_shell/component.rb
+++ b/app/components/mpi_design_system/admin/app_shell/component.rb
@@ -23,11 +23,12 @@ module MpiDesignSystem
         # @param profile_url [String] Optional URL for user profile link
         # @param logo_text [String] Logo text (default: "MARKAZ")
         # @param logo_href [String] Logo link URL
+        # @param logo_mark [String] Custom logo mark markup (trusted SVG/image); forwarded to NavBar
         def initialize(current_section: :dashboard, current_subsection: nil, user_name: nil,
                        search_url: nil, search_placeholder: "Search...", show_sidebar: false,
                        sections: nil, subsections: nil, environment: nil, system_url: nil,
                        sign_out_url: nil, sign_out_method: :delete, profile_url: nil,
-                       logo_text: "MARKAZ", logo_href: nil)
+                       logo_text: "MARKAZ", logo_href: nil, logo_mark: nil)
           @current_section = current_section
           @current_subsection = current_subsection
           @user_name = user_name
@@ -43,6 +44,7 @@ module MpiDesignSystem
           @profile_url = profile_url
           @logo_text = logo_text
           @logo_href = logo_href
+          @logo_mark = logo_mark
         end
 
         private
@@ -64,6 +66,7 @@ module MpiDesignSystem
           opts[:sign_out_method] = @sign_out_method if @sign_out_method != :delete
           opts[:profile_url] = @profile_url if @profile_url
           opts[:logo_href] = @logo_href if @logo_href
+          opts[:logo_mark] = @logo_mark if @logo_mark
           opts
         end
 

--- a/app/components/mpi_design_system/admin/nav_bar/component.html.erb
+++ b/app/components/mpi_design_system/admin/nav_bar/component.html.erb
@@ -6,7 +6,7 @@
   <div class="mds-navbar d-flex align-items-center justify-content-between px-3">
     <div class="d-flex align-items-center gap-3">
       <a href="<%= @logo_href %>" class="mds-navbar__brand d-flex align-items-center gap-2">
-        <%= markaz_logo_svg %>
+        <%= @logo_mark.presence || markaz_logo_svg %>
         <span><%= @logo_text %></span>
       </a>
 

--- a/app/components/mpi_design_system/admin/nav_bar/component.rb
+++ b/app/components/mpi_design_system/admin/nav_bar/component.rb
@@ -41,10 +41,11 @@ module MpiDesignSystem
         # @param profile_url [String] Optional URL for user profile link
         # @param logo_text [String] Logo text (default: "MARKAZ")
         # @param logo_href [String] Logo link URL (default: first section's href or "/")
+        # @param logo_mark [String] Custom logo mark markup (trusted SVG/image); default renders the Markaz diamond
         def initialize(current_section: nil, current_subsection: nil, user_name: nil, search_url: nil,
                        search_placeholder: "Search...", sections: nil, subsections: nil, environment: nil,
                        system_url: nil, sign_out_url: nil, sign_out_method: :delete, profile_url: nil,
-                       logo_text: "MARKAZ", logo_href: nil)
+                       logo_text: "MARKAZ", logo_href: nil, logo_mark: nil)
           @current_section = current_section
           @current_subsection = current_subsection
           @user_name = user_name
@@ -59,6 +60,7 @@ module MpiDesignSystem
           @profile_url = profile_url
           @logo_text = logo_text
           @logo_href = logo_href
+          @logo_mark = logo_mark
         end
 
         def before_render
@@ -86,7 +88,7 @@ module MpiDesignSystem
         end
 
         def current_subsections
-          @subsections[@current_section] || []
+          (@subsections[@current_section] || []).select { |s| s.fetch(:visible, true) }
         end
 
         def show_env_bar?
@@ -105,11 +107,11 @@ module MpiDesignSystem
         def markaz_logo_svg
           <<~SVG.html_safe
             <svg width="20" height="24" viewBox="0 0 22 26" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <polygon points="1,0 6,0 12.5,11 10.5,13" fill="#1B2A4A"/>
-              <polygon points="16,0 21,0 11.5,13 9.5,11" fill="#1B2A4A"/>
-              <polygon points="10.5,15 12.5,13 5,26 0,26" fill="#1B2A4A"/>
-              <polygon points="9.5,13 11.5,15 22,26 17,26" fill="#1B2A4A"/>
-              <polygon points="11,11 13,13 11,15 9,13" fill="#2E75B6"/>
+              <polygon points="1,0 6,0 12.5,11 10.5,13" class="mds-navbar__brand-arm" fill="currentColor"/>
+              <polygon points="16,0 21,0 11.5,13 9.5,11" class="mds-navbar__brand-arm" fill="currentColor"/>
+              <polygon points="10.5,15 12.5,13 5,26 0,26" class="mds-navbar__brand-arm" fill="currentColor"/>
+              <polygon points="9.5,13 11.5,15 22,26 17,26" class="mds-navbar__brand-arm" fill="currentColor"/>
+              <polygon points="11,11 13,13 11,15 9,13" class="mds-navbar__brand-center" fill="currentColor"/>
             </svg>
           SVG
         end

--- a/catalog/components/navbar.md
+++ b/catalog/components/navbar.md
@@ -10,7 +10,7 @@ Two-level horizontal navigation used as the primary app shell navigation across 
 
 ## Design Decisions
 
-- **Brand mark:** Nexus SVG diamond logo (navy `#1B2A4A` arms + primary blue `#2E75B6` center diamond) — NOT "X MARKAZ" text logo
+- **Brand mark:** Nexus SVG diamond logo (navy arms + primary blue center diamond) — NOT "X MARKAZ" text logo. The default mark's fills are **token-sourced**, not hardcoded hex: the arm polygons carry `.mds-navbar__brand-arm` (filled from `$mpi-brand-navy`) and the center polygon carries `.mds-navbar__brand-center` (filled from `$mpi-primary`), each with a `fill="currentColor"` fallback in the markup. A caller can replace the whole mark via `logo_mark:` (see Props / API)
 - **MARKAZ text:** `font-weight: 300`, `letter-spacing: 0.12em`, color `#1B2A4A`
 - **White background:** Both bars use white background with bottom border (`#DEE2E6`)
 - **Active state:** Primary blue text (`#2E75B6`) + 2px blue bottom border + `font-weight: 600`
@@ -64,12 +64,37 @@ Other section sub-navs will be documented as their designs are finalized.
 ```ruby
 # MpiDesignSystem::Admin::NavBar::Component
 class MpiDesignSystem::Admin::NavBar::Component < ViewComponent::Base
-  # @param current_section [Symbol] :dashboard, :content, :crm, :rights_avails, :releases, :screenings
-  # @param current_subsection [Symbol] Section-specific (e.g., :contacts, :accounts for CRM)
+  # @param current_section [Symbol] Active top-level section key (e.g. :dashboard, :crm)
+  # @param current_subsection [Symbol] Active subsection key (e.g. :contacts, :accounts for CRM)
   # @param user_name [String] Current user name (for avatar)
-  # @param search_url [String] Global search action URL
+  # @param search_url [String] Global search action URL (search bar hidden when nil)
+  # @param search_placeholder [String] Placeholder text for search input (default: "Search...")
+  # @param sections [Array<Hash>] Custom top-level sections (overrides defaults); each hash supports visible: (default true)
+  # @param subsections [Hash{Symbol => Array<Hash>}] Custom subsections (overrides defaults); each hash supports visible: (default true)
+  # @param environment [Symbol] :development, :staging, :production (env bar shown for dev/staging)
+  # @param system_url [String] URL for system admin gear icon (shown when present)
+  # @param sign_out_url [String] URL for sign-out action
+  # @param sign_out_method [Symbol] HTTP method for sign-out (default: :delete)
+  # @param profile_url [String] Optional URL for user profile link
+  # @param logo_text [String] Logo text (default: "MARKAZ")
+  # @param logo_href [String] Logo link URL (default: first visible section's href or "/")
+  # @param logo_mark [String] Custom logo mark markup (trusted SVG/image); default renders the Markaz diamond
 end
 ```
+
+### Subsection visibility
+
+Each subsection hash supports an optional `visible:` key (default `true`), mirroring the
+top-level `sections`. A subsection with `visible: false` is filtered out of the sub-nav; when
+every subsection of the active section is hidden, the sub-nav bar is not rendered at all.
+
+### Custom logo mark
+
+`logo_mark:` overrides the default Markaz diamond with caller-supplied markup (an SVG or
+`<img>`). It accepts **trusted, developer-authored markup only** — a non-`html_safe` string is
+escaped and rendered as text, so pass `.html_safe` markup you control, never user input. A blank
+value (`nil` or `""`) falls back to the default mark. Supply your own decorative or labeled
+accessibility semantics (e.g. `aria-hidden="true"` for a mark paired with the visible logo text).
 
 ## Bootstrap Classes
 

--- a/catalog/layouts/app-shell.md
+++ b/catalog/layouts/app-shell.md
@@ -10,7 +10,7 @@ Global application frame used on every page of every MPI app. Provides the Nexus
 
 ## Design Decisions
 
-- **Brand mark:** Nexus SVG diamond logo (navy `#1B2A4A` arms + primary blue `#2E75B6` center diamond) + "MARKAZ" text (`font-weight: 300`, `letter-spacing: 0.12em`, `color: #1B2A4A`). NOT "X MARKAZ" text -- corrected after design review
+- **Brand mark:** Nexus SVG diamond logo (navy arms + primary blue center diamond) + "MARKAZ" text (`font-weight: 300`, `letter-spacing: 0.12em`, `color: #1B2A4A`). NOT "X MARKAZ" text -- corrected after design review. The default mark's fills are token-sourced (`.mds-navbar__brand-arm` → `$mpi-brand-navy`, `.mds-navbar__brand-center` → `$mpi-primary`, with a `currentColor` fallback), not hardcoded hex. Callers can override the whole mark by forwarding `logo_mark:` to NavBar
 - **White background:** Canonical style (V2). Both top bar and sub-nav use white background with bottom border (`#DEE2E6`)
 - **Top bar height:** 52px. Sub-nav height: 42px
 - **Level 1 nav:** 6 items -- Dashboard, Content, CRM, Rights & Avails, Releases, Screenings
@@ -55,6 +55,7 @@ class MpiDesignSystem::Admin::AppShell::Component < ViewComponent::Base
   # @param search_url [String] Global search action URL
   # @param search_placeholder [String] Contextual placeholder text
   # @param show_sidebar [Boolean] Whether to show the content sidebar (default: false)
+  # @param logo_mark [String] Custom logo mark markup (trusted SVG/image); forwarded to NavBar, default renders the Markaz diamond
   #
   # Renders content via a block/slot:
   # renders_one :sidebar  # Optional sidebar slot

--- a/spec/components/mpi_design_system/admin/app_shell/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/app_shell/component_spec.rb
@@ -151,5 +151,31 @@ RSpec.describe MpiDesignSystem::Admin::AppShell::Component, type: :component do
 
       expect(page).to have_css("input[placeholder='Search...']")
     end
+
+    it "forwards a custom logo mark to NavBar" do
+      render_inline(described_class.new(
+        current_section: :dashboard,
+        logo_mark: '<svg class="app-mark"><rect width="10" height="10"/></svg>'.html_safe
+      ))
+
+      expect(page).to have_css("svg.app-mark")
+      expect(page).not_to have_css("svg[viewbox='0 0 22 26']")
+    end
+
+    it "forwards subsection visibility to NavBar" do
+      render_inline(described_class.new(
+        current_section: :crm,
+        sections: [ { key: :crm, label: "CRM", href: "/crm" } ],
+        subsections: { crm: [
+          { key: :alpha, label: "Alpha Sub", href: "/crm/alpha" },
+          { key: :beta, label: "Beta Sub", href: "/crm/beta", visible: false }
+        ] }
+      ))
+
+      within("nav[aria-label='Section navigation']") do
+        expect(page).to have_link("Alpha Sub")
+        expect(page).not_to have_link("Beta Sub")
+      end
+    end
   end
 end

--- a/spec/components/mpi_design_system/admin/nav_bar/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/nav_bar/component_spec.rb
@@ -345,8 +345,13 @@ RSpec.describe MpiDesignSystem::Admin::NavBar::Component, type: :component do
       render_inline(described_class.new(current_section: :dashboard))
 
       expect(page).to have_css("a.mds-navbar__brand svg[viewbox='0 0 22 26'][aria-hidden='true']")
+      expect(page).to have_css("a.mds-navbar__brand svg[width='20'][height='24']")
       expect(page).to have_css("a.mds-navbar__brand svg polygon.mds-navbar__brand-arm[fill='currentColor']", count: 4)
       expect(page).to have_css("a.mds-navbar__brand svg polygon.mds-navbar__brand-center[fill='currentColor']", count: 1)
+      # Pin the geometry that STAYED through the tokenization — the fills moved to CSS but the
+      # points did not. Without these, deleting every `points` attribute ships green.
+      expect(page).to have_css("polygon.mds-navbar__brand-center[points='11,11 13,13 11,15 9,13']")
+      expect(page).to have_css("polygon.mds-navbar__brand-arm[points='1,0 6,0 12.5,11 10.5,13']")
       expect(page).not_to have_css("polygon[fill='#1B2A4A']")
       expect(page).not_to have_css("polygon[fill='#2E75B6']")
     end

--- a/spec/components/mpi_design_system/admin/nav_bar/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/nav_bar/component_spec.rb
@@ -313,6 +313,91 @@ RSpec.describe MpiDesignSystem::Admin::NavBar::Component, type: :component do
     end
   end
 
+  describe "custom logo mark" do
+    it "renders a provided logo mark instead of the default Markaz mark" do
+      render_inline(described_class.new(
+        current_section: :dashboard,
+        logo_mark: '<svg class="custom-mark"><rect width="10" height="10"/></svg>'.html_safe
+      ))
+
+      expect(page).to have_css("a.mds-navbar__brand svg.custom-mark")
+      expect(page).not_to have_css("a.mds-navbar__brand svg[viewbox='0 0 22 26']")
+    end
+
+    it "falls back to the default Markaz mark when logo_mark is blank" do
+      render_inline(described_class.new(current_section: :dashboard, logo_mark: ""))
+
+      expect(page).to have_css("a.mds-navbar__brand svg[viewbox='0 0 22 26'] polygon.mds-navbar__brand-center")
+    end
+
+    it "does not treat a non-html_safe logo_mark string as raw HTML" do
+      render_inline(described_class.new(current_section: :dashboard, logo_mark: "<b>x</b>"))
+
+      within("a.mds-navbar__brand") do
+        expect(page).to have_text("<b>x</b>")
+        expect(page).not_to have_css("b")
+      end
+    end
+  end
+
+  describe "default logo mark (tokenized)" do
+    it "sources the mark fills from tokens with no hardcoded brand hex" do
+      render_inline(described_class.new(current_section: :dashboard))
+
+      expect(page).to have_css("a.mds-navbar__brand svg[viewbox='0 0 22 26'][aria-hidden='true']")
+      expect(page).to have_css("a.mds-navbar__brand svg polygon.mds-navbar__brand-arm[fill='currentColor']", count: 4)
+      expect(page).to have_css("a.mds-navbar__brand svg polygon.mds-navbar__brand-center[fill='currentColor']", count: 1)
+      expect(page).not_to have_css("polygon[fill='#1B2A4A']")
+      expect(page).not_to have_css("polygon[fill='#2E75B6']")
+    end
+  end
+
+  describe "subsection visible: filtering" do
+    let(:crm_sections) { [ { key: :crm, label: "CRM", href: "/crm" } ] }
+
+    it "hides a subsection marked visible: false" do
+      render_inline(described_class.new(
+        current_section: :crm,
+        sections: crm_sections,
+        subsections: { crm: [
+          { key: :alpha, label: "Alpha Sub", href: "/crm/alpha" },
+          { key: :beta, label: "Beta Sub", href: "/crm/beta", visible: false }
+        ] }
+      ))
+
+      within("nav[aria-label='Section navigation']") do
+        expect(page).to have_link("Alpha Sub", href: "/crm/alpha")
+        expect(page).not_to have_link("Beta Sub")
+      end
+    end
+
+    it "renders a subsection with no :visible key (defaults to visible)" do
+      render_inline(described_class.new(
+        current_section: :crm,
+        sections: crm_sections,
+        subsections: { crm: [ { key: :alpha, label: "Alpha Sub", href: "/crm/alpha" } ] }
+      ))
+
+      within("nav[aria-label='Section navigation']") do
+        expect(page).to have_link("Alpha Sub", href: "/crm/alpha")
+      end
+    end
+
+    it "hides the entire sub-nav when every subsection is not visible" do
+      render_inline(described_class.new(
+        current_section: :crm,
+        sections: crm_sections,
+        subsections: { crm: [
+          { key: :alpha, label: "Alpha Sub", href: "/crm/alpha", visible: false },
+          { key: :beta, label: "Beta Sub", href: "/crm/beta", visible: false }
+        ] }
+      ))
+
+      expect(page).to have_css("a.mds-navbar__section-link--active", text: "CRM")
+      expect(page).not_to have_css("nav[aria-label='Section navigation']")
+    end
+  end
+
   describe "regression: profile_url without sign_out_url" do
     it "does not render sign out link when only profile_url is provided" do
       render_inline(described_class.new(

--- a/spec/components/previews/mpi_design_system/admin/app_shell/component_preview/custom_crm_app.html.erb
+++ b/spec/components/previews/mpi_design_system/admin/app_shell/component_preview/custom_crm_app.html.erb
@@ -7,6 +7,7 @@
   sections: sections,
   subsections: subsections,
   logo_text: logo_text,
+  logo_mark: '<svg width="20" height="24" viewBox="0 0 24 24" fill="#4EA8DE" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><rect x="2" y="2" width="20" height="20" rx="4"/></svg>'.html_safe,
   system_url: system_url,
   sign_out_url: sign_out_url,
   profile_url: profile_url,

--- a/spec/components/previews/mpi_design_system/admin/nav_bar/component_preview.rb
+++ b/spec/components/previews/mpi_design_system/admin/nav_bar/component_preview.rb
@@ -95,4 +95,27 @@ class MpiDesignSystem::Admin::NavBar::ComponentPreview < ApplicationComponentPre
       profile_url: "/profile"
     )
   end
+
+  # @label Custom Logo Mark
+  def custom_logo_mark
+    render MpiDesignSystem::Admin::NavBar::Component.new(
+      current_section: :dashboard,
+      logo_text: "HARVEST",
+      logo_mark: '<svg width="20" height="24" viewBox="0 0 24 24" fill="#4EA8DE" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><rect x="2" y="2" width="20" height="20" rx="4"/></svg>'.html_safe
+    )
+  end
+
+  # @label Subsection Visibility
+  def subsection_visibility
+    render MpiDesignSystem::Admin::NavBar::Component.new(
+      current_section: :crm,
+      current_subsection: :contacts,
+      sections: [ { key: :crm, label: "CRM", href: "/crm" } ],
+      subsections: { crm: [
+        { key: :contacts, label: "Contacts", href: "/crm/contacts" },
+        { key: :accounts, label: "Accounts", href: "/crm/accounts" },
+        { key: :secret, label: "Hidden (visible: false)", href: "/crm/secret", visible: false }
+      ] }
+    )
+  end
 end

--- a/spec/dummy/app/assets/stylesheets/application.scss
+++ b/spec/dummy/app/assets/stylesheets/application.scss
@@ -3,3 +3,7 @@
 @import "mpi_design_system/tokens";
 @import "bootstrap/scss/bootstrap";
 @import "bootstrap-icons/font/bootstrap-icons";
+// Component CSS — the tokenized NavBar brand mark degrades to monochrome without it
+// (_nav_bar.scss maps .mds-navbar__brand-arm/-center onto $mpi-brand-navy / $mpi-primary).
+// Loaded last so both $danger (Bootstrap) and the $mpi-* tokens are already in scope. (#155)
+@import "mpi_design_system/nav_bar";

--- a/spec/dummy/app/views/contrast_demo/show.html.erb
+++ b/spec/dummy/app/views/contrast_demo/show.html.erb
@@ -69,6 +69,14 @@
         ) %>
   </section>
 
+  <%# NavBar brand mark (#155) — the tokenized default diamond. Rendered against the
+      compiled bundle (which now imports _nav_bar.scss) so the spec can read the COMPUTED
+      fill of each polygon and prove the arm/center classes resolve to their tokens rather
+      than falling back to the monochrome currentColor. %>
+  <section id="nav-bar-mark" class="mb-4">
+    <%= render MpiDesignSystem::Admin::NavBar::Component.new(current_section: :dashboard) %>
+  </section>
+
   <%# Same components under Bootstrap's dark colour mode. ActiveFilterBar pins a
       light background, so a theme-aware foreground would render light-on-light
       (1.16:1) unless the component pins its colour mode too. (#130) %>

--- a/spec/features/contrast_spec.rb
+++ b/spec/features/contrast_spec.rb
@@ -365,6 +365,33 @@ RSpec.describe "Derived foreground contrast", type: :feature, js: true do
     end
   end
 
+  # NavBar brand mark (#155). The default diamond's fills were tokenized from inline hex to
+  # `.mds-navbar__brand-arm`/`.mds-navbar__brand-center` classes (mapped to $mpi-brand-navy /
+  # $mpi-primary) with a `currentColor` fallback in markup. render_inline proves the classes
+  # and `fill="currentColor"` are emitted; only a browser proves the author CSS class wins over
+  # the presentation attribute and paints the two-tone. The load-bearing assertion is the
+  # CENTER: currentColor would fall back to the brand navy, so center == primary is exactly what
+  # distinguishes "the .mds-navbar__brand-center rule resolved" from "the fallback painted".
+  describe "NavBar brand mark" do
+    def fill_of(selector)
+      page.evaluate_script(
+        "(() => { const e = document.querySelector(#{selector.to_json}); " \
+        "if (!e) throw new Error('no element matched'); " \
+        "return getComputedStyle(e).fill; })()"
+      )
+    end
+
+    it "paints the arm polygons navy from $mpi-brand-navy, not the monochrome fallback" do
+      expect(page).to have_css("#nav-bar-mark polygon.mds-navbar__brand-arm")
+      expect(fill_of("#nav-bar-mark polygon.mds-navbar__brand-arm")).to eq("rgb(27, 42, 74)")
+    end
+
+    it "paints the center polygon primary from $mpi-primary — the value the currentColor fallback cannot produce" do
+      expect(page).to have_css("#nav-bar-mark polygon.mds-navbar__brand-center")
+      expect(fill_of("#nav-bar-mark polygon.mds-navbar__brand-center")).to eq("rgb(46, 117, 182)")
+    end
+  end
+
   describe "muted text" do
     it "paints the ActiveFilterBar label above the AA floor against the bar" do
       foreground = computed("#active-filter-bar .text-body-secondary", "color")


### PR DESCRIPTION
## Summary
Closes #155. Part of #147. Fills two additive gaps in the NavBar public API,
forwarded through AppShell so every consuming app (Markaz, SFA, Garden, Harvest)
can use them: (1) a `logo_mark:` keyword to override the default brand mark, and
(2) subsection `visible:` filtering, which the component previously accepted in a
subsection hash but silently ignored. The default mark's fills are tokenized in
the same change, removing the last hardcoded brand hex from the component.

## Changes Made
- `app/components/mpi_design_system/admin/nav_bar/component.rb`
  - New `logo_mark: nil` param + `@logo_mark`, with YARD doc.
  - `current_subsections` now filters on `s.fetch(:visible, true)`, mirroring
    `visible_sections`.
  - `markaz_logo_svg` arms/center polygons emit `class="mds-navbar__brand-arm|center"`
    + `fill="currentColor"` instead of hardcoded `#1B2A4A` / `#2E75B6`.
- `app/components/mpi_design_system/admin/nav_bar/component.html.erb`
  - Brand renders `@logo_mark.presence || markaz_logo_svg`.
- `app/components/mpi_design_system/admin/app_shell/component.rb`
  - New `logo_mark:` param forwarded via `nav_bar_options`.
- `app/assets/stylesheets/mpi_design_system/_nav_bar.scss`
  - `.mds-navbar__brand-arm { fill: $mpi-brand-navy; }` and
    `.mds-navbar__brand-center { fill: $mpi-primary; }`.
- Specs, Lookbook previews, and catalog docs (`catalog/components/navbar.md`,
  `catalog/layouts/app-shell.md`) updated to match.

## Technical Approach
- **Additive, non-breaking:** both features default to today's behavior — a nil/blank
  `logo_mark` renders the Markaz diamond; a subsection with no `:visible` key defaults
  to visible.
- **Tokenized fills, not inline hex:** the SVG uses `currentColor` in markup and
  `_nav_bar.scss` maps the two brand classes onto `$mpi-brand-navy` / `$mpi-primary`,
  keeping the mark on the MPI palette (this component ships compiled with MPI's tokens).
  A `currentColor` fallback in markup keeps the mark visible even where the component
  stylesheet isn't loaded.
- **Safe custom markup:** `logo_mark:` is documented as trusted developer-authored
  markup; a non-`html_safe` string is escaped, proven by spec.

## Testing
- `bundle exec rubocop -a` — 157 files, 0 offenses.
- `bundle exec rspec` — 942 examples, 0 failures; preview-render sweep 137/0.
- 11 new examples (9 component-spec + 2 preview scenarios). Each `not_to` assertion
  is paired with a positive control; the tokenization spec guards both what stayed
  (`currentColor` classes, counts 4 + 1, `aria-hidden`) and what left (no `#1B2A4A` /
  `#2E75B6`).
- Engine-SCSS token check compiled the legacy `@import` path and asserted
  `mds-navbar__brand-center{fill:#2e75b6}` and `mds-navbar__brand-arm{fill:#1b2a4a}`
  in the compiled CSS; mutation-tested by deleting the center rule (grep went empty)
  and restoring it (grep matched again). Note: `yarn build:css` compiles the dummy
  app, which does not import `_nav_bar.scss`, so this token wiring is verified against
  the engine stylesheet directly.

## Checklist
- [x] Tests pass
- [x] Linting passes

— Claude Code (Fable 5)

https://claude.ai/code/session_01JRbQdyx5akxuQiP5PUHe7t
