### PR TITLE
docs(contributing): document the release flow

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -270,6 +270,34 @@ fail *closed*, which is luck rather than design. The instructive part is the sel
 the author executed the gate whose logic he doubted and skipped the line that looked obvious,
 so the doubted line got fixed and the obvious one shipped broken. Run all of them.
 
+**Verifying the gate is not verifying the value it reads.** #163 documented a release runbook whose
+CI-green gate was the exact `sort -u` form above — already verified against
+`success`/`failure`/`skipped`/`cancelled`/`empty`. It still shipped **fail-open**, because the bug
+was in the command that *produces* `$CONCLUSIONS`, not in the gate. Two `gh` traps, both reproduced
+by execution:
+
+```bash
+# FAIL-OPEN — a still-running check has conclusion null, which gh renders as a BLANK line, and $()
+# strips a trailing blank, so [success, <pending>] collapses to "success" and the gate proceeds.
+CONCLUSIONS=$(gh api "$url" --jq '.check_runs[].conclusion')
+
+# CLOSED — map null to a non-success token so a pending check can't vanish; --paginate past the
+# 30-results-per-page default; and || abort, because gh streams pages and a mid-pagination failure
+# otherwise leaves a partial, green-looking list in the variable (VAR=$(cmd) ignores cmd's status).
+CONCLUSIONS=$(gh api --paginate "$url" --jq '.check_runs[] | .conclusion // "pending"') \
+  || { echo "ABORT: could not read CI checks"; exit 1; }
+```
+
+The bug the author cannot see is the one in the input, not the assertion. #163 shipped that
+fail-open plus a `git tag` that ran before the `git push` it should have gated — and the *first
+round of fixes* introduced two more (a substring `grep` version check that also matched
+`OLD_VERSION =` and treated `.` as a wildcard; `--paginate` swallowing a failed read). Every one
+was caught by an **independent model told to break the runbook**, across two rounds — none by the
+author's own failure-case tests, which were real but tested the cases the author already imagined.
+For a step awkward to retract, that second adversary is not optional polish; it is the layer that
+catches the fail-open you wrote and therefore cannot see. (The hardened block lives in
+`CONTRIBUTING.md` § Release.)
+
 ## Anti-Patterns
 
 - Never assert only that a component "renders without error" — that is a false green
@@ -281,6 +309,10 @@ so the doubted line got fixed and the obvious one shipped broken. Run all of the
 - Never publish a command, gate, or runbook step you have not executed against its failure
   case — a check in prose is still a check, and it is the kind no suite will ever run for you
   — see **A check written in documentation is still a check** above
