### PR TITLE
Convert StatCard, AvatarStack, ActiveFilterBar to theme-adaptive utilities + v0.9.0 (#150 phase 2)

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -83,6 +83,20 @@ routinely survive a narrow sweep and ship green:
   and added `.mds-navbar__brand-arm { fill: $mpi-brand-navy }` / `-center { fill: $mpi-primary }` —
   two fresh frozen fills the rebase surfaced, which #154 then had to convert too, and whose
   per-selector bindings the compile guard had to grow.)
+- **An inline-styled component may already have browser contrast coverage that pins the old hex —
+  sweep `spec/features/` and `spec/dummy/**/contrast_demo` before converting, not just `app/**` and
+  the render specs.** The `contrast_demo`/`contrast_spec` pattern (#130, #155) renders a component in
+  a real browser and asserts its *computed* colours, so a conversion that changes those colours
+  breaks the feature spec's hardcoded assertions — and an exploration sweep that greps only `app/**`
+  + `spec/components/**` never sees them. `git grep` the component name **and** the old hex across
+  `spec/features/**` and the `contrast_demo` fixture, and update the pinned computed values (surface,
+  foreground, ratio) in the same change. A conversion that reverses a previously *documented*
+  decision must also rewrite that decision's rationale (comments, the changelog, and the feature spec
+  that encoded it), not just the code. (Reference: #150 converted `ActiveFilterBar`'s `#F5F7FA` bar;
+  `spec/features/contrast_spec.rb` asserted `background == "#F5F7FA"` in two places — missed by the
+  initial code exploration, caught only by external review — and the conversion had to reverse #130's
+  `data-bs-theme="light"` pin and re-pin the adaptive `#E9ECEF`/`#343A40` surface the browser now
+  paints.)
 
 ## Component Catalog First
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -195,6 +195,29 @@ lives: a per-selector compile guard (`bin/verify-nav-bar-adaptive`, run from
 modes — each proven by breaking it. Do not add a `render_inline` colour assertion for a partial
 conversion; it cannot see CSS. (#154.)
 
+**Related — a browser contrast spec must pin the painted *foreground*, not only the ratio.** A
+computed-style assertion of the shape `ratio(fg, bg) >= 4.5` — reading `fg` from the element that
+*should* carry the colour class — false-greens if that class stops applying: the element falls back
+to inherited body text, which usually also clears AA against the same surface, so the ratio still
+passes while the intended token has silently stopped driving the colour. Pin the *value* the class
+must paint (`expect(computed(sel, "color")).to eq("#4F5B73")`) beside the ratio. The #149 pilot
+already does this ("asserting the painted value as well as the ratio, because inherited body text
+clears AA in both modes and would make a ratio-only assertion a false green"); it is a named rule
+now because #150 regressed below it — its two new `ActiveFilterBar` browser checks asserted surface
++ ratio only, and external review had to restore the foreground pins (`#4F5B73` light / `#B4B8BD`
+dark, both Chrome-measured). (#150.)
+
+**Related — when a component legitimately keeps one hex (no Bootstrap equivalent), guard it by
+parsing declarations, not by string-deleting the allowed value before a residual sweep.** A sweep of
+the shape "delete the permitted hex from the style, then assert no hex remains" false-greens on the
+*same* hex reused in another property: deleting every `#64748B` also deletes an unwanted
+`outline: 1px solid #64748B`. Parse the style into declarations, assert the exact permitted
+`property: value` pairs are present (`contain_exactly("background-color: #64748B", "color: #fff")`),
+and reject a hex literal in every *other* declaration — then a stray hex in a new property reddens.
+Prove it by adding one and watching red. (Reference: #150 — `AvatarStack` keeps `#64748B` for the
+`+N` overflow chip; the first residual sweep string-deleted it and would have masked the same hex
+reused elsewhere, caught by external review.)
+
 ## A Guard Is Not Real Until You Have Watched It Fail
 
 The two shapes above are assertions that *can* fail but don't discriminate. This is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,33 @@ include breaking changes).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-22
+
 ### Changed
+- **`Admin::StatCard`, `Admin::AvatarStack`, and `Admin::ActiveFilterBar` are theme-adaptive** —
+  the three components no longer pin a light palette in inline styles; every colour now resolves
+  from a Bootstrap semantic utility, so each follows `data-bs-theme` and the consuming app's mapped
+  tokens. **StatCard**: the card is `bg-body border rounded-3` (was `#fff` / `1px solid #DEE2E6` /
+  `border-radius: 8px` — `rounded-3` is `--bs-border-radius-lg` = 8px, so the radius is preserved),
+  the label `text-body-secondary` (was `#6C757D`), the value `text-body` or, when `alert:`,
+  `text-danger` (was `#1B2A4A` / `#DC3545`), and the trend `text-success-emphasis` /
+  `text-danger-emphasis` / `text-body-secondary` (was `#22A06B` / `#DC3545` / `#6C757D`). The trend
+  uses the `-emphasis` variants deliberately: at 12px (small text, AA 4.5:1) base `.text-success`
+  (3.33:1 on the light card) and `.text-danger` (3.41:1 on the dark card) both fail the floor and
+  do not follow the colour mode, while the emphasis tokens pass (7.7–13.7:1) and adapt — a contrast
+  improvement, like the pilot's results text. The 32px value keeps base `.text-danger` for alerts
+  (large text, AA 3:1, and semantically red in both modes). **AvatarStack**: the `+N` overflow
+  chip's separator ring moves from `#fff` to `var(--bs-body-bg)`, so it tracks the surface in
+  either colour mode; the chip's own `#64748B` background (`$mpi-tag-internal`, which has no
+  Bootstrap semantic equivalent) and its #130-derived accessible foreground are unchanged.
+  **ActiveFilterBar**: the bar surface moves from `#F5F7FA` to `bg-body-secondary rounded`, and the
+  `data-bs-theme="light"` pin is removed — it existed only to freeze the light hex against a
+  theme-aware label, and an adaptive surface makes it a dark-mode regression instead. **For a
+  consumer that does not remap Bootstrap's defaults**, the StatCard card, border and radius are
+  pixel-identical to the literals they replace, and the one deliberate light-mode shift is the
+  filter-bar surface (`#F5F7FA` → `#E9ECEF`, Bootstrap's `--bs-secondary-bg`). Dark mode is new
+  behaviour. ActiveFilterBar's pills, labels and remove buttons were already tokenised (#130). No
+  public API change. (#150 — Track 2 phase 2, epic #147)
 - **`Admin::NavBar` and `Admin::AppShell` are theme-adaptive** — `_nav_bar.scss` (which styles
   both) no longer pins a light palette in compile-time Sass variables. Every colour now resolves
   from a Bootstrap **runtime CSS custom property** (`var(--bs-*)`), so the nav follows
@@ -355,7 +381,8 @@ Initial internal version: the ViewComponent library, design tokens, Stimulus con
 and Lookbook previews, prior to the adoption-prep packaging corrections above. (No release
 tag was cut for 0.1.0.)
 
-[Unreleased]: https://github.com/mpimedia/mpi-design-system/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/mpimedia/mpi-design-system/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.5.0...v0.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ include breaking changes).
 
 ### Changed
 - **`Admin::StatCard`, `Admin::AvatarStack`, and `Admin::ActiveFilterBar` are theme-adaptive** —
-  the three components no longer pin a light palette in inline styles; every colour now resolves
-  from a Bootstrap semantic utility, so each follows `data-bs-theme` and the consuming app's mapped
-  tokens. **StatCard**: the card is `bg-body border rounded-3` (was `#fff` / `1px solid #DEE2E6` /
+  the three components no longer pin a light palette in inline styles; every converted colour now
+  resolves from a Bootstrap semantic utility (the one documented exception is AvatarStack's
+  `#64748B` chip background, which has no Bootstrap semantic equivalent — see below), so each
+  follows `data-bs-theme` and the consuming app's mapped tokens. **StatCard**: the card is `bg-body border rounded-3` (was `#fff` / `1px solid #DEE2E6` /
   `border-radius: 8px` — `rounded-3` is `--bs-border-radius-lg` = 8px, so the radius is preserved),
   the label `text-body-secondary` (was `#6C757D`), the value `text-body` or, when `alert:`,
   `text-danger` (was `#1B2A4A` / `#DC3545`), and the trend `text-success-emphasis` /

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ on where Bundler unpacks the gem.
 
 ```ruby
 # Gemfile
-gem "mpi_design_system", git: "git@github.com:mpimedia/mpi-design-system.git", tag: "v0.8.0"
+gem "mpi_design_system", git: "git@github.com:mpimedia/mpi-design-system.git", tag: "v0.9.0"
 ```
 
-Pin to a release tag (`tag: "v0.8.0"`) so upgrades are deliberate. Then:
+Pin to a release tag (`tag: "v0.9.0"`) so upgrades are deliberate. Then:
 
 ```bash
 bundle install

--- a/app/components/mpi_design_system/admin/active_filter_bar/component.html.erb
+++ b/app/components/mpi_design_system/admin/active_filter_bar/component.html.erb
@@ -1,11 +1,12 @@
 <% if show? %>
-  <%# `data-bs-theme="light"` scopes Bootstrap's colour mode to this bar.
-      `bar_styles` pins a light background ($mpi-background), while
-      `.text-body-secondary` resolves through `--bs-body-color` — which Bootstrap
-      flips to #dee2e6 under `data-bs-theme="dark"`. Pairing a theme-aware
-      foreground with a pinned background rendered light text on a light bar:
-      1.16:1. Pinning the surface means pinning its colour mode too. (#130) %>
-  <div style="<%= bar_styles %>" data-bs-theme="light" role="toolbar" aria-label="Active filters">
+  <%# The bar surface is `.bg-body-secondary` — adaptive — so there is no
+      `data-bs-theme` pin here. #130 pinned `data-bs-theme="light"` because the
+      surface was a frozen light hex ($mpi-background) paired with a theme-aware
+      `.text-body-secondary` label (light-on-light, 1.16:1, in dark mode). With an
+      adaptive surface the label and bar flip together — `.text-body-secondary` on
+      `.bg-body-secondary` stays ~5.76:1 light / 5.77:1 dark — and pinning light would
+      now be the regression, blocking dark mode. (#150) %>
+  <div class="bg-body-secondary rounded" style="<%= bar_styles %>" role="toolbar" aria-label="Active filters">
     <span class="text-body-secondary" style="<%= label_styles %>">Active:</span>
     <% @filters.each do |filter| %>
       <span class="rounded-pill text-bg-primary" style="<%= pill_styles %>">

--- a/app/components/mpi_design_system/admin/active_filter_bar/component.rb
+++ b/app/components/mpi_design_system/admin/active_filter_bar/component.rb
@@ -13,15 +13,17 @@ module MpiDesignSystem
 
         private
 
+        # Geometry only. The surface and radius come from `.bg-body-secondary.rounded`
+        # in the template, so the bar tracks `data-bs-theme` instead of pinning a light
+        # `#F5F7FA`. That adaptive surface is why the template no longer pins
+        # `data-bs-theme="light"` — the pin existed only to freeze the light hex. (#150)
         def bar_styles
           [
             "display: flex",
             "align-items: center",
             "flex-wrap: wrap",
             "gap: 8px",
-            "padding: 10px 16px",
-            "background: #F5F7FA",
-            "border-radius: 6px"
+            "padding: 10px 16px"
           ].join("; ")
         end
 

--- a/app/components/mpi_design_system/admin/avatar_stack/component.html.erb
+++ b/app/components/mpi_design_system/admin/avatar_stack/component.html.erb
@@ -6,8 +6,12 @@
   <% end %>
   <% if overflow? %>
     <div style="margin-left: -8px; position: relative; z-index: 0;">
+      <%# The separator ring tracks the body background (var(--bs-body-bg)) so it stays
+          the surface colour in either colour mode rather than pinning #fff. The chip's
+          own background (#64748B, $mpi-tag-internal) has no Bootstrap semantic
+          equivalent, and its foreground is the #130-derived AA pair — both kept. %>
       <span class="d-inline-flex align-items-center justify-content-center rounded-circle fw-semibold"
-            style="width: <%= dimension %>px; height: <%= dimension %>px; font-size: 11px; background-color: <%= overflow_background_color %>; color: <%= overflow_foreground_color %>; border: 2px solid #fff; line-height: 1;"
+            style="width: <%= dimension %>px; height: <%= dimension %>px; font-size: 11px; background-color: <%= overflow_background_color %>; color: <%= overflow_foreground_color %>; border: 2px solid var(--bs-body-bg); line-height: 1;"
             aria-hidden="true">
         +<%= overflow_count %>
       </span>

--- a/app/components/mpi_design_system/admin/stat_card/component.html.erb
+++ b/app/components/mpi_design_system/admin/stat_card/component.html.erb
@@ -1,8 +1,8 @@
-<div style="<%= card_styles %>"<% if @alert %> role="alert"<% end %>>
-  <div style="<%= label_styles %>"><%= @label %></div>
-  <div style="<%= value_styles %>"><%= @value %></div>
+<div class="bg-body border rounded-3" style="<%= card_styles %>"<% if @alert %> role="alert"<% end %>>
+  <div class="text-body-secondary" style="<%= label_styles %>"><%= @label %></div>
+  <div class="<%= value_class %>" style="<%= value_styles %>"><%= @value %></div>
   <% if show_trend? %>
-    <div style="<%= trend_styles %>">
+    <div class="<%= trend_class %>" style="<%= trend_styles %>">
       <% if trend_icon %>
         <i class="bi <%= trend_icon %>" aria-hidden="true"></i>
       <% end %>

--- a/app/components/mpi_design_system/admin/stat_card/component.rb
+++ b/app/components/mpi_design_system/admin/stat_card/component.rb
@@ -24,46 +24,47 @@ module MpiDesignSystem
 
         private
 
+        # Geometry only. The surface, border, and radius now come from Bootstrap
+        # utilities in the template (`bg-body border rounded-3`) so the card tracks
+        # `data-bs-theme` instead of pinning a light `#fff` / `#DEE2E6`. `rounded-3`
+        # resolves to `--bs-border-radius-lg` = 8px under this engine's configuration,
+        # preserving the retired literal. 20px has no Bootstrap equivalent, stays inline.
         def card_styles
-          [
-            "background: #fff",
-            "border: 1px solid #DEE2E6",
-            "border-radius: 8px",
-            "padding: 20px"
-          ].join("; ")
+          "padding: 20px"
         end
 
+        # Colour comes from `.text-body-secondary` in the template, not a pinned
+        # `#6C757D` — so the label follows the colour mode. Geometry only here.
         def label_styles
           [
             "font-size: 11px",
             "font-weight: 600",
             "text-transform: uppercase",
             "letter-spacing: 0.06em",
-            "color: #6C757D",
             "margin-bottom: 8px"
           ].join("; ")
         end
 
+        # Geometry only. The value's colour comes from `value_class` — `.text-danger`
+        # for alerts, `.text-body` otherwise — both theme-adaptive. At 32px the value is
+        # "large text" (AA 3:1), which `.text-danger` clears in both modes (4.53 light /
+        # 3.41 dark) while staying semantically red, so base danger is correct here.
         def value_styles
-          color = @alert ? "#DC3545" : "#1B2A4A"
           [
             "font-size: 32px",
             "font-weight: 700",
-            "color: #{color}",
             "line-height: 1.1"
           ].join("; ")
         end
 
+        # Geometry only. The trend's colour comes from `trend_class`. Unlike the 32px
+        # value, the 12px trend is "small text" (AA 4.5:1), so it uses the `-emphasis`
+        # variants, which pass AA in both modes where base `text-success`/`text-danger`
+        # do not.
         def trend_styles
-          color = case @trend_sentiment
-          when :positive then "#22A06B"
-          when :negative then "#DC3545"
-          else "#6C757D"
-          end
           [
             "font-size: 12px",
             "font-weight: 500",
-            "color: #{color}",
             "margin-top: 4px"
           ].join("; ")
         end
@@ -79,11 +80,19 @@ module MpiDesignSystem
           @trend_text.present?
         end
 
+        def value_class
+          @alert ? "text-danger" : "text-body"
+        end
+
+        # Small-text (12px) trend colour. The `-emphasis` variants are used deliberately:
+        # base `.text-success` (#22A06B = 3.33:1 on light) and `.text-danger`
+        # (#DC3545 = 3.41:1 on dark) both FAIL the 4.5:1 small-text floor and do not
+        # follow the colour mode. The emphasis tokens pass (7.7–13.7:1) and are adaptive.
         def trend_class
           case @trend_sentiment
-          when :positive then "text-success"
-          when :negative then "text-danger"
-          else "text-muted"
+          when :positive then "text-success-emphasis"
+          when :negative then "text-danger-emphasis"
+          else "text-body-secondary"
           end
         end
       end

--- a/catalog/components/filter-chip-bar.md
+++ b/catalog/components/filter-chip-bar.md
@@ -52,7 +52,7 @@ Two filter bar patterns used in CRM list views. Group filter chips provide tag-g
 
 | Element | Description |
 |---|---|
-| Container | Horizontal flex row with `gap-2` |
+| Container | Horizontal flex row (`gap: 8px`) on a `.bg-body-secondary.rounded` bar — adaptive surface that follows `data-bs-theme`, replacing the pinned light `#F5F7FA` (#150) |
 | Label | "ACTIVE:" in gray, ALL-CAPS, 11px |
 | Pill | `.rounded-pill.text-bg-primary`, derived foreground, format: "Category: Value" |
 | Remove button | `×` icon (`bi-x`), `color: inherit` at full strength — **no opacity fade** |
@@ -86,6 +86,7 @@ end
 ## Bootstrap Classes
 
 - `d-flex`, `align-items-center`, `flex-wrap`, `gap-2` — layout
+- `.bg-body-secondary.rounded` — the `ActiveFilterBar` surface (adaptive, replaces the pinned light `#F5F7FA`; `.rounded` == `--bs-border-radius` == the retired 6px) (#150)
 - Custom `.group-chip` (pill, border, padding)
 - `.rounded-pill.text-bg-primary` — active pill fill and derived foreground (replaces the former custom `.active-pill`)
 - `.text-body-secondary` — labels, "Clear all", "Reset all"

--- a/catalog/components/stat-card.md
+++ b/catalog/components/stat-card.md
@@ -10,12 +10,15 @@ Top-level metric card for dashboards. Displays an ALL-CAPS label, a large number
 
 ## Design Decisions
 
-- **Visible borders:** Cards have `border: 1px solid #DEE2E6` — confirmed, not borderless
-- **Label style:** ALL-CAPS, 11px, `font-weight: 600`, `letter-spacing: 0.06em`, gray (`#6C757D`)
-- **Number size:** 32px, `font-weight: 700`, brand navy (`#1B2A4A`) — or danger red for alerts
-- **Trend indicators:** Arrow icon + descriptive text below the number
-- **Background:** White card on `#F5F7FA` page background
-- **Border radius:** 8px
+Colour comes from Bootstrap 5.3 semantic utilities, so the card tracks `data-bs-theme`
+instead of pinning a light palette. Only geometry (padding, font sizes/weights) is inline. (#150)
+
+- **Visible borders:** Cards carry `.border` (theme-adaptive `--bs-border-color`), not a pinned `#DEE2E6` — confirmed, not borderless
+- **Label style:** ALL-CAPS, 11px, `font-weight: 600`, `letter-spacing: 0.06em`, coloured by `.text-body-secondary` (adaptive) rather than a pinned gray
+- **Number size:** 32px, `font-weight: 700`, `.text-body` (adaptive — brand navy in light mode) — or `.text-danger` for alerts. At 32px the value is *large text* (AA 3:1), which base `.text-danger` clears in both modes (4.53 light / 3.41 dark) while staying semantically red
+- **Trend indicators:** Arrow icon + descriptive text below the number, coloured by `.text-success-emphasis` (positive) / `.text-danger-emphasis` (negative) / `.text-body-secondary` (neutral). The 12px trend is *small text* (AA 4.5:1), so the `-emphasis` variants are used deliberately — base `.text-success` (3.33:1) and `.text-danger` (3.41:1) fail AA at that size and do not follow the colour mode; the emphasis tokens pass (7.7–13.7:1) and are adaptive
+- **Surface:** `.bg-body` card (adaptive — white in light mode) on the page background
+- **Border radius:** `.rounded-3` == `--bs-border-radius-lg` == 8px, preserving the retired literal
 
 ## Variants
 
@@ -39,8 +42,8 @@ Top-level metric card for dashboards. Displays an ALL-CAPS label, a large number
 
 | State | Description |
 |---|---|
-| Default | Standard metric display |
-| Alert | Number displayed in danger red (`#DC3545`) — for metrics that need attention |
+| Default | Standard metric display — value in `.text-body` |
+| Alert | Number displayed in danger red via `.text-danger` (adaptive) — for metrics that need attention |
 | Loading | Skeleton placeholder or spinner in place of number |
 
 ## Props / API
@@ -59,21 +62,34 @@ end
 
 ## Bootstrap Classes
 
-- `card` with custom border and radius — or custom `.stat-card`
+- Card surface: `.bg-body .border .rounded-3` — adaptive surface, border and 8px radius
 - `row g-3`, `col-3` — 4-card dashboard layout
 - `bi-arrow-up`, `bi-arrow-down` — trend direction icons
-- Text colors: `text-success` (green), `text-danger` (red), `text-muted` (gray)
+- Label: `.text-body-secondary`
+- Value: `.text-body` (default) / `.text-danger` (alert)
+- Trend: `.text-success-emphasis` (positive) / `.text-danger-emphasis` (negative) / `.text-body-secondary` (neutral) — `-emphasis` for AA at 12px
 
 ## Key Styles
 
+The card carries **no colour of its own** — surface, border, radius and every foreground
+come from Bootstrap utilities so they derive from the app's palette and colour mode. Only
+geometry is declared inline. The `-emphasis` trend variants are a deliberate small-text AA
+fix (base `.text-success`/`.text-danger` fail 4.5:1 at 12px). (#150)
+
 ```css
-.stat-card { background: #fff; border: 1px solid #DEE2E6; border-radius: 8px; padding: 20px; }
-.stat-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: #6C757D; }
-.stat-value { font-size: 32px; font-weight: 700; color: #1B2A4A; line-height: 1.1; }
+/* Card: classes `bg-body border rounded-3`, no background/border/radius declaration.
+   rounded-3 == --bs-border-radius-lg == 8px (the retired literal). */
+.stat-card { padding: 20px; }
+
+/* Label: class `text-body-secondary`, no `color` declaration. */
+.stat-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; }
+
+/* Value: class `text-body` (or `text-danger` when alert), no `color` declaration. */
+.stat-value { font-size: 32px; font-weight: 700; line-height: 1.1; }
+
+/* Trend: classes text-success-emphasis / text-danger-emphasis / text-body-secondary,
+   no `color` declaration. */
 .stat-trend { font-size: 12px; font-weight: 500; }
-.trend-up { color: #22A06B; }
-.trend-down { color: #DC3545; }
-.trend-neutral { color: #6C757D; }
 ```
 
 ## Accessibility

--- a/catalog/previews/filter-chip-bar.html
+++ b/catalog/previews/filter-chip-bar.html
@@ -22,7 +22,7 @@
     .group-chip.all .count { color: #6C757D; }
 
     /* Active filter pills — from Screen 6 */
-    .active-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: #6C757D; margin-right: 8px; white-space: nowrap; }
+    .active-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--bs-secondary-color); margin-right: 8px; white-space: nowrap; }
     /*
       Static hand-authored snapshot — the live ViewComponent is canonical, and
       catalog/previews/screenshots/filter-chip-bar.png is stale pending regeneration.
@@ -37,21 +37,35 @@
       Note the `pill-close` has NO opacity: the retired `opacity: 0.8` faded white
       to an effective #D5E3F0 over the pill — 3.71:1, below the WCAG AA floor (#130).
     */
-    /* #150: the ActiveFilterBar surface is now `.bg-body-secondary.rounded` (adaptive),
-       so the active-pill rows below sit on `--bs-secondary-bg`. MPI does not override
-       $secondary-bg or $body-bg, so these equal stock Bootstrap (#E9ECEF / #FFF) — they
-       are declared for drift-safety and to document the surface, and flip correctly if a
-       consumer ever overrides the token or the mockup gains a data-bs-theme="dark" block. */
+    /* #150: the ActiveFilterBar surface is now `.bg-body-secondary.rounded` (adaptive), so
+       the active-pill rows below sit on `--bs-secondary-bg`, and the ACTIVE label + Clear-all
+       resolve from `--bs-secondary-color` / `--bs-link-color` (the shipped component renders
+       them via `.text-body-secondary`). This page loads STOCK Bootstrap from a CDN, whose
+       tokens are grey/indigo, so we mirror the engine's `_tokens.scss` mapping here: MPI does
+       not override $secondary-bg or $body-bg (so #E9ECEF / #FFF equal stock), but $body-color
+       maps to MPI navy #1B2A4A — so `--bs-secondary-color` is rgba(navy, .75), not stock grey,
+       and $link-color maps to $primary #2E75B6. The `[data-bs-theme="dark"]` block below mirrors
+       the dark values the engine produces (Bootstrap's dark $secondary-bg/$secondary-color plus
+       MPI's dark link #82ACD3), so the dark active-bar example paints readably rather than in
+       stock Bootstrap's palette. */
     :root {
       --bs-primary-rgb: 46, 117, 182;
       --bs-secondary-bg: #E9ECEF;
       --bs-body-bg: #FFFFFF;
+      --bs-secondary-color: rgba(27, 42, 74, 0.75);
+      --bs-link-color: #2E75B6;
+    }
+    [data-bs-theme="dark"] {
+      --bs-secondary-bg: #343A40;
+      --bs-body-bg: #212529;
+      --bs-secondary-color: rgba(222, 226, 230, 0.75);
+      --bs-link-color: #82ACD3;
     }
     .active-pill { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; font-size: 12px; font-weight: 500; text-decoration: none; white-space: nowrap; }
     .active-pill .pill-close { font-size: 10px; cursor: pointer; margin-left: 2px; }
     .active-pill .pill-close:hover { text-decoration: none; }
-    .clear-all { font-size: 13px; color: #6C757D; text-decoration: none; margin-left: 8px; }
-    .clear-all:hover { color: #2E75B6; text-decoration: underline; }
+    .clear-all { font-size: 13px; color: var(--bs-secondary-color); text-decoration: none; margin-left: 8px; }
+    .clear-all:hover { color: var(--bs-link-color); text-decoration: underline; }
   </style>
 </head>
 <body>
@@ -108,6 +122,20 @@
     <div class="bg-body-secondary rounded d-flex align-items-center flex-wrap gap-2" style="max-width:800px; padding:10px 16px;">
       <span class="active-label">ACTIVE:</span>
       <span class="active-pill rounded-pill text-bg-primary">Location: Los Angeles <button style="background:none;border:none;color:inherit;padding:0;font-size:10px;cursor:pointer;margin-left:2px;" aria-label="Remove filter: Location: Los Angeles"><i class="bi bi-x"></i></button></span>
+      <a class="clear-all" href="#">Clear all</a>
+    </div>
+  </div>
+
+  <!-- Active filter pills — dark colour mode (#150) -->
+  <!-- The #150 conversion drops the `data-bs-theme="light"` pin so the bar tracks the
+       colour mode. `.bg-body-secondary` flips to #343A40, the ACTIVE label and Clear-all
+       (via --bs-secondary-color) stay readable, and the pills keep MPI primary. -->
+  <div class="preview-section" data-bs-theme="dark" style="background:#212529; padding:16px; border-radius:8px;">
+    <div class="preview-label">Active Filter Pills — Dark Mode (Adaptive Surface)</div>
+    <div class="bg-body-secondary rounded d-flex align-items-center flex-wrap gap-2" style="max-width:800px; padding:10px 16px;">
+      <span class="active-label">ACTIVE:</span>
+      <span class="active-pill rounded-pill text-bg-primary">Keyword: investors <button style="background:none;border:none;color:inherit;padding:0;font-size:10px;cursor:pointer;margin-left:2px;" aria-label="Remove filter: Keyword: investors"><i class="bi bi-x"></i></button></span>
+      <span class="active-pill rounded-pill text-bg-primary">Group: Buyers <button style="background:none;border:none;color:inherit;padding:0;font-size:10px;cursor:pointer;margin-left:2px;" aria-label="Remove filter: Group: Buyers"><i class="bi bi-x"></i></button></span>
       <a class="clear-all" href="#">Clear all</a>
     </div>
   </div>

--- a/catalog/previews/filter-chip-bar.html
+++ b/catalog/previews/filter-chip-bar.html
@@ -37,7 +37,16 @@
       Note the `pill-close` has NO opacity: the retired `opacity: 0.8` faded white
       to an effective #D5E3F0 over the pill — 3.71:1, below the WCAG AA floor (#130).
     */
-    :root { --bs-primary-rgb: 46, 117, 182; }
+    /* #150: the ActiveFilterBar surface is now `.bg-body-secondary.rounded` (adaptive),
+       so the active-pill rows below sit on `--bs-secondary-bg`. MPI does not override
+       $secondary-bg or $body-bg, so these equal stock Bootstrap (#E9ECEF / #FFF) — they
+       are declared for drift-safety and to document the surface, and flip correctly if a
+       consumer ever overrides the token or the mockup gains a data-bs-theme="dark" block. */
+    :root {
+      --bs-primary-rgb: 46, 117, 182;
+      --bs-secondary-bg: #E9ECEF;
+      --bs-body-bg: #FFFFFF;
+    }
     .active-pill { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; font-size: 12px; font-weight: 500; text-decoration: none; white-space: nowrap; }
     .active-pill .pill-close { font-size: 10px; cursor: pointer; margin-left: 2px; }
     .active-pill .pill-close:hover { text-decoration: none; }
@@ -84,7 +93,7 @@
   <!-- Active filter pills — from Figma Screen 6 (Active Search) -->
   <div class="preview-section">
     <div class="preview-label">Active Filter Pills — From Figma Screen 6 (Active Search Results)</div>
-    <div class="d-flex align-items-center flex-wrap gap-2" style="max-width:800px;">
+    <div class="bg-body-secondary rounded d-flex align-items-center flex-wrap gap-2" style="max-width:800px; padding:10px 16px;">
       <span class="active-label">ACTIVE:</span>
       <span class="active-pill rounded-pill text-bg-primary">Keyword: investors <button style="background:none;border:none;color:inherit;padding:0;font-size:10px;cursor:pointer;margin-left:2px;" aria-label="Remove filter: Keyword: investors"><i class="bi bi-x"></i></button></span>
       <span class="active-pill rounded-pill text-bg-primary">Group: Buyers <button style="background:none;border:none;color:inherit;padding:0;font-size:10px;cursor:pointer;margin-left:2px;" aria-label="Remove filter: Group: Buyers"><i class="bi bi-x"></i></button></span>
@@ -96,7 +105,7 @@
   <!-- Single active filter -->
   <div class="preview-section">
     <div class="preview-label">Active Filter Pills — Single Filter</div>
-    <div class="d-flex align-items-center flex-wrap gap-2" style="max-width:800px;">
+    <div class="bg-body-secondary rounded d-flex align-items-center flex-wrap gap-2" style="max-width:800px; padding:10px 16px;">
       <span class="active-label">ACTIVE:</span>
       <span class="active-pill rounded-pill text-bg-primary">Location: Los Angeles <button style="background:none;border:none;color:inherit;padding:0;font-size:10px;cursor:pointer;margin-left:2px;" aria-label="Remove filter: Location: Los Angeles"><i class="bi bi-x"></i></button></span>
       <a class="clear-all" href="#">Clear all</a>

--- a/catalog/previews/filter-chip-bar.html
+++ b/catalog/previews/filter-chip-bar.html
@@ -61,6 +61,9 @@
       --bs-secondary-color: rgba(222, 226, 230, 0.75);
       --bs-link-color: #82ACD3;
     }
+    /* #150: in the dark example the scaffolding preview label sits on #212529; source it
+       from --bs-secondary-color so it stays AA — the hardcoded #6C757D was 3.29:1 there. */
+    [data-bs-theme="dark"] .preview-label { color: var(--bs-secondary-color); }
     .active-pill { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; font-size: 12px; font-weight: 500; text-decoration: none; white-space: nowrap; }
     .active-pill .pill-close { font-size: 10px; cursor: pointer; margin-left: 2px; }
     .active-pill .pill-close:hover { text-decoration: none; }

--- a/catalog/previews/stat-card.html
+++ b/catalog/previews/stat-card.html
@@ -7,52 +7,86 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <style>
-    body { padding: 32px; background: #F5F7FA; }
+    /* This file loads STOCK Bootstrap from the CDN, which ships indigo #0D6EFD, a
+       neutral-gray body (#212529), Bootstrap-green success (#198754) and its own
+       emphasis derivatives. The engine compiles Bootstrap with MPI's tokens instead,
+       so without these overrides the semantic utilities below would paint Bootstrap's
+       palette and this mockup would contradict the component it documents. Mirrors what
+       _tokens.scss maps at build time. (Same pattern as pagination.html /
+       filter-chip-bar.html.) Only the LIGHT values plus the mode-flipping emphasis
+       tokens need restating — the engine leaves Bootstrap's dark body/border/secondary
+       defaults (#DEE2E6 / #495057 / #343A40 on #212529) untouched, and those are what
+       the component measurably renders. (#150) */
+    :root {
+      --bs-primary: #2E75B6;
+      --bs-primary-rgb: 46, 117, 182;
+      --bs-body-bg: #FFFFFF;
+      --bs-body-color: #1B2A4A;                 /* $mpi-navy */
+      --bs-body-color-rgb: 27, 42, 74;
+      --bs-border-color: #DEE2E6;               /* $mpi-border */
+      --bs-secondary-color: rgba(27, 42, 74, 0.75);
+      --bs-secondary-bg: #E9ECEF;
+      --bs-success: #22A06B;                    /* $mpi-success */
+      --bs-success-rgb: 34, 160, 107;
+      --bs-success-text-emphasis: #0E402B;      /* shade-color($mpi-success, 60%) */
+      --bs-danger: #DC3545;                     /* Bootstrap default; MPI keeps it */
+      --bs-danger-rgb: 220, 53, 69;
+      --bs-danger-text-emphasis: #58151C;       /* shade-color($danger, 60%) */
+    }
+    [data-bs-theme="dark"] {
+      --bs-success-text-emphasis: #7AC6A6;      /* tint-color($mpi-success, 40%) */
+      --bs-danger-text-emphasis: #EA868F;       /* tint-color($danger, 40%) — equals stock */
+    }
+
+    /* Geometry only. Every colour now comes from a Bootstrap semantic utility in the
+       markup below (`bg-body border rounded-3`, `text-body-secondary`, `text-body` /
+       `text-danger`, `text-success-emphasis` / `text-danger-emphasis`), so this mockup
+       follows data-bs-theme exactly as the shipped component does. rounded-3 ==
+       --bs-border-radius-lg == 8px = the retired literal. Anything reintroducing a
+       colour hex outside the :root block above has drifted from the component. */
+    body { padding: 32px; }
     .preview-section { margin-bottom: 40px; }
-    .preview-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6C757D; margin-bottom: 8px; }
-    .stat-card { background: #fff; border: 1px solid #DEE2E6; border-radius: 8px; padding: 20px; }
-    .stat-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: #6C757D; margin-bottom: 8px; }
-    .stat-value { font-size: 32px; font-weight: 700; color: #1B2A4A; line-height: 1.1; margin-bottom: 4px; }
+    .preview-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 8px; }
+    .stat-card { padding: 20px; }
+    .stat-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 8px; }
+    .stat-value { font-size: 32px; font-weight: 700; line-height: 1.1; margin-bottom: 4px; }
     .stat-trend { font-size: 12px; font-weight: 500; }
-    .trend-up { color: #22A06B; }
-    .trend-down { color: #DC3545; }
-    .trend-neutral { color: #6C757D; }
   </style>
 </head>
-<body>
-  <h4 class="mb-1" style="color:#1B2A4A;">StatCard</h4>
-  <p class="text-muted small mb-4">Top-level metric card for dashboards. ALL-CAPS label, large number, and trend indicator. From Figma Screen 7 (CRM Dashboard).</p>
+<body class="bg-body-secondary text-body">
+  <h4 class="mb-1">StatCard</h4>
+  <p class="text-body-secondary small mb-4">Top-level metric card for dashboards. ALL-CAPS label, large number, and trend indicator. From Figma Screen 7 (CRM Dashboard).</p>
 
   <!-- Dashboard row — exact layout from Figma Screen 7 -->
   <div class="preview-section">
-    <div class="preview-label">Dashboard Row — From Figma Screen 7 (CRM Dashboard)</div>
+    <div class="preview-label text-body-secondary">Dashboard Row — From Figma Screen 7 (CRM Dashboard)</div>
     <div class="row g-3" style="max-width:900px;">
       <div class="col-3">
-        <div class="stat-card">
-          <div class="stat-label">Total Contacts</div>
-          <div class="stat-value">2,307</div>
-          <div class="stat-trend trend-up"><i class="bi bi-arrow-up"></i> 34 this month</div>
+        <div class="stat-card bg-body border rounded-3">
+          <div class="stat-label text-body-secondary">Total Contacts</div>
+          <div class="stat-value text-body">2,307</div>
+          <div class="stat-trend text-success-emphasis"><i class="bi bi-arrow-up"></i> 34 this month</div>
         </div>
       </div>
       <div class="col-3">
-        <div class="stat-card">
-          <div class="stat-label">Engagements This Week</div>
-          <div class="stat-value">47</div>
-          <div class="stat-trend trend-up"><i class="bi bi-arrow-up"></i> 12% vs last week</div>
+        <div class="stat-card bg-body border rounded-3">
+          <div class="stat-label text-body-secondary">Engagements This Week</div>
+          <div class="stat-value text-body">47</div>
+          <div class="stat-trend text-success-emphasis"><i class="bi bi-arrow-up"></i> 12% vs last week</div>
         </div>
       </div>
       <div class="col-3">
-        <div class="stat-card">
-          <div class="stat-label">Accounts</div>
-          <div class="stat-value">418</div>
-          <div class="stat-trend trend-neutral">8 added this month</div>
+        <div class="stat-card bg-body border rounded-3">
+          <div class="stat-label text-body-secondary">Accounts</div>
+          <div class="stat-value text-body">418</div>
+          <div class="stat-trend text-body-secondary">8 added this month</div>
         </div>
       </div>
       <div class="col-3">
-        <div class="stat-card">
-          <div class="stat-label">Overdue Follow-Ups</div>
-          <div class="stat-value" style="color:#DC3545;">12</div>
-          <div class="stat-trend trend-down"><i class="bi bi-arrow-down"></i> 3 since yesterday</div>
+        <div class="stat-card bg-body border rounded-3" role="alert">
+          <div class="stat-label text-body-secondary">Overdue Follow-Ups</div>
+          <div class="stat-value text-danger">12</div>
+          <div class="stat-trend text-danger-emphasis"><i class="bi bi-arrow-down"></i> 3 since yesterday</div>
         </div>
       </div>
     </div>
@@ -60,34 +94,64 @@
 
   <!-- Single card variants -->
   <div class="preview-section">
-    <div class="preview-label">Variants</div>
+    <div class="preview-label text-body-secondary">Variants</div>
     <div class="row g-3" style="max-width:600px;">
       <div class="col-6">
-        <div class="stat-card">
-          <div class="stat-label">Positive Trend</div>
-          <div class="stat-value">2,307</div>
-          <div class="stat-trend trend-up"><i class="bi bi-arrow-up"></i> 34 this month</div>
+        <div class="stat-card bg-body border rounded-3">
+          <div class="stat-label text-body-secondary">Positive Trend</div>
+          <div class="stat-value text-body">2,307</div>
+          <div class="stat-trend text-success-emphasis"><i class="bi bi-arrow-up"></i> 34 this month</div>
         </div>
       </div>
       <div class="col-6">
-        <div class="stat-card">
-          <div class="stat-label">Negative / Alert</div>
-          <div class="stat-value" style="color:#DC3545;">12</div>
-          <div class="stat-trend trend-down"><i class="bi bi-arrow-down"></i> 3 since yesterday</div>
+        <div class="stat-card bg-body border rounded-3" role="alert">
+          <div class="stat-label text-body-secondary">Negative / Alert</div>
+          <div class="stat-value text-danger">12</div>
+          <div class="stat-trend text-danger-emphasis"><i class="bi bi-arrow-down"></i> 3 since yesterday</div>
         </div>
       </div>
       <div class="col-6">
-        <div class="stat-card">
-          <div class="stat-label">Neutral Trend</div>
-          <div class="stat-value">418</div>
-          <div class="stat-trend trend-neutral">8 added this month</div>
+        <div class="stat-card bg-body border rounded-3">
+          <div class="stat-label text-body-secondary">Neutral Trend</div>
+          <div class="stat-value text-body">418</div>
+          <div class="stat-trend text-body-secondary">8 added this month</div>
         </div>
       </div>
       <div class="col-6">
-        <div class="stat-card">
-          <div class="stat-label">Percentage Trend</div>
-          <div class="stat-value">47</div>
-          <div class="stat-trend trend-up"><i class="bi bi-arrow-up"></i> 12% vs last week</div>
+        <div class="stat-card bg-body border rounded-3">
+          <div class="stat-label text-body-secondary">Percentage Trend</div>
+          <div class="stat-value text-body">47</div>
+          <div class="stat-trend text-success-emphasis"><i class="bi bi-arrow-up"></i> 12% vs last week</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- The point of #150: identical markup, no variant flag, following the colour mode. -->
+  <div class="preview-section" data-bs-theme="dark">
+    <div class="bg-body text-body p-3 rounded">
+      <div class="preview-label text-body-secondary">Dark Mode (data-bs-theme="dark")</div>
+      <div class="row g-3" style="max-width:900px;">
+        <div class="col-3">
+          <div class="stat-card bg-body border rounded-3">
+            <div class="stat-label text-body-secondary">Total Contacts</div>
+            <div class="stat-value text-body">2,307</div>
+            <div class="stat-trend text-success-emphasis"><i class="bi bi-arrow-up"></i> 34 this month</div>
+          </div>
+        </div>
+        <div class="col-3">
+          <div class="stat-card bg-body border rounded-3">
+            <div class="stat-label text-body-secondary">Accounts</div>
+            <div class="stat-value text-body">418</div>
+            <div class="stat-trend text-body-secondary">8 added this month</div>
+          </div>
+        </div>
+        <div class="col-3">
+          <div class="stat-card bg-body border rounded-3" role="alert">
+            <div class="stat-label text-body-secondary">Overdue Follow-Ups</div>
+            <div class="stat-value text-danger">12</div>
+            <div class="stat-trend text-danger-emphasis"><i class="bi bi-arrow-down"></i> 3 since yesterday</div>
+          </div>
         </div>
       </div>
     </div>

--- a/lib/mpi_design_system/version.rb
+++ b/lib/mpi_design_system/version.rb
@@ -1,3 +1,3 @@
 module MpiDesignSystem
-  VERSION = "0.8.0"
+  VERSION = "0.9.0"
 end

--- a/spec/components/mpi_design_system/admin/active_filter_bar/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/active_filter_bar/component_spec.rb
@@ -10,11 +10,23 @@ RSpec.describe MpiDesignSystem::Admin::ActiveFilterBar::Component, type: :compon
     ]
   end
 
-  # These two examples previously asserted `style*='background: #2E75B6'`, which
-  # pinned a hardcoded duplicate of $mpi-primary. The pill now carries Bootstrap's
-  # `.text-bg-primary`, so its background AND foreground derive from the consuming
-  # app's actual $primary rather than a literal that silently desynchronises when
-  # a consumer overrides the token. (#130)
+  # Utilities that pin one colour scheme. Any of these on a bar meant to follow
+  # `data-bs-theme` reintroduces exactly the defect #150 removed.
+  let(:fixed_scheme_utilities) do
+    %w[
+      bg-white bg-black bg-light bg-dark
+      text-white text-black text-light text-dark
+      text-bg-light text-bg-dark
+      border-white border-black border-light border-dark
+    ]
+  end
+
+  # Matches 3-, 4-, 6- and 8-digit CSS hex. The trailing (?!\h) stops #abcdef1234
+  # from matching as a 6-digit literal, and the 4/8 branches close the alpha forms.
+  let(:hex_literal) { /#(?:\h{8}|\h{6}|\h{4}|\h{3})(?!\h)/ }
+
+  # The pill carries Bootstrap's `.text-bg-primary`, so its background AND foreground
+  # derive from the consuming app's actual $primary rather than a literal. (#130)
   it "renders active filter pills" do
     render_inline(described_class.new(filters: filters))
 
@@ -41,25 +53,25 @@ RSpec.describe MpiDesignSystem::Admin::ActiveFilterBar::Component, type: :compon
     expect(page).to have_css("a[href='/contacts?clear']", text: "Clear all")
   end
 
-  it "does not render when filters are empty" do
-    render_inline(described_class.new(filters: []))
-
-    expect(page).not_to have_css("div[role='toolbar']")
-  end
-
-  it "renders on a light gray background" do
-    render_inline(described_class.new(filters: filters))
-
-    expect(page).to have_css("div[style*='background: #F5F7FA']")
-  end
-
   it "renders as a toolbar with aria label" do
     render_inline(described_class.new(filters: filters))
 
     expect(page).to have_css("div[role='toolbar'][aria-label='Active filters']")
   end
 
-  describe "contrast (#130)" do
+  # #150: the bar surface was a pinned light `#F5F7FA` scoped to `data-bs-theme="light"`.
+  # It is now `.bg-body-secondary.rounded` — adaptive — so the theme pin is gone (it
+  # would now BLOCK dark mode). `.rounded` == --bs-border-radius == 6px under this
+  # engine's config, preserving the retired `border-radius: 6px`.
+  it "renders the bar on the adaptive secondary body surface with no colour-mode pin" do
+    render_inline(described_class.new(filters: filters))
+
+    expect(page).to have_css("div.bg-body-secondary.rounded[role='toolbar']")
+    expect(page).to have_no_css("div[style*='background']")
+    expect(page).to have_no_css("[data-bs-theme]")
+  end
+
+  describe "contrast (#130) and theme-adaptivity (#150)" do
     it "derives the pill foreground from Bootstrap instead of pinning white" do
       render_inline(described_class.new(filters: filters))
 
@@ -68,10 +80,9 @@ RSpec.describe MpiDesignSystem::Admin::ActiveFilterBar::Component, type: :compon
       expect(page).to have_no_css("span[style*='background: #2E75B6']")
     end
 
-    # The retired `opacity: 0.8` faded white to an effective #D5E3F0 over the
-    # pill — 3.71:1, an AA failure invisible to any audit that only reads
-    # `color:` declarations. The button now inherits the pill's derived
-    # foreground at full strength.
+    # The retired `opacity: 0.8` faded white to an effective #D5E3F0 over the pill —
+    # 3.71:1, an AA failure invisible to any audit that only reads `color:`. The
+    # button now inherits the pill's derived foreground at full strength.
     it "does not fade the remove button, which eroded contrast to 3.71:1" do
       render_inline(described_class.new(filters: filters))
 
@@ -87,24 +98,46 @@ RSpec.describe MpiDesignSystem::Admin::ActiveFilterBar::Component, type: :compon
       expect(page).to have_no_css("[style*='color: #6C757D']")
     end
 
-    # A single sweep over the whole rendered document, so a hardcoded pair
-    # reintroduced anywhere in this template fails the suite — including in
-    # markup this spec does not enumerate.
-    # The lookbehind matters: `background-color:` also ends in "color:", so
-    # without it this would flag a *background* declaration as a foreground one.
-    # `\s*` around the colon catches whitespace variants a tighter pattern misses.
-    # It deliberately covers hex only — the components emit no named/rgb()/hsl()
-    # colours, and broadening it would trade a precise assertion for a vague one.
-    it "emits no hardcoded hex foreground anywhere in the rendered markup" do
+    # The component now carries NO colour hex at all (surface, pill, label and remove
+    # button are all Bootstrap utilities), so a single sweep over the whole rendered
+    # document catches a hardcoded literal reintroduced anywhere in this template —
+    # including markup this spec does not enumerate. The positive pin proves the
+    # markup actually rendered, so the regex is not passing over an empty string.
+    it "emits no literal hex anywhere in the rendered markup" do
       render_inline(described_class.new(filters: filters, clear_all_url: "/contacts?clear"))
 
-      expect(page.native.to_html).not_to match(/(?<!background-)color\s*:\s*#[0-9a-f]{3,8}\b/i)
+      expect(page).to have_css("div.bg-body-secondary[role='toolbar']")
+      expect(page).to have_css("span.text-bg-primary", text: "Keyword: investors")
+
+      expect(rendered_content).not_to match(hex_literal)
+    end
+
+    it "pins no fixed-scheme utility that would break under data-bs-theme" do
+      render_inline(described_class.new(filters: filters, clear_all_url: "/contacts?clear"))
+
+      elements = page.all("div[role='toolbar'], div[role='toolbar'] *")
+      expect(elements.size).to be > 1
+
+      applied = elements.flat_map { |el| el[:class].to_s.split }.uniq
+      expect(applied).to include("bg-body-secondary", "text-bg-primary", "text-body-secondary")
+      expect(applied & fixed_scheme_utilities).to be_empty
     end
   end
 
   describe "edge cases" do
-    it "does not raise when filters is nil" do
-      expect { render_inline(described_class.new(filters: nil)) }.not_to raise_error
+    it "renders nothing when filters are empty" do
+      render_inline(described_class.new(filters: []))
+
+      # show? is false, so the whole template is elided — assert the output itself
+      # is empty rather than merely that the toolbar is absent (a positive check on
+      # the rendered string, not a bare absence).
+      expect(rendered_content.strip).to be_empty
+    end
+
+    it "renders nothing and does not raise when filters is nil" do
+      output = nil
+      expect { output = render_inline(described_class.new(filters: nil)) }.not_to raise_error
+      expect(output.to_html.strip).to be_empty
     end
 
     it "renders a pill without a remove button when remove_url is missing" do
@@ -117,6 +150,7 @@ RSpec.describe MpiDesignSystem::Admin::ActiveFilterBar::Component, type: :compon
     it "omits the clear-all link when no url is given" do
       render_inline(described_class.new(filters: filters))
 
+      expect(page).to have_css("span.text-bg-primary", text: "Keyword: investors")
       expect(page).to have_no_css("a[aria-label='Clear all filters']")
     end
   end

--- a/spec/components/mpi_design_system/admin/avatar_stack/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/avatar_stack/component_spec.rb
@@ -116,12 +116,16 @@ RSpec.describe MpiDesignSystem::Admin::AvatarStack::Component, type: :component 
 
     # AvatarStack's own only hex is the chip's background/foreground pair — its visible
     # avatars are AvatarCircle sub-renders, whose palette is swept by AvatarCircle's own
-    # spec, so an unscoped rendered_content sweep would red on them. Scoped to the chip's
-    # style, deleting the two intentional colours must leave it hex-free — catching any
-    # OTHER hardcoded hex introduced into the chip. (A re-pinned white ring is caught by
-    # the `solid #fff` guard above, not here: deleting the derived #fff foreground would
-    # also mask it in this residual.)
-    it "emits no chip hex beyond the two intentional overflow colours" do
+    # spec, so an unscoped rendered_content sweep would red on them.
+    #
+    # A global gsub of the two allowed hex strings is a false green: it deletes those
+    # values from ANY property, so a NEW `outline: 1px solid #64748B` (a hex re-introduced
+    # in a different declaration) would be gsubbed away and escape detection. Instead,
+    # parse the style into `property: value` declarations and assert EXACTLY the two
+    # permitted declarations carry a hex — any hex in a third declaration reddens here.
+    # (The `solid #fff`/`solid #ffffff` ring guards above stay: a re-pinned white ring
+    # is a hex in the derived-foreground's own value, which this pair-level check allows.)
+    it "permits hex in exactly the two intentional chip declarations and nowhere else" do
       render_inline(described_class.new(names: names, max: 4))
 
       chip = page.find("span[aria-hidden='true']")
@@ -129,11 +133,14 @@ RSpec.describe MpiDesignSystem::Admin::AvatarStack::Component, type: :component 
 
       background = described_class::OVERFLOW_COLOR
       foreground = MpiDesignSystem::ColorContrast.accessible_foreground(background)
-      residual = chip[:style]
-        .gsub(/#{Regexp.escape(background)}/i, "")
-        .gsub(/#{Regexp.escape(foreground)}/i, "")
 
-      expect(residual).not_to match(hex_literal)
+      declarations = chip[:style].split(";").map(&:strip).reject(&:empty?)
+      hex_bearing = declarations.select { |declaration| declaration.match?(hex_literal) }
+
+      expect(hex_bearing).to contain_exactly(
+        "background-color: #{background}",
+        "color: #{foreground}"
+      )
     end
   end
 end

--- a/spec/components/mpi_design_system/admin/avatar_stack/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/avatar_stack/component_spec.rb
@@ -73,13 +73,17 @@ RSpec.describe MpiDesignSystem::Admin::AvatarStack::Component, type: :component 
   end
 
   # The "+N" chip hand-copied AvatarCircle's markup, including a pinned
-  # `color: #fff`, so it would not have inherited #130's fix. It is now derived
-  # from the same helper. This pair resolves to white (4.76:1) — unchanged
-  # visually, but it now tracks the background instead of assuming it.
-  describe "overflow chip contrast (#130)" do
+  # `color: #fff`, so it would not have inherited #130's fix. Its foreground is now
+  # derived from the same helper (resolves to white, 4.76:1 — visually unchanged).
+  # #150 additionally converts the separator ring from a pinned `#fff` to
+  # `var(--bs-body-bg)` so it tracks the surface in either colour mode.
+  describe "overflow chip (#130 contrast + #150 adaptive ring)" do
     let(:names) { [ "Alice", "Bob", "Carol", "Dave", "Eve", "Frank" ] }
 
-    it "renders the overflow chip with a derived foreground" do
+    # Matches 3-, 4-, 6- and 8-digit CSS hex; trailing (?!\h) stops over-matching.
+    let(:hex_literal) { /#(?:\h{8}|\h{6}|\h{4}|\h{3})(?!\h)/ }
+
+    it "renders the overflow chip with the neutral background and derived foreground" do
       render_inline(described_class.new(names: names, max: 4))
 
       expect(page).to have_css("span[style*='background-color: #64748B'][style*='color: #fff']", text: "+2")
@@ -92,16 +96,44 @@ RSpec.describe MpiDesignSystem::Admin::AvatarStack::Component, type: :component 
       expect(MpiDesignSystem::ColorContrast.ratio(background, foreground)).to be >= 4.5
     end
 
-    it "keeps the white separator border, which is decorative rather than text" do
+    # #150: the separator ring was `2px solid #fff` — a pinned light colour that stayed
+    # white in dark mode. It now tracks `var(--bs-body-bg)`, so the ring is the surface
+    # colour in either mode. The positive pin proves the var survived render_inline;
+    # the two absence guards pin the specific regression it replaces.
+    it "tracks the body background for the separator ring instead of pinning white" do
       render_inline(described_class.new(names: names, max: 4))
 
-      expect(page).to have_css("span[style*='border: 2px solid #fff']", text: "+2")
+      expect(page).to have_css("span[style*='border: 2px solid var(--bs-body-bg)']", text: "+2")
+      expect(page).to have_no_css("span[style*='solid #fff']")
+      expect(page).to have_no_css("span[style*='solid #ffffff']")
     end
 
     it "renders the chip at the small size too" do
       render_inline(described_class.new(names: names, max: 4, size: :sm))
 
       expect(page).to have_css("span[style*='width: 28px'][style*='color: #fff']", text: "+2")
+    end
+
+    # AvatarStack's own only hex is the chip's background/foreground pair — its visible
+    # avatars are AvatarCircle sub-renders, whose palette is swept by AvatarCircle's own
+    # spec, so an unscoped rendered_content sweep would red on them. Scoped to the chip's
+    # style, deleting the two intentional colours must leave it hex-free — catching any
+    # OTHER hardcoded hex introduced into the chip. (A re-pinned white ring is caught by
+    # the `solid #fff` guard above, not here: deleting the derived #fff foreground would
+    # also mask it in this residual.)
+    it "emits no chip hex beyond the two intentional overflow colours" do
+      render_inline(described_class.new(names: names, max: 4))
+
+      chip = page.find("span[aria-hidden='true']")
+      expect(chip.text.strip).to eq("+2")
+
+      background = described_class::OVERFLOW_COLOR
+      foreground = MpiDesignSystem::ColorContrast.accessible_foreground(background)
+      residual = chip[:style]
+        .gsub(/#{Regexp.escape(background)}/i, "")
+        .gsub(/#{Regexp.escape(foreground)}/i, "")
+
+      expect(residual).not_to match(hex_literal)
     end
   end
 end

--- a/spec/components/mpi_design_system/admin/stat_card/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/stat_card/component_spec.rb
@@ -3,6 +3,21 @@
 require "spec_helper"
 
 RSpec.describe MpiDesignSystem::Admin::StatCard::Component, type: :component do
+  # Utilities that pin one colour scheme. Any of these on a card meant to follow
+  # `data-bs-theme` reintroduces exactly the defect this conversion (#150) removed.
+  let(:fixed_scheme_utilities) do
+    %w[
+      bg-white bg-black bg-light bg-dark
+      text-white text-black text-light text-dark
+      text-bg-light text-bg-dark
+      border-white border-black border-light border-dark
+    ]
+  end
+
+  # Matches 3-, 4-, 6- and 8-digit CSS hex. The trailing (?!\h) stops #abcdef1234
+  # from matching as a 6-digit literal, and the 4/8 branches close the alpha forms.
+  let(:hex_literal) { /#(?:\h{8}|\h{6}|\h{4}|\h{3})(?!\h)/ }
+
   it "renders label and value" do
     render_inline(described_class.new(label: "Total Contacts", value: "2,307"))
 
@@ -10,57 +25,217 @@ RSpec.describe MpiDesignSystem::Admin::StatCard::Component, type: :component do
     expect(page).to have_css("div[style*='font-size: 32px']", text: "2,307")
   end
 
-  it "renders value in navy by default" do
+  it "renders the card on the adaptive body surface with a border and lg radius" do
     render_inline(described_class.new(label: "Accounts", value: "418"))
 
-    expect(page).to have_css("div[style*='color: #1B2A4A']", text: "418")
+    # `rounded-3` == --bs-border-radius-lg == 8px under this engine's config, so the
+    # retired `border-radius: 8px` is preserved while becoming theme-adaptive.
+    expect(page).to have_css("div.bg-body.border.rounded-3", text: "418")
   end
 
-  it "renders value in danger red when alert is true" do
+  it "colours the label with the secondary body token, not a pinned gray" do
+    render_inline(described_class.new(label: "Accounts", value: "418"))
+
+    expect(page).to have_css("div.text-body-secondary", text: "Accounts")
+  end
+
+  it "renders the value in the adaptive body colour by default" do
+    render_inline(described_class.new(label: "Accounts", value: "418"))
+
+    expect(page).to have_css("div.text-body", text: "418")
+  end
+
+  it "renders the value in danger red when alert is true" do
     render_inline(described_class.new(label: "Overdue Follow-Ups", value: "12", alert: true))
 
-    expect(page).to have_css("div[style*='color: #DC3545']", text: "12")
+    # 32px value is large text (AA 3:1); base `.text-danger` clears it in both modes
+    # while staying semantically red — so base danger is correct here, not -emphasis.
+    expect(page).to have_css("div.text-danger", text: "12")
+  end
+
+  it "does not render the value in danger red when alert is false" do
+    render_inline(described_class.new(label: "Accounts", value: "418"))
+
+    expect(page).to have_css("div.text-body", text: "418")
+    expect(page).to have_no_css("div.text-danger")
   end
 
   it "adds role=alert when alert is true" do
     render_inline(described_class.new(label: "Overdue", value: "5", alert: true))
 
-    expect(page).to have_css("div[role='alert']")
+    expect(page).to have_css("div.bg-body[role='alert']", text: "5")
   end
 
-  it "renders an up arrow with positive trend" do
-    render_inline(described_class.new(
-      label: "Total", value: "100",
-      trend_text: "34 this month", trend_direction: :up, trend_sentiment: :positive
-    ))
+  it "omits role=alert when alert is false" do
+    render_inline(described_class.new(label: "Accounts", value: "418"))
 
-    expect(page).to have_css("i.bi.bi-arrow-up")
-    expect(page).to have_css("div[style*='color: #22A06B']", text: "34 this month")
+    expect(page).to have_css("div.bg-body", text: "418")
+    expect(page).to have_no_css("[role='alert']")
   end
 
-  it "renders a down arrow with negative trend" do
-    render_inline(described_class.new(
-      label: "Active", value: "50",
-      trend_text: "5 this week", trend_direction: :down, trend_sentiment: :negative
-    ))
+  describe "trend colour by sentiment" do
+    # The `-emphasis` variants are a deliberate AA fix: the 12px trend is small text
+    # (AA 4.5:1), where base `.text-success` (3.33:1 light) and `.text-danger`
+    # (3.41:1 dark) both fail and do not follow the colour mode. Neutral uses the
+    # secondary body token.
+    expected = {
+      positive: "text-success-emphasis",
+      negative: "text-danger-emphasis",
+      neutral: "text-body-secondary"
+    }
 
-    expect(page).to have_css("i.bi.bi-arrow-down")
-    expect(page).to have_css("div[style*='color: #DC3545']", text: "5 this week")
+    it "maps every sentiment the constant declares (an unmapped addition reddens here)" do
+      expect(described_class::TREND_SENTIMENTS).to match_array(expected.keys)
+    end
+
+    described_class::TREND_SENTIMENTS.each do |sentiment|
+      it "renders #{sentiment} trend text in .#{expected.fetch(sentiment)}" do
+        render_inline(described_class.new(
+          label: "Total", value: "100",
+          trend_text: "34 this month", trend_sentiment: sentiment
+        ))
+
+        expect(page).to have_css("div.#{expected.fetch(sentiment)}", text: "34 this month")
+      end
+    end
   end
 
-  it "renders neutral trend without arrow" do
-    render_inline(described_class.new(
-      label: "Accounts", value: "418",
-      trend_text: "8 added this month", trend_direction: :neutral, trend_sentiment: :neutral
-    ))
+  describe "trend arrows" do
+    it "renders an up arrow with an up direction" do
+      render_inline(described_class.new(
+        label: "Total", value: "100",
+        trend_text: "34 this month", trend_direction: :up, trend_sentiment: :positive
+      ))
 
-    expect(page).not_to have_css("i.bi")
-    expect(page).to have_css("div[style*='color: #6C757D']", text: "8 added this month")
+      expect(page).to have_css("i.bi.bi-arrow-up[aria-hidden='true']")
+    end
+
+    it "renders a down arrow with a down direction" do
+      render_inline(described_class.new(
+        label: "Active", value: "50",
+        trend_text: "5 this week", trend_direction: :down, trend_sentiment: :negative
+      ))
+
+      expect(page).to have_css("i.bi.bi-arrow-down[aria-hidden='true']")
+    end
+
+    it "renders no arrow with a neutral direction" do
+      render_inline(described_class.new(
+        label: "Accounts", value: "418",
+        trend_text: "8 added this month", trend_direction: :neutral, trend_sentiment: :neutral
+      ))
+
+      expect(page).to have_css("div.text-body-secondary", text: "8 added this month")
+      expect(page).to have_no_css("i.bi")
+    end
   end
 
-  it "hides trend section when no trend_text is provided" do
+  it "hides the trend section when no trend_text is provided" do
     render_inline(described_class.new(label: "Total", value: "100"))
 
-    expect(page).not_to have_css("div[style*='font-size: 12px']")
+    # Pin the card positively so the absence below is not a false green on an
+    # empty render.
+    expect(page).to have_css("div.bg-body", text: "100")
+    expect(page).to have_no_css("div[style*='font-size: 12px']")
+  end
+
+  describe "theme-adaptivity guards" do
+    it "keeps the non-colour geometry that has no Bootstrap equivalent" do
+      render_inline(described_class.new(
+        label: "Total Contacts", value: "2,307",
+        trend_text: "34 this month", trend_direction: :up, trend_sentiment: :positive
+      ))
+
+      # Colour left these declarations; size did not. Nothing else pins them — the
+      # guards below only assert what must be ABSENT, so removing a style helper
+      # outright would otherwise ship green.
+      expect(page).to have_css("div.bg-body[style*='padding: 20px']")
+      expect(page).to have_css("div[style*='text-transform: uppercase']", text: "Total Contacts")
+      expect(page).to have_css(
+        "div.text-body[style*='font-size: 32px'][style*='font-weight: 700']",
+        text: "2,307"
+      )
+      expect(page).to have_css(
+        "div.text-success-emphasis[style*='font-size: 12px']",
+        text: "34 this month"
+      )
+    end
+
+    it "emits no literal hex anywhere in the markup" do
+      # alert value (.text-danger) AND a positive trend (.text-success-emphasis) in
+      # one render, so every colour helper the component can emit is exercised.
+      render_inline(described_class.new(
+        label: "Overdue", value: "12", alert: true,
+        trend_text: "3 since yesterday", trend_direction: :up, trend_sentiment: :positive
+      ))
+
+      # Prove the markup actually rendered — a regex over an empty string passes forever.
+      expect(page).to have_css("div.bg-body[role='alert']")
+      expect(page).to have_css("div.text-danger", text: "12")
+      expect(page).to have_css("div.text-success-emphasis", text: "3 since yesterday")
+
+      expect(rendered_content).not_to match(hex_literal)
+    end
+
+    it "emits no colour, background, or border declaration in the inline styles that remain" do
+      render_inline(described_class.new(
+        label: "Total", value: "100",
+        trend_text: "34 this month", trend_direction: :up, trend_sentiment: :positive
+      ))
+
+      # Inline styles DO still exist (geometry) — without this the absences below
+      # would pass on a component that emitted no style at all.
+      expect(page).to have_css("div[style*='padding: 20px']")
+
+      expect(page).to have_no_css("[style*='color']")
+      expect(page).to have_no_css("[style*='background']")
+      # Colon-anchored so it does not match a future `border-radius` inline (radius is
+      # a class now, but the guard stays precise regardless).
+      expect(page).to have_no_css("[style*='border: ']")
+    end
+
+    it "pins no fixed-scheme utility that would break under data-bs-theme" do
+      render_inline(described_class.new(
+        label: "Total", value: "100",
+        trend_text: "34 this month", trend_direction: :up, trend_sentiment: :positive
+      ))
+
+      elements = page.all("div, div *")
+      expect(elements.size).to be > 1
+
+      applied = elements.flat_map { |el| el[:class].to_s.split }.uniq
+      expect(applied).to include("bg-body", "border", "rounded-3", "text-body-secondary", "text-body", "text-success-emphasis")
+      expect(applied & fixed_scheme_utilities).to be_empty
+    end
+  end
+
+  describe "edge cases" do
+    it "falls back to :neutral for an invalid trend_direction (no arrow)" do
+      render_inline(described_class.new(
+        label: "Total", value: "100",
+        trend_text: "note", trend_direction: :sideways, trend_sentiment: :neutral
+      ))
+
+      expect(page).to have_css("div.text-body-secondary", text: "note")
+      expect(page).to have_no_css("i.bi")
+    end
+
+    it "falls back to :neutral for an invalid trend_sentiment" do
+      render_inline(described_class.new(
+        label: "Total", value: "100",
+        trend_text: "note", trend_sentiment: :fuchsia
+      ))
+
+      expect(page).to have_css("div.text-body-secondary", text: "note")
+      expect(page).to have_no_css("div.text-success-emphasis")
+      expect(page).to have_no_css("div.text-danger-emphasis")
+    end
+
+    it "renders no trend div when trend_text is nil" do
+      render_inline(described_class.new(label: "Total", value: "100", trend_text: nil))
+
+      expect(page).to have_css("div.bg-body", text: "100")
+      expect(page).to have_no_css("div[style*='font-size: 12px']")
+    end
   end
 end

--- a/spec/components/mpi_design_system/admin/stat_card/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/stat_card/component_spec.rb
@@ -161,20 +161,39 @@ RSpec.describe MpiDesignSystem::Admin::StatCard::Component, type: :component do
       )
     end
 
-    it "emits no literal hex anywhere in the markup" do
-      # alert value (.text-danger) AND a positive trend (.text-success-emphasis) in
-      # one render, so every colour helper the component can emit is exercised.
-      render_inline(described_class.new(
-        label: "Overdue", value: "12", alert: true,
-        trend_text: "3 since yesterday", trend_direction: :up, trend_sentiment: :positive
-      ))
+    it "emits no literal hex in any colour-bearing branch" do
+      # A single render can show at most one value branch (alert is card-wide) and one
+      # trend sentiment, so sweeping one render leaves the others unswept — a hex
+      # re-introduced in an unrendered branch ships green. Sweep every colour-bearing
+      # branch: the default value (.text-body), the alert value (.text-danger), and each
+      # TREND_SENTIMENTS member (.text-success-emphasis / .text-danger-emphasis /
+      # .text-body-secondary), driving the sentiment set off the constant so a new
+      # sentiment is swept automatically.
+      trend_class = {
+        positive: "text-success-emphasis",
+        negative: "text-danger-emphasis",
+        neutral: "text-body-secondary"
+      }
 
-      # Prove the markup actually rendered — a regex over an empty string passes forever.
-      expect(page).to have_css("div.bg-body[role='alert']")
-      expect(page).to have_css("div.text-danger", text: "12")
-      expect(page).to have_css("div.text-success-emphasis", text: "3 since yesterday")
+      branches = [
+        { args: { label: "Accounts", value: "418" }, css: "div.text-body", text: "418" },
+        { args: { label: "Overdue", value: "12", alert: true }, css: "div.text-danger", text: "12" }
+      ]
+      described_class::TREND_SENTIMENTS.each do |sentiment|
+        branches << {
+          args: { label: "Total", value: "100", trend_text: "34 this month", trend_sentiment: sentiment },
+          css: "div.#{trend_class.fetch(sentiment)}", text: "34 this month"
+        }
+      end
 
-      expect(rendered_content).not_to match(hex_literal)
+      branches.each do |branch|
+        render_inline(described_class.new(**branch[:args]))
+
+        # Prove the branch actually rendered — a regex over an empty string passes forever.
+        expect(page).to have_css(branch[:css], text: branch[:text])
+        expect(rendered_content).not_to match(hex_literal),
+          "hex literal leaked in branch #{branch[:args]}"
+      end
     end
 
     it "emits no colour, background, or border declaration in the inline styles that remain" do

--- a/spec/dummy/app/views/contrast_demo/show.html.erb
+++ b/spec/dummy/app/views/contrast_demo/show.html.erb
@@ -37,6 +37,21 @@
         ) %>
   </section>
 
+  <%# StatCard (#150) — the card surface, value, and trend all resolve from Bootstrap
+      utilities after the conversion. render_inline proves the classes are emitted; only
+      a browser proves the `-emphasis` trend token actually PAINTS an AA-clean small-text
+      colour on the card surface, and that `.text-body` resolves for the value. Rendered
+      again inside #dark-mode below so the spec measures both colour modes. %>
+  <section id="stat-card" class="mb-4">
+    <%= render MpiDesignSystem::Admin::StatCard::Component.new(
+          label: "Total Contacts",
+          value: "2,307",
+          trend_text: "34 this month",
+          trend_direction: :up,
+          trend_sentiment: :positive
+        ) %>
+  </section>
+
   <section id="active-filter-bar" class="mb-4">
     <%= render MpiDesignSystem::Admin::ActiveFilterBar::Component.new(
           filters: [
@@ -107,6 +122,27 @@
     </div>
     <div id="dark-avatars">
       <%= render MpiDesignSystem::Admin::AvatarCircle::Component.new(name: "Mona Habib") %>
+    </div>
+    <%# #150: the AvatarStack `+N` chip's separator ring is `var(--bs-body-bg)`. Inside
+        this dark section `--bs-body-bg` resolves to Bootstrap's dark default (#212529),
+        so the ring border must compute rgb(33, 37, 41) — proving the var resolved rather
+        than pinning a light #fff. %>
+    <div id="dark-stack" class="mb-3">
+      <%= render MpiDesignSystem::Admin::AvatarStack::Component.new(
+            names: [ "Alice Wong", "Bob Smith", "Carol Davis", "Dave Ruiz", "Eve Fox", "Frank Ito" ],
+            max: 4
+          ) %>
+    </div>
+    <%# #150: StatCard under dark mode. The `-emphasis` trend token and `.text-body` value
+        must stay AA against the dark card surface (--bs-body-bg = #212529). %>
+    <div id="dark-stat-card" class="mb-3">
+      <%= render MpiDesignSystem::Admin::StatCard::Component.new(
+            label: "Total Contacts",
+            value: "2,307",
+            trend_text: "34 this month",
+            trend_direction: :up,
+            trend_sentiment: :positive
+          ) %>
     </div>
   </section>
 </main>

--- a/spec/dummy/app/views/contrast_demo/show.html.erb
+++ b/spec/dummy/app/views/contrast_demo/show.html.erb
@@ -77,9 +77,11 @@
     <%= render MpiDesignSystem::Admin::NavBar::Component.new(current_section: :dashboard) %>
   </section>
 
-  <%# Same components under Bootstrap's dark colour mode. ActiveFilterBar pins a
-      light background, so a theme-aware foreground would render light-on-light
-      (1.16:1) unless the component pins its colour mode too. (#130) %>
+  <%# Same components under Bootstrap's dark colour mode. After #150 ActiveFilterBar's
+      surface is `.bg-body-secondary` (adaptive), so the bar and its label flip to dark
+      together — the spec measures that the dark bar computes --bs-secondary-bg (#343A40)
+      and the label stays AA against it, where #130's pinned-light bar would instead have
+      rendered light-on-light (1.16:1). %>
   <section id="dark-mode" data-bs-theme="dark" class="p-3" style="background: #212529;">
     <div id="dark-active-filter-bar" class="mb-3">
       <%= render MpiDesignSystem::Admin::ActiveFilterBar::Component.new(

--- a/spec/features/contrast_spec.rb
+++ b/spec/features/contrast_spec.rb
@@ -147,6 +147,60 @@ RSpec.describe "Derived foreground contrast", type: :feature, js: true do
       expect(background).to eq(MpiDesignSystem::Admin::AvatarStack::Component::OVERFLOW_COLOR)
       expect(measured).to be >= 4.5
     end
+
+    # #150: the separator ring is `border: 2px solid var(--bs-body-bg)`. render_inline
+    # can only see the literal `var(--bs-body-bg)` string in the style attribute — it
+    # cannot prove the variable RESOLVES. A browser can: an unresolved/transparent ring
+    # would compute rgba(0, 0, 0, 0) (or the currentColor fallback), not the surface
+    # colour. In light mode `--bs-body-bg` is the page body bg (#FFFFFF).
+    it "resolves the ring border to the light body background (var(--bs-body-bg) = #FFFFFF)" do
+      expect(page).to have_css("#stack span[aria-hidden='true']")
+      expect(border_color_of("#stack span[aria-hidden='true']")).to eq("rgb(255, 255, 255)")
+    end
+
+    # And the whole point of the conversion: under data-bs-theme='dark' the ring tracks
+    # the dark surface (--bs-body-bg = #212529) instead of staying the retired white.
+    it "tracks the dark surface for the ring under data-bs-theme='dark' (#212529)" do
+      expect(page).to have_css("#dark-stack span[aria-hidden='true']")
+      expect(border_color_of("#dark-stack span[aria-hidden='true']")).to eq("rgb(33, 37, 41)")
+    end
+  end
+
+  # StatCard (#150). render_inline proves the `-emphasis` trend classes and `.text-body`
+  # value class are EMITTED (the unit spec covers that); only a browser proves they PAINT
+  # an AA-clean colour once the runtime `--bs-*-text-emphasis` / `--bs-body-color` chain
+  # resolves against the compiled bundle. The 12px trend is small text (AA 4.5:1); this is
+  # the external-oracle proof that the deliberate `-emphasis` choice actually clears it in
+  # BOTH colour modes, and that the value colour resolves. Painted values measured in Chrome.
+  describe "StatCard" do
+    {
+      "light" => { root: "#stat-card", trend_fg: "#0E402B", value_fg: "#1B2A4A", surface: "#FFFFFF" },
+      "dark" => { root: "#dark-stat-card", trend_fg: "#7AC6A6", value_fg: "#DEE2E6", surface: "#212529" }
+    }.each do |mode, expected|
+      context "in #{mode} mode" do
+        # Pinning the painted trend_fg is load-bearing: base `.text-success` would paint
+        # #22A06B (3.33:1 on the light card — below the 4.5:1 small-text floor), and a
+        # dropped class would fall back to inherited body colour. Only the exact
+        # `-emphasis` value distinguishes "the AA fix resolved" from either.
+        it "paints the -emphasis trend token AA-clean on the card surface (12px small text, 4.5:1)" do
+          measured, foreground, background = ratio_for("#{expected[:root]} .text-success-emphasis")
+
+          expect(foreground).to eq(expected[:trend_fg])
+          expect(background).to eq(expected[:surface])
+          expect(measured).to be >= 4.5,
+            "#{mode} trend #{foreground} on #{background} = #{measured.round(2)}:1"
+        end
+
+        it "paints the value in the adaptive body colour above the AA floor" do
+          measured, foreground, background = ratio_for("#{expected[:root]} .text-body")
+
+          expect(foreground).to eq(expected[:value_fg])
+          expect(background).to eq(expected[:surface])
+          expect(measured).to be >= 4.5,
+            "#{mode} value #{foreground} on #{background} = #{measured.round(2)}:1"
+        end
+      end
+    end
   end
 
   # The load-bearing part of this spec. Everything below is about whether the
@@ -211,6 +265,11 @@ RSpec.describe "Derived foreground contrast", type: :feature, js: true do
       foreground = computed("#dark-active-filter-bar .text-body-secondary", "color")
       background = computed("#dark-active-filter-bar [role='toolbar']", "backgroundColor")
 
+      # Pin the PAINTED foreground, not just the ratio. `.text-body-secondary` composites
+      # to rgba(dark body-color, .75) over the #343A40 bar = #B4B8BD (measured in Chrome).
+      # Without this, dropping the class lets the label fall back to inherited body colour
+      # and the ratio alone can't tell "the token resolved" from "something else painted".
+      expect(foreground).to eq("#B4B8BD")
       expect(background).to eq("#343A40")
       expect(MpiDesignSystem::ColorContrast.ratio(foreground, background)).to be >= 4.5,
         "dark-mode label #{foreground} on adaptive bar #{background} = " \
@@ -405,6 +464,13 @@ RSpec.describe "Derived foreground contrast", type: :feature, js: true do
 
       # #150: the light bar now computes `--bs-secondary-bg` (#E9ECEF), not the retired
       # pinned `#F5F7FA`. The label follows the surface instead of assuming it.
+      #
+      # Pin the PAINTED foreground too: `.text-body-secondary` composites to
+      # rgba(MPI navy body-color, .75) over #E9ECEF = #4F5B73 (measured in Chrome). The
+      # ratio alone is a false green here — if the class stopped applying the label falls
+      # back to inherited navy body text (#1B2A4A), which STILL clears AA on this light
+      # bar, so only the painted value distinguishes "token resolved" from "fell back".
+      expect(foreground).to eq("#4F5B73")
       expect(background).to eq("#E9ECEF")
       expect(MpiDesignSystem::ColorContrast.ratio(foreground, background)).to be >= 4.5
     end

--- a/spec/features/contrast_spec.rb
+++ b/spec/features/contrast_spec.rb
@@ -199,19 +199,21 @@ RSpec.describe "Derived foreground contrast", type: :feature, js: true do
     end
   end
 
-  # Bootstrap 5.3 colour modes. `.text-body-secondary` resolves through
-  # `--bs-body-color`, which flips to #dee2e6 under `data-bs-theme="dark"`.
-  # ActiveFilterBar pins a LIGHT background, so without pinning its colour mode
-  # too the label rendered at 1.16:1 in dark mode — a regression introduced by
-  # the fix itself and invisible to a light-mode-only suite. (#130)
+  # Bootstrap 5.3 colour modes. After #150 ActiveFilterBar's surface is
+  # `.bg-body-secondary` (adaptive), so the bar AND its `.text-body-secondary` label
+  # flip together with `data-bs-theme` — the inverse of #130, which had to PIN the bar's
+  # colour mode because its surface was a frozen light hex ($mpi-background) that would
+  # have rendered light-on-light (1.16:1) under a theme-aware label. With an adaptive
+  # surface the pin is gone and the dark bar computes `--bs-secondary-bg` = #343A40, the
+  # value the engine leaves at Bootstrap's dark default. (#150)
   describe "under data-bs-theme='dark'" do
-    it "keeps the ActiveFilterBar label readable against its pinned light bar" do
+    it "flips the ActiveFilterBar surface with the colour mode and keeps its label readable" do
       foreground = computed("#dark-active-filter-bar .text-body-secondary", "color")
       background = computed("#dark-active-filter-bar [role='toolbar']", "backgroundColor")
 
-      expect(background).to eq("#F5F7FA")
+      expect(background).to eq("#343A40")
       expect(MpiDesignSystem::ColorContrast.ratio(foreground, background)).to be >= 4.5,
-        "dark-mode label #{foreground} on pinned light bar #{background} = " \
+        "dark-mode label #{foreground} on adaptive bar #{background} = " \
         "#{MpiDesignSystem::ColorContrast.ratio(foreground, background).round(2)}:1"
     end
 
@@ -397,11 +399,13 @@ RSpec.describe "Derived foreground contrast", type: :feature, js: true do
   end
 
   describe "muted text" do
-    it "paints the ActiveFilterBar label above the AA floor against the bar" do
+    it "paints the ActiveFilterBar label above the AA floor against the adaptive bar" do
       foreground = computed("#active-filter-bar .text-body-secondary", "color")
       background = computed("#active-filter-bar [role='toolbar']", "backgroundColor")
 
-      expect(background).to eq("#F5F7FA")
+      # #150: the light bar now computes `--bs-secondary-bg` (#E9ECEF), not the retired
+      # pinned `#F5F7FA`. The label follows the surface instead of assuming it.
+      expect(background).to eq("#E9ECEF")
       expect(MpiDesignSystem::ColorContrast.ratio(foreground, background)).to be >= 4.5
     end
 

--- a/spec/packaging/version_spec.rb
+++ b/spec/packaging/version_spec.rb
@@ -10,11 +10,13 @@ require "spec_helper"
 # headers (harvest#692); v0.7.0 (#148) releases Admin::ActionButton's classes_append: /
 # verb-gated role: / :info color (#136), AA foreground derivation for the inline-styled
 # components (#130), and the changelog release guard (#127); v0.8.0 (#149) makes
-# Admin::Pagination theme-adaptive — the Track 2 pilot conversion (epic #147). This spec
+# Admin::Pagination theme-adaptive — the Track 2 pilot conversion (epic #147);
+# v0.9.0 releases the NavBar/AppShell theme-adaptive conversion (#154, phase 6) and the
+# StatCard/AvatarStack/ActiveFilterBar small conversions (#150, phase 2). This spec
 # fails if the constant regresses, keeping lib/mpi_design_system/version.rb in lockstep
 # with CHANGELOG.md and the git tag.
 RSpec.describe "MpiDesignSystem::VERSION" do
-  it "is 0.8.0" do
-    expect(MpiDesignSystem::VERSION).to eq("0.8.0")
+  it "is 0.9.0" do
+    expect(MpiDesignSystem::VERSION).to eq("0.9.0")
   end
 end


### PR DESCRIPTION
## Summary
Converts three components — **StatCard**, **AvatarStack**, and **ActiveFilterBar** — from hardcoded inline hex to Bootstrap 5.3 theme-adaptive semantic utilities, following the #149 Pagination pilot. Each now tracks `data-bs-theme` (light/dark) instead of pinning a light palette, and two verified WCAG AA improvements ship along the way. The PR also bundles the **v0.9.0** release (a separate commit) per the epic's one-release-per-phase DoD.

Closes #150. Part of the Track 2 epic #147 (phase 2).

## Changes Made
Two commits:
1. **Convert 3 components to theme-adaptive utilities** — conversion + specs + catalog
2. **chore(release): v0.9.0** — `version.rb`, `version_spec.rb`, README tag pins, `CHANGELOG.md`

- **StatCard** (`component.rb` + `.erb`): card `bg-body border rounded-3` (radius preserved at 8px); label `text-body-secondary`; value `text-body` / `text-danger`; trend `text-success-emphasis` / `text-danger-emphasis` / `text-body-secondary` (rewrote the dead `trend_class`, which returned non-adaptive base classes). Style helpers reduced to geometry.
- **AvatarStack** (`.erb`): separator ring `#fff` → `var(--bs-body-bg)`. Chip bg (`#64748B` / `$mpi-tag-internal`) and #130-derived foreground kept (no Bootstrap semantic equivalent).
- **ActiveFilterBar** (`component.rb` + `.erb`): bar `#F5F7FA` → `bg-body-secondary rounded`; removed the now-wrong `data-bs-theme="light"` pin (it existed only to freeze the light hex against a theme-aware label — an adaptive surface makes it a dark-mode regression). Pills/labels/remove already tokenised (#130).
- **Specs**: rewrote the StatCard and ActiveFilterBar render specs and the AvatarStack chip block — hex-literal sweeps, fixed-scheme-utility guards, geometry-survivor pins, and a `TREND_SENTIMENTS` loop. `spec/features/contrast_spec.rb` now asserts the adaptive bar's computed `#E9ECEF` (light) / `#343A40` (dark), measured in-browser; the `contrast_demo` fixture comment updated.
- **Catalog**: `catalog/components/stat-card.md` and `filter-chip-bar.md` re-derived (incl. accessibility claims); `catalog/previews/stat-card.html` and `filter-chip-bar.html` converted to utilities with `:root` token blocks mirroring `_tokens.scss`.
- **Release**: `v0.9.0` releases this batch **and** the already-merged NavBar #154 work that was sitting in `[Unreleased]`.

## Technical Approach
- Bootstrap utilities so colour derives from the consuming app's tokens + colour mode, per the epic's dark-mode mandate.
- **Large vs small text AA split** in StatCard: the 32px value keeps base `.text-danger` (large text, 3:1 — clears both modes, semantically red); the 12px trend uses `-emphasis` variants (small text, 4.5:1 — base `.text-success` = 3.33:1 and `.text-danger` = 3.41:1 fail and aren't adaptive). Verified with the engine's `ColorContrast` oracle.
- Computed/emphasis values measured against the compiled engine bundle and confirmed in a real browser; the two CDN mockups got `:root` blocks so they paint MPI's palette, not stock Bootstrap indigo/green.
- Every new guard was mutation-tested (watched fail, then reverted). The plan was **Codex-reviewed before any code** — it caught the browser feature spec and the trend AA failure (see the #150 thread).

## Testing
- `bundle exec rubocop -a` — 0 offenses.
- `bundle exec rspec` — **1006 examples, 0 failures**, including the browser feature specs (`spec/features/contrast_spec.rb`, real headless Chrome), which ran and passed.
- 4 guard mutations each reddened the intended example and were reverted.
- Both catalog mockups browser-verified against CDN Bootstrap (MPI palette confirmed, light + dark).
- `spec/packaging/` guards green after the release bump.

## Release
- `v0.9.0`. The git tag is cut **post-merge**, fail-closed on the merge SHA's CI (CONTRIBUTING § Release).

## Checklist
- [x] Tests pass
- [x] Linting passes

— Claude Code (Fable 5)