+- Never assume that verifying a gate covers the command that produces its input — in #163 the
+  `sort -u` CI gate was sound while the `gh` producer feeding it silently dropped a still-running
+  check; the fail-open lived in the producer, and only an independent adversary caught it — see
+  **A check written in documentation is still a check** above
 - Never test private methods — test through the rendered output
 - Never reference models, the database, or request specs — the engine has none (browser
   feature specs exist, but only for genuine JS behavior — see Stack; default to `render_inline`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,9 +142,10 @@ A release is a single `chore(release): vX.Y.Z — <summary>` commit touching exa
 The `.gemspec` needs no edit — it reads the `VERSION` constant.
 
 - **`lib/mpi_design_system/version.rb`** — bump `VERSION`.
-- **`spec/packaging/version_spec.rb`** — update the `it "is X.Y.Z"` description **and** the
-  `expect(...).to eq("X.Y.Z")` (both literals are asserted), and add a one-line clause to the
-  release-lineage comment (house convention — the comment itself is not asserted).
+- **`spec/packaging/version_spec.rb`** — update the `expect(...).to eq("X.Y.Z")` (the only
+  asserted literal), the `it "is X.Y.Z"` example description (cosmetic — RSpec never compares it
+  to `VERSION`, so a stale one ships green; keep it honest anyway), and a one-line clause on the
+  release-lineage comment (also not asserted — house convention).
 - **`README.md`** — bump the `tag: "vX.Y.Z"` pin in **both** the Gemfile install example and the
   explanatory line beneath it.
 - **`CHANGELOG.md`** — the four edits below.
@@ -207,21 +208,25 @@ MERGE_SHA=$(gh pr view "$PR" --json mergeCommit --jq .mergeCommit.oid)
 [ -n "$MERGE_SHA" ] || { echo "ABORT: no merge commit (PR not merged?)"; exit 1; }
 
 # Gate: every check on the MERGE COMMIT must be green. check-runs gives per-job conclusions, so a
-# skipped job cannot hide behind a workflow-level roll-up. Fail closed on empty (no run yet) and on
-# any pending/failed/skipped/cancelled job.
-CONCLUSIONS=$(gh api "repos/mpimedia/mpi-design-system/commits/$MERGE_SHA/check-runs" \
-  --jq '.check_runs[].conclusion')
+# skipped job cannot hide behind a workflow-level roll-up. `--paginate` so a non-success beyond the
+# first 30 checks is not missed; `.conclusion // "pending"` maps a still-running check (null
+# conclusion, which gh would otherwise emit as a blank line that command substitution silently
+# trims) to a non-success token. Fails closed on empty, pending, or any non-success job.
+CONCLUSIONS=$(gh api --paginate "repos/mpimedia/mpi-design-system/commits/$MERGE_SHA/check-runs" \
+  --jq '.check_runs[] | .conclusion // "pending"')
 [ -n "$CONCLUSIONS" ] || { echo "ABORT: no CI checks for $MERGE_SHA"; exit 1; }
 [ "$(printf '%s\n' "$CONCLUSIONS" | sort -u)" = "success" ] \
   || { echo "ABORT: CI not all green -> $CONCLUSIONS"; exit 1; }
 
-# Sanity-check the version at that commit. BRACE the variable — a bare "$MERGE_SHA:lib/..." triggers
-# zsh's :l modifier and mangles the path into "<sha>ib/...".
-git show "${MERGE_SHA}:lib/mpi_design_system/version.rb"
+# Assert the version at that commit is the one you're tagging (substitute X.Y.Z). BRACE the
+# variable — a bare "$MERGE_SHA:lib/..." triggers zsh's :l modifier and mangles the path into
+# "<sha>ib/...". Fails closed if git show errors or the version does not match.
+git show "${MERGE_SHA}:lib/mpi_design_system/version.rb" | grep -q 'VERSION = "X.Y.Z"' \
+  || { echo "ABORT: version.rb at $MERGE_SHA is not X.Y.Z"; exit 1; }
 
-# Lightweight tag on the merge commit, then push it.
-git tag "vX.Y.Z" "$MERGE_SHA"
-git push origin "vX.Y.Z"
+# Lightweight tag on the merge commit, then push it — chained so a failed tag (e.g. one that
+# already exists at the wrong commit) never reaches the push.
+git tag "vX.Y.Z" "$MERGE_SHA" && git push origin "vX.Y.Z"
 ```
 
 - Resolve `$MERGE_SHA` from the PR's own `mergeCommit`, **not** `git rev-parse origin/main` — `main`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,17 +211,22 @@ MERGE_SHA=$(gh pr view "$PR" --json mergeCommit --jq .mergeCommit.oid)
 # skipped job cannot hide behind a workflow-level roll-up. `--paginate` so a non-success beyond the
 # first 30 checks is not missed; `.conclusion // "pending"` maps a still-running check (null
 # conclusion, which gh would otherwise emit as a blank line that command substitution silently
-# trims) to a non-success token. Fails closed on empty, pending, or any non-success job.
+# trims) to a non-success token. The `|| exit` catches a mid-pagination gh failure that would
+# otherwise leave a partial, falsely-green list. Fails closed on empty, pending, or non-success.
 CONCLUSIONS=$(gh api --paginate "repos/mpimedia/mpi-design-system/commits/$MERGE_SHA/check-runs" \
-  --jq '.check_runs[] | .conclusion // "pending"')
+  --jq '.check_runs[] | .conclusion // "pending"') \
+  || { echo "ABORT: could not read CI checks for $MERGE_SHA"; exit 1; }
 [ -n "$CONCLUSIONS" ] || { echo "ABORT: no CI checks for $MERGE_SHA"; exit 1; }
 [ "$(printf '%s\n' "$CONCLUSIONS" | sort -u)" = "success" ] \
   || { echo "ABORT: CI not all green -> $CONCLUSIONS"; exit 1; }
 
-# Assert the version at that commit is the one you're tagging (substitute X.Y.Z). BRACE the
-# variable — a bare "$MERGE_SHA:lib/..." triggers zsh's :l modifier and mangles the path into
-# "<sha>ib/...". Fails closed if git show errors or the version does not match.
-git show "${MERGE_SHA}:lib/mpi_design_system/version.rb" | grep -q 'VERSION = "X.Y.Z"' \
+# Assert the version at that commit is exactly the one you're tagging (substitute X.Y.Z). Capture
+# git show separately so its own failure aborts; BRACE the variable — a bare "$MERGE_SHA:lib/..."
+# triggers zsh's :l modifier and mangles the path. Match the whole line as a fixed string
+# (grep -qxF) so a comment, an `OLD_VERSION =`, or the "." wildcard can't false-match.
+VERSION_RB=$(git show "${MERGE_SHA}:lib/mpi_design_system/version.rb") \
+  || { echo "ABORT: cannot read version.rb at $MERGE_SHA"; exit 1; }
+printf '%s\n' "$VERSION_RB" | grep -qxF '  VERSION = "X.Y.Z"' \
   || { echo "ABORT: version.rb at $MERGE_SHA is not X.Y.Z"; exit 1; }
 
 # Lightweight tag on the merge commit, then push it — chained so a failed tag (e.g. one that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,3 +124,116 @@ feat(catalog): add button component spec
 
 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 ```
+
+## Release
+
+The gem is released by cutting a **git tag** — there is no RubyGems publish. Consuming apps
+resolve the gem from GitHub and pin to a tag (see the README install snippet), so **the tag is
+the only release artifact**. Versions follow [SemVer](https://semver.org/) with a **pre-1.0
+caveat: minor bumps may include breaking changes** (as stated at the top of `CHANGELOG.md`). Cut
+**one release per shipped unit** — typically the feature or fix PR you just merged. History has
+varied (`v0.7.0` batched three runtime changes; `v0.8.0` folded its release commit into the
+feature PR), and a documentation-only change — like this very section — may ride the next runtime
+release rather than getting its own, since `CONTRIBUTING.md` is not shipped in the gem.
+
+### What a release changes
+
+A release is a single `chore(release): vX.Y.Z — <summary>` commit touching exactly **four** files.
+The `.gemspec` needs no edit — it reads the `VERSION` constant.
+
+- **`lib/mpi_design_system/version.rb`** — bump `VERSION`.
+- **`spec/packaging/version_spec.rb`** — update the `it "is X.Y.Z"` description **and** the
+  `expect(...).to eq("X.Y.Z")` (both literals are asserted), and add a one-line clause to the
+  release-lineage comment (house convention — the comment itself is not asserted).
+- **`README.md`** — bump the `tag: "vX.Y.Z"` pin in **both** the Gemfile install example and the
+  explanatory line beneath it.
+- **`CHANGELOG.md`** — the four edits below.
+
+### The four CHANGELOG edits
+
+`spec/packaging/changelog_spec.rb` enforces that every `## [x]` heading has a matching `[x]:` link
+definition and vice versa (an exact multiset), that `## [Unreleased]` is always present with its
+own definition, and that the current `VERSION` has its own `## [VERSION]` heading. Cutting
+`vX.Y.Z` (previous tag `vP.Q.R`) therefore means all four of:
+
+```markdown
+## [Unreleased]                       ← 2. keep this heading (leaving it empty is fine)
+
+## [X.Y.Z] - YYYY-MM-DD               ← 1. add, dated; POPULATE from the shipped unit's changes
+
+... (existing dated sections) ...
+
+[Unreleased]: https://github.com/mpimedia/mpi-design-system/compare/vX.Y.Z...HEAD   ← 4. re-aim
+[X.Y.Z]: https://github.com/mpimedia/mpi-design-system/compare/vP.Q.R...vX.Y.Z      ← 3. add
+```
+
+**The spec checks label _coverage_, not correctness.** It will not catch a wrong compare-URL
+range, a wrong date, or an **empty** `## [X.Y.Z]` section — so populate the entry from the commits
+since the previous tag, and eyeball the URLs and date yourself. For the date, use the day you
+author the release commit (the merge day in a normal same-day flow); if the PR lingers past
+midnight, amend the date before tagging.
+
+### Cutting the release
+
+1. **Branch from fresh `main`** so the shipped unit's `[Unreleased]` notes are present:
+   ```bash
+   git fetch origin
+   git switch -c release/vX.Y.Z origin/main
+   ```
+2. Make the four-file `chore(release): vX.Y.Z — <summary>` commit, then run both required checks —
+   the packaging specs must pass on the new version:
+   ```bash
+   bundle exec rubocop -a
+   bundle exec rspec
+   ```
+3. Open the release PR and **wait for CI to pass on it**.
+
+### Tagging (the fragile part — gate it on CI)
+
+CI runs on branch pushes but **not on tag pushes** (`.github/workflows/ci.yml` has no `tags:`
+filter, and `main` has no branch protection), so **a pushed tag runs no CI of its own**. Gate the
+tag on the merge commit's checks already being green. Every command below is verified against its
+failure case; see `.claude/rules/testing.md` §"A check written in documentation is still a check"
+for why they are shaped this way — and run any change to them against its failure case before you
+commit it.
+
+After the PR merges:
+
+```bash
+git fetch origin   # gh returns a SHA from GitHub; fetch puts that commit object in your local repo
+
+PR=<pr-number>
+MERGE_SHA=$(gh pr view "$PR" --json mergeCommit --jq .mergeCommit.oid)
+[ -n "$MERGE_SHA" ] || { echo "ABORT: no merge commit (PR not merged?)"; exit 1; }
+
+# Gate: every check on the MERGE COMMIT must be green. check-runs gives per-job conclusions, so a
+# skipped job cannot hide behind a workflow-level roll-up. Fail closed on empty (no run yet) and on
+# any pending/failed/skipped/cancelled job.
+CONCLUSIONS=$(gh api "repos/mpimedia/mpi-design-system/commits/$MERGE_SHA/check-runs" \
+  --jq '.check_runs[].conclusion')
+[ -n "$CONCLUSIONS" ] || { echo "ABORT: no CI checks for $MERGE_SHA"; exit 1; }
+[ "$(printf '%s\n' "$CONCLUSIONS" | sort -u)" = "success" ] \
+  || { echo "ABORT: CI not all green -> $CONCLUSIONS"; exit 1; }
+
+# Sanity-check the version at that commit. BRACE the variable — a bare "$MERGE_SHA:lib/..." triggers
+# zsh's :l modifier and mangles the path into "<sha>ib/...".
+git show "${MERGE_SHA}:lib/mpi_design_system/version.rb"
+
+# Lightweight tag on the merge commit, then push it.
+git tag "vX.Y.Z" "$MERGE_SHA"
+git push origin "vX.Y.Z"
+```
+
+- Resolve `$MERGE_SHA` from the PR's own `mergeCommit`, **not** `git rev-parse origin/main` — `main`
+  is mutable and may have already advanced to another PR's work.
+- Tag the explicit SHA. Do **not** `git checkout main` — `main` is checked out in the parent
+  worktree, so the checkout fails from inside a worktree.
+- Never run `rake release` — it invokes Bundler's RubyGems push task, and this gem is not
+  published to RubyGems.
+
+### Notify consumers
+
+The tag is live, but no consumer moves until its pin is bumped. Tell each consuming app (Markaz,
+SFA, Garden, Harvest) to bump the `tag: "vX.Y.Z"` pin in its Gemfile (syntax is in this repo's
+README install section). Harvest's own bump procedure lives in its `.claude/rules/backend.md`
+("Git-Sourced Gem Pins").

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,7 +202,7 @@ After the PR merges:
 ```bash
 git fetch origin   # gh returns a SHA from GitHub; fetch puts that commit object in your local repo
 
-PR=<pr-number>
+PR=NNN   # the merged release PR's number
 MERGE_SHA=$(gh pr view "$PR" --json mergeCommit --jq .mergeCommit.oid)
 [ -n "$MERGE_SHA" ] || { echo "ABORT: no merge commit (PR not merged?)"; exit 1; }
 


### PR DESCRIPTION
## Summary

Documents the gem's release flow in `CONTRIBUTING.md` — **Phase 8 of epic #147**. Until now the mechanics lived only as git-history precedent (PRs #126/#132/#135, and the v0.7.0/v0.8.0 cuts) plus cautionary detail in `.claude/rules/testing.md`; there was no runbook. This adds a self-contained `## Release` section so a releaser can cut a version correctly without reconstructing the procedure from commit archaeology.

This is a documentation-only change: `git diff --stat` is `CONTRIBUTING.md | 113 ++++`, zero code. Not ecosystem-propagating (no runtime dependency, component API, token, or gem-packaging change).

## Changes Made

- **`CONTRIBUTING.md`** — appended a `## Release` section after `## Commit Messages`, covering:
  - The tag-is-the-only-artifact model (no RubyGems publish) and the pre-1.0 SemVer caveat.
  - **The exact four files a release touches** — `lib/mpi_design_system/version.rb`, `spec/packaging/version_spec.rb` (both asserted literals + the lineage comment), `README.md` (the `tag:` pin), `CHANGELOG.md` — and that the gemspec needs no edit.
  - **The four CHANGELOG edits** the `changelog_spec.rb` multiset guard enforces, as a worked before/after, plus an explicit callout of what the spec does **not** catch (compare-URL range, date, an empty entry).
  - **The tagging step gated on the merge commit's CI**, because `ci.yml` has no `tags:` filter so a pushed tag runs no CI of its own — with the zsh-brace, per-job-conclusions, and `mergeCommit`-not-`origin/main` traps documented inline.
  - Consumer notification (bump the `tag:` pin; Harvest's external procedure).

## Technical Approach

Chose a **self-contained runbook** (over delegating the fragile shell to `testing.md` by reference) so the procedure never has to be left mid-release; `testing.md` remains the *doctrine*, `CONTRIBUTING.md` becomes the *procedure*.

Per the repo's "a check written in documentation is still a check" doctrine, **every shell snippet in the section was executed against its failure case before publishing** — reasoning about them is not enough here, given two prior releases shipped broken gates in prose (#148's BSD `grep -qv`, #157's zsh `${MERGE_SHA}`):

| Snippet | Verified |
|---|---|
| CI-green gate (`sort -u` == `success`) | aborts on failure / skipped / cancelled / empty; proceeds only all-green |
| `$CONCLUSIONS` producer (check-runs API) | returns **per-job** conclusions (3× `success` on `be7bd32`) — a skipped job can't hide behind a roll-up |
| Merge-SHA resolver | **fails closed** (empty → abort) on a real closed-unmerged PR (#82) and a nonexistent PR |
| Braced `${MERGE_SHA}` `git show` | unbraced mangles via zsh `:l`; braced resolves to `VERSION = "0.7.0"` |
| tag-on-SHA + push | disposable repo + bare remote → lightweight tag (type `commit`) on the intended SHA |

The four-file list (incl. `README.md`, which the plan initially missed) was confirmed against the actual `be7bd32` (v0.8.0) and `18d9ca7` (v0.7.0) release commits — a correction Codex raised in plan review.

## Testing

- `bundle exec rubocop -a` — **157 files, no offenses**.
- `bundle exec rspec` — **931 examples, 0 failures**. (A fresh worktree with no `node_modules` fails ~54 `spec/features/` specs on `yarn build`; a routine `yarn install` clears them — the documented non-regression, unrelated to this docs change.)
- The section's own commands were verified against their failure cases (table above) — that verification *is* the definition of done for a docs change that ships executable procedure.

## Checklist

- [x] Tests pass (`bundle exec rspec` — 931/0)
- [x] Linting passes (`bundle exec rubocop -a` — 0 offenses)
- [x] Every shell snippet executed against its failure case before publishing
- [x] Four-file release list verified against real release commits
- [x] Documentation-only; no component/spec/token/packaging change

Closes #156
Part of #147

— Claude Code (Fable 5)

https://claude.ai/code/session_014D2XDo1UJY6tLPjktfJULS
