### PR TITLE
Convert FilterChipBar & DataTable to theme-adaptive utilities (Phase 3, #151)

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -256,6 +256,29 @@ Rules:
   `ratio(bg, accessible_foreground(bg)) >= 4.5` calls the code under test on both sides — wrong
   luminance math agrees with itself and still ships a failure. `bin/verify-contrast-oracle`
   compiles Bootstrap's own `color-contrast()` over the palette in CI for exactly this reason
+- **Mapping a bespoke multi-category palette onto Bootstrap semantics yields at most five distinct
+  *adaptive* hues — MPI maps `$info → $primary`.** The theme-adaptive families are
+  `primary`/`success`/`warning`/`danger`/`secondary` (`light`/`dark` are neutrals, not category
+  colours), and because `_tokens_values.scss` sets `$mpi-info: $mpi-primary`, `bg-info-subtle` /
+  `text-info-emphasis` render the *same blue* as `primary`. So a palette of more than five
+  categories collapses when mapped to semantics — the extras must double up. Present the collapse
+  honestly (state which categories share a hue) and rely on the always-present text label to carry
+  the identity; if per-category distinction is load-bearing, that is the real-token path — a
+  designer decision. (Reference: #151 mapped the 7-category `TagChip::Component::GROUPS`, and
+  `press_festival`/`production`/`vendors` all collapsed onto blue — Codex's plan review caught the
+  `info==primary` fact the plan had missed.)
+- **A solid `bg-#{semantic}` fill is a *fixed* hue, not theme-adaptive — it reads
+  `--bs-#{semantic}-rgb`, which Bootstrap does not shift under `data-bs-theme`.** Only
+  `-subtle`/`-emphasis`, `bg-body`, `text-body`/`text-body-secondary` and `--bs-link-color`
+  re-resolve per mode. Reserve solid `bg-#{semantic}` for **decorative** marks (a category/status
+  dot whose meaning is carried by an adjacent text label — WCAG 2.1 SC 1.4.11 exempts decorative
+  graphics), keep it a deliberate fixed identity hue like the nav env-bar's status strips, and
+  **prove ≥3:1 on the *resting* surface in both modes — do not claim contrast the `table-hover`
+  (or any hover) state violates.** A dot on a hovered `.table` row composites an inset shadow over
+  the backdrop and can dip below 3:1; that transient dip is acceptable only because the dot is
+  decorative. (Reference: #151 — DataTable's tag/status dots; Codex's PR review caught a CHANGELOG
+  claim that "each dot" was proven ≥3:1 which a never-hovering, two-variant browser guard did not
+  actually establish.)
 - Visible focus indicators on every focusable element
 
 ## Anti-Patterns

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -218,6 +218,17 @@ Prove it by adding one and watching red. (Reference: #150 — `AvatarStack` keep
 `+N` overflow chip; the first residual sweep string-deleted it and would have masked the same hex
 reused elsewhere, caught by external review.)
 
+**Related — a theme-adaptivity guard must forbid the colour-bearing *properties by name*, not only
+literal-colour *values*.** A guard that rejects `color`/`background` declarations plus hex/rgb/hsl
+literals still lets `border: 1px solid red` (a *named* colour) and `border: none` through — the exact
+inline-border regression a hex→utility conversion removes. Parse each surviving inline declaration and
+reject any whose property is `color` / `background(-color)` /
+`border(-top|right|bottom|left|color|style|width)` / `outline` / `box-shadow` / `opacity` (allow the
+geometry custom property `--bs-border-width` and `border-radius`), and add named colours to the value
+scan. Prove it by injecting `border: 1px solid red` into a style helper and watching red. (Reference:
+#151 — the FilterChipBar/DataTable conversion's first guard rejected only hex/rgb/hsl values and
+`color`/`background` properties, so a named-colour or `none` border passed; caught by external review.)
+
 ## A Guard Is Not Real Until You Have Watched It Fail
 
 The two shapes above are assertions that *can* fail but don't discriminate. This is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ include breaking changes).
 
 ## [Unreleased]
 
+### Changed
+- **`Admin::FilterChipBar` and `Admin::DataTable` are theme-adaptive** — both stopped pinning
+  a light palette in inline styles; every colour now resolves from a Bootstrap semantic
+  utility, so they follow `data-bs-theme` and the consuming app's mapped tokens. A new shared
+  map, `TagChip::Component::GROUP_VARIANTS`, translates each CRM tag group onto a Bootstrap
+  semantic (`press_festival`/`production`/`vendors` → `primary`, `outreach` → `success`,
+  `finance` → `warning`, `distribution` → `danger`, `internal` → `secondary`). Because MPI maps
+  `$info` → `$primary`, the palette offers **five** distinct adaptive hues, so the three cool
+  categories collapse onto blue — an accepted trade of the smallest-blast conversion; the tag's
+  always-present text label carries the identity (see `catalog/elements/tag-chip.md` § Semantic
+  Mapping). Mapping:
+  - **FilterChipBar** — selected chip `bg-#{sem}-subtle text-#{sem}-emphasis border border-#{sem}-subtle`
+    (AA in both modes, unlike the frozen hex pairs); unselected `border bg-body text-body`; the
+    active pill's `×` moved from inline `color: inherit` to `text-reset bg-transparent border-0`.
+  - **DataTable** — header muted via `text-body-secondary`, its 2px separator the `border-bottom`
+    utility with an inline `--bs-border-width: 2px` on the bottom edge only (`border-2` would box
+    all four sides of a `.table th`); name/tag text `text-body`, title/meta `text-body-secondary`;
+    the account link uses Bootstrap's default adaptive `--bs-link-color` (`#2E75B6` light,
+    `#82ACD3` dark) and keeps its natural underline; cells `align-middle`.
+
+  The tag/status **dots** are the one deliberate exception: `bg-#{sem}` reads `--bs-#{sem}-rgb`, a
+  **fixed identity hue across colour modes** (decorative — the adjacent label carries the meaning,
+  mirroring the nav env-bar's fixed status hues). Every variant (all five group hues, all three
+  status hues) is browser-proven ≥3:1 against the **resting** row backdrop in **both** themes;
+  because the dots are decorative — the text label conveys the category — the transient dip below
+  3:1 on a **hovered** row (`table-hover` composites an inset shadow over the backdrop) is
+  acceptable per WCAG 2.1 SC 1.4.11 and is deliberately not claimed. `TagChip`'s own rendering still uses the frozen hex pairs this
+  phase; converting the remaining `GROUPS` consumers is a tracked follow-up. Both partials are
+  proven in a real browser (`spec/features/contrast_spec.rb`) — painted value **and** ratio, in
+  both colour modes. No public API change to the components' parameters. (#151 — Track 2 phase 3,
+  epic #147)
+
+  **Removed (internal, pre-1.0):** `DataTable::Component::STATUS_COLORS` and
+  `DataTable::Component::TAG_DOT_COLORS` — the two frozen hex maps the conversion replaced with
+  `STATUS_VARIANTS` and the shared `GROUP_VARIANTS`. Both were public Ruby constants; no consumer
+  call sites were found. Formally breaking only if an app referenced them directly.
+
 ## [0.9.0] - 2026-07-22
 
 ### Changed

--- a/app/components/mpi_design_system/admin/data_table/component.html.erb
+++ b/app/components/mpi_design_system/admin/data_table/component.html.erb
@@ -2,7 +2,7 @@
   <thead>
     <tr>
       <% @columns.each do |col| %>
-        <th scope="col" style="<%= header_styles %>"<% if aria_sort(col) %> aria-sort="<%= aria_sort(col) %>"<% end %>>
+        <th scope="col" class="text-body-secondary border-bottom" style="<%= header_styles %>"<% if aria_sort(col) %> aria-sort="<%= aria_sort(col) %>"<% end %>>
           <%= col[:label] %><%= sort_indicator(col) %>
         </th>
       <% end %>
@@ -12,21 +12,21 @@
     <% @rows.each do |row| %>
       <tr>
         <% @columns.each do |col| %>
-          <td style="<%= cell_styles %>">
+          <td class="align-middle">
             <% case col[:key] %>
             <% when :name %>
               <div class="d-flex align-items-center gap-2">
                 <%= render MpiDesignSystem::Admin::AvatarCircle::Component.new(name: row[:name], size: :md) %>
                 <div>
-                  <div style="<%= name_styles %>">
+                  <div class="text-body" style="<%= name_styles %>">
                     <% if row[:name_href] %>
-                      <a href="<%= row[:name_href] %>" style="color: inherit; text-decoration: none;"><%= row[:name] %></a>
+                      <a href="<%= row[:name_href] %>" class="text-body text-decoration-none"><%= row[:name] %></a>
                     <% else %>
                       <%= row[:name] %>
                     <% end %>
                   </div>
                   <% if row[:title] %>
-                    <div style="<%= title_styles %>"><%= sanitize(row[:title], tags: %w[strong em b i a span], attributes: %w[href title class]) %></div>
+                    <div class="text-body-secondary" style="<%= title_styles %>"><%= sanitize(row[:title], tags: %w[strong em b i a span], attributes: %w[href title class]) %></div>
                   <% end %>
                 </div>
               </div>
@@ -35,8 +35,8 @@
                 <div class="d-flex flex-wrap gap-1">
                   <% row[:tags].each do |tag| %>
                     <span class="d-inline-flex align-items-center gap-1">
-                      <span style="<%= tag_dot_style(tag[:group]) %>"></span>
-                      <span style="<%= tag_text_styles %>"><%= tag[:label] %></span>
+                      <span class="<%= tag_dot_class(tag[:group]) %>" style="<%= dot_styles %>"></span>
+                      <span class="text-body" style="<%= tag_text_styles %>"><%= tag[:label] %></span>
                     </span>
                   <% end %>
                 </div>
@@ -46,18 +46,18 @@
                 <% if row[:account_href].present? %>
                   <a href="<%= row[:account_href] %>" style="<%= account_link_styles %>"><%= row[:account] %></a>
                 <% else %>
-                  <span style="<%= account_link_styles %>"><%= row[:account] %></span>
+                  <span class="text-body" style="<%= account_link_styles %>"><%= row[:account] %></span>
                 <% end %>
               <% end %>
             <% when :status %>
               <% if row[:status] %>
                 <span class="d-inline-flex align-items-center gap-1">
-                  <span style="<%= status_dot_style(row[:status_key]) %>"></span>
-                  <span style="<%= meta_text_styles %>"><%= row[:status] %></span>
+                  <span class="<%= status_dot_class(row[:status_key]) %>" style="<%= dot_styles %>"></span>
+                  <span class="text-body-secondary" style="<%= meta_text_styles %>"><%= row[:status] %></span>
                 </span>
               <% end %>
             <% else %>
-              <span style="<%= meta_text_styles %>"><%= row[col[:key]].is_a?(String) ? sanitize(row[col[:key]], tags: %w[strong em b i code br a], attributes: %w[href title]) : row[col[:key]] %></span>
+              <span class="text-body-secondary" style="<%= meta_text_styles %>"><%= row[col[:key]].is_a?(String) ? sanitize(row[col[:key]], tags: %w[strong em b i code br a], attributes: %w[href title]) : row[col[:key]] %></span>
             <% end %>
           </td>
         <% end %>

--- a/app/components/mpi_design_system/admin/data_table/component.rb
+++ b/app/components/mpi_design_system/admin/data_table/component.rb
@@ -6,12 +6,18 @@ module MpiDesignSystem
       class Component < ViewComponent::Base
         VARIANTS = %i[contacts search_results].freeze
 
-        TAG_DOT_COLORS = MpiDesignSystem::Admin::TagChip::Component::GROUPS.transform_values { |v| v[:color] }.freeze
+        # Tag dots derive their colour from the shared tag-group -> semantic mapping,
+        # so a category renders the same theme-adaptive hue everywhere it is converted.
+        GROUP_VARIANTS = MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS
 
-        STATUS_COLORS = {
-          active: "#22A06B",
-          follow_up: "#D97706",
-          inactive: "#6C757D"
+        # Record status -> Bootstrap semantic. Replaces the retired STATUS_COLORS hex
+        # map. The status dot fill (`bg-#{sem}`) is a FIXED decorative identity hue —
+        # constant across colour modes, NOT `data-bs-theme`-adaptive (see
+        # `status_dot_class`); the adjacent status label carries the meaning.
+        STATUS_VARIANTS = {
+          active: :success,
+          follow_up: :warning,
+          inactive: :secondary
         }.freeze
 
         # @param columns [Array<Hash>] Column definitions:
@@ -30,14 +36,18 @@ module MpiDesignSystem
 
         private
 
+        # Geometry only. The muted foreground now comes from `text-body-secondary`
+        # and the 2px separator from the `border-bottom` utility (colour via the
+        # adaptive `--bs-border-color`), both applied in the template. The `<th>` keeps
+        # `--bs-border-width: 2px` inline so the utility renders 2px on the BOTTOM edge
+        # only — `border-2` would widen all four sides of a `.table th`. (#151)
         def header_styles
           [
             "font-size: 11px",
             "font-weight: 600",
             "text-transform: uppercase",
             "letter-spacing: 0.06em",
-            "color: #6C757D",
-            "border-bottom: 2px solid #DEE2E6"
+            "--bs-border-width: 2px"
           ].join("; ")
         end
 
@@ -53,38 +63,59 @@ module MpiDesignSystem
           @sort_dir == :asc ? "ascending" : "descending"
         end
 
+        # Geometry only; the navy foreground now comes from `text-body` in the
+        # template (adaptive via `--bs-body-color`).
         def name_styles
-          "font-weight: 600; color: #1B2A4A; font-size: 14px;"
+          "font-weight: 600; font-size: 14px;"
         end
 
+        # Geometry only; muted foreground now comes from `text-body-secondary`.
         def title_styles
-          "font-size: 12px; color: #6C757D;"
+          "font-size: 12px;"
         end
 
-        def tag_dot_style(group)
-          color = TAG_DOT_COLORS[group] || "#64748B"
-          "width: 6px; height: 6px; border-radius: 50%; background: #{color}; display: inline-block;"
+        # Dots are geometry only — their fill comes from `tag_dot_class` /
+        # `status_dot_class` (`bg-#{variant}`). See the dark-mode note on those.
+        def dot_styles
+          "width: 6px; height: 6px; border-radius: 50%;"
         end
 
+        # Decorative identity dots. `bg-#{variant}` reads `--bs-#{variant}-rgb`, a
+        # FIXED hue across colour modes rather than a `data-bs-theme`-adaptive one —
+        # an intentional exception, mirroring the nav env-bar's fixed status hues: a
+        # category/status IDENTITY colour should stay constant, and the browser spec
+        # proves every variant >=3:1 on both the light and dark RESTING row backdrops.
+        # The colour meaning is carried by the adjacent text label, so the dot is
+        # purely decorative (WCAG 2.1 SC 1.4.11) — which is why the transient dip below
+        # 3:1 on a HOVERED row (`table-hover` paints an inset shadow over the backdrop)
+        # is acceptable and deliberately not asserted. An unknown group falls back to
+        # `secondary`. (#151)
+        def tag_dot_class(group)
+          "d-inline-block bg-#{GROUP_VARIANTS[group] || :secondary}"
+        end
+
+        # Geometry only; navy foreground now comes from `text-body`.
         def tag_text_styles
-          "font-size: 13px; color: #1B2A4A;"
+          "font-size: 13px;"
         end
 
+        # Geometry only; muted foreground now comes from `text-body-secondary`.
         def meta_text_styles
-          "font-size: 13px; color: #6C757D;"
+          "font-size: 13px;"
         end
 
+        # Geometry only. The account anchor now uses Bootstrap's DEFAULT adaptive link
+        # colour (`--bs-link-color` — AA on white ~4.6:1, `#82ACD3` in dark) and keeps
+        # its natural underline as the navigation affordance, so no colour or
+        # text-decoration is declared here. (#151)
         def account_link_styles
-          "color: #2E75B6; font-size: 13px; text-decoration: none;"
+          "font-size: 13px;"
         end
 
-        def status_dot_style(status)
-          color = STATUS_COLORS[status] || "#6C757D"
-          "width: 6px; height: 6px; border-radius: 50%; background: #{color}; display: inline-block;"
-        end
-
-        def cell_styles
-          "vertical-align: middle;"
+        # See tag_dot_class — same decorative fixed-hue exception. Unknown status
+        # falls back to `secondary`.
+        def status_dot_class(status)
+          "d-inline-block bg-#{STATUS_VARIANTS[status] || :secondary}"
         end
       end
     end

--- a/app/components/mpi_design_system/admin/filter_chip_bar/component.html.erb
+++ b/app/components/mpi_design_system/admin/filter_chip_bar/component.html.erb
@@ -5,12 +5,13 @@
       <% @groups.each do |chip| %>
         <% if chip[:href] %>
           <a href="<%= chip[:href] %>"
-             style="<%= group_chip_styles(chip) %>"
+             class="<%= group_chip_classes(chip) %>"
+             style="<%= group_chip_styles %>"
              <% if chip[:selected] %>aria-current="page"<% end %>>
             <%= chip_label(chip) %>
           </a>
         <% else %>
-          <span style="<%= group_chip_styles(chip) %>">
+          <span class="<%= group_chip_classes(chip) %>" style="<%= group_chip_styles %>">
             <%= chip_label(chip) %>
           </span>
         <% end %>
@@ -29,6 +30,7 @@
           <%= pill_label(filter) %>
           <% if filter[:remove_url] %>
             <a href="<%= filter[:remove_url] %>"
+               class="text-reset bg-transparent border-0"
                style="<%= remove_btn_styles %>"
                aria-label="Remove filter: <%= pill_label(filter) %>"
                data-turbo-method="delete">

--- a/app/components/mpi_design_system/admin/filter_chip_bar/component.rb
+++ b/app/components/mpi_design_system/admin/filter_chip_bar/component.rb
@@ -5,6 +5,7 @@ module MpiDesignSystem
     module FilterChipBar
       class Component < ViewComponent::Base
         GROUPS = MpiDesignSystem::Admin::TagChip::Component::GROUPS
+        GROUP_VARIANTS = MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS
 
         # @param groups [Array<Hash>] Group chip data:
         #   [{ label: "All", count: 2307 },
@@ -36,35 +37,36 @@ module MpiDesignSystem
           ].join("; ")
         end
 
-        def group_chip_styles(chip)
-          selected = chip[:selected]
-          group_key = chip[:group]
-
-          styles = [
+        # Geometry only. Every colour (border, background, foreground) now comes from
+        # the Bootstrap semantic utilities in `group_chip_classes`, so the chip tracks
+        # `data-bs-theme` instead of pinning a light palette. `border-radius: 999px`,
+        # `text-decoration: none` and `display: inline-block` moved to their utility
+        # equivalents (`rounded-pill`/`text-decoration-none`/`d-inline-block`); the
+        # 5px/12px padding, 13px size and 500 weight have no Bootstrap equivalent and
+        # stay inline deliberately. (#151)
+        def group_chip_styles
+          [
             "padding: 5px 12px",
-            "border-radius: 999px",
             "font-size: 13px",
-            "font-weight: 500",
-            "text-decoration: none",
-            "display: inline-block"
-          ]
+            "font-weight: 500"
+          ].join("; ")
+        end
 
-          if selected && group_key && GROUPS[group_key]
-            colors = GROUPS[group_key]
-            styles.concat([
-              "border: 1px solid #{colors[:color]}",
-              "background: #{colors[:bg]}",
-              "color: #{colors[:color]}"
-            ])
+        # A selected chip with a known group renders that group's semantic `-subtle`
+        # surface + `-emphasis` foreground (AA-clean, theme-adaptive). An unselected
+        # chip — or a selected one whose group is unknown/absent — falls back to the
+        # neutral `bg-body text-body` treatment. The fallback is a state the selected
+        # branch cannot produce (no `-subtle`/`-emphasis` utilities), so the spec can
+        # tell the two apart. (#151)
+        def group_chip_classes(chip)
+          base = "rounded-pill d-inline-block text-decoration-none"
+          variant = chip[:selected] ? GROUP_VARIANTS[chip[:group]] : nil
+
+          if variant
+            "#{base} border border-#{variant}-subtle bg-#{variant}-subtle text-#{variant}-emphasis"
           else
-            styles.concat([
-              "border: 1px solid #DEE2E6",
-              "background: #fff",
-              "color: #1B2A4A"
-            ])
+            "#{base} border bg-body text-body"
           end
-
-          styles.join("; ")
         end
 
         # Geometry only — background and foreground come from `.text-bg-primary`.
@@ -81,13 +83,14 @@ module MpiDesignSystem
           ].join("; ")
         end
 
-        # Inherits the pill's derived foreground. The retired `opacity: 0.8` faded
-        # white to an effective #D5E3F0 — 3.71:1, an AA failure. (#130)
+        # Geometry only. Colour, background and border now come from
+        # `text-reset bg-transparent border-0` in the template, so the button inherits
+        # the pill's derived foreground (as the retired inline `color: inherit` did)
+        # and pins nothing of its own — leaving no colour declaration for the
+        # theme-adaptivity guard to catch. The retired `opacity: 0.8` faded white to
+        # an effective #D5E3F0 (3.71:1, an AA failure) and stays gone. (#130, #151)
         def remove_btn_styles
           [
-            "color: inherit",
-            "background: none",
-            "border: none",
             "padding: 0",
             "font-size: inherit",
             "line-height: 1",

--- a/app/components/mpi_design_system/admin/tag_chip/component.rb
+++ b/app/components/mpi_design_system/admin/tag_chip/component.rb
@@ -14,6 +14,30 @@ module MpiDesignSystem
           outreach: { color: "#2DA67E", bg: "#ECF8F4" }
         }.freeze
 
+        # Maps each CRM tag group onto a Bootstrap semantic colour so consumers that
+        # want a theme-adaptive chip (FilterChipBar's selected chip, DataTable's tag
+        # dots) resolve their colour from `--bs-*` rather than the frozen hex above.
+        # This is the single source of truth for that mapping — every key in GROUPS
+        # has an entry (asserted in the spec).
+        #
+        # MPI maps `$info` -> `$primary` (`_tokens_values.scss`), so `info` would
+        # render the same blue as `primary`; the palette therefore offers five
+        # distinct adaptive hues, and the three cool categories collapse onto
+        # `primary` (blue). This is an accepted trade of Option A (#151) — the tag's
+        # always-present text label carries the identity, not the hue alone. The
+        # remaining `GROUPS` consumers (TagChip's own rendering, contact/engagement
+        # cards, list rows, detail panels) still render the frozen hex this phase;
+        # unifying them is the tracked #151 follow-up.
+        GROUP_VARIANTS = {
+          press_festival: :primary,
+          production: :primary,
+          vendors: :primary,
+          outreach: :success,
+          finance: :warning,
+          distribution: :danger,
+          internal: :secondary
+        }.freeze
+
         # @param label [String] Tag display text
         # @param group [Symbol] :production, :distribution, :finance, :press_festival, :internal, :vendors, :outreach
         # @param removable [Boolean] Show x remove button (default: false)

--- a/catalog/components/data-table.md
+++ b/catalog/components/data-table.md
@@ -10,13 +10,19 @@ Sortable data table for CRM list views. Used for contacts, search results, and o
 
 ## Design Decisions
 
-- **Row structure:** Avatar + Name/Title in first column, Tags with colored dots, Last Engagement as relative time, Account as blue link
-- **Tag format:** Colored dot + "Group — Role" text (e.g., `● Acquisitions`), not pill badges in table rows
-- **Status format:** Colored dot + text (e.g., `● Active`, `● Follow up`)
+- **Row structure:** Avatar + Name/Title in first column, Tags with colored dots, Last Engagement as relative time, Account as an adaptive link
+- **Tag format:** Semantic dot (`bg-#{sem}` via `GROUP_VARIANTS`) + "Group — Role" text (e.g., `● Acquisitions`), not pill badges in table rows
+- **Status format:** Semantic dot (`bg-#{sem}` via `STATUS_VARIANTS`) + text (e.g., `● Active`, `● Follow up`)
 - **Search results variant:** Adds "Match Found In" and "Status" columns with keyword highlighting (`<strong>`)
-- **Account names:** Blue links (`#2E75B6`) that navigate to account detail
-- **Header style:** ALL-CAPS, 11px, `font-weight: 600`, `letter-spacing: 0.06em`, color `#6C757D`
+- **Account names:** Links in Bootstrap's default adaptive colour (`--bs-link-color`; `#2E75B6`
+  in light, `#82ACD3` in dark) with their natural underline, navigating to account detail (#151)
+- **Header style:** ALL-CAPS, 11px, `font-weight: 600`, `letter-spacing: 0.06em`, muted via
+  `text-body-secondary`; the 2px separator is the `border-bottom` utility with an inline
+  `--bs-border-width: 2px` (bottom edge only — `border-2` would box all four sides of a `.table th`) (#151)
 - **Row hover:** Uses Bootstrap `table-hover` for subtle row highlighting
+- **Theme-adaptive:** Every colour resolves from a Bootstrap utility (`--bs-*`), so the table
+  follows `data-bs-theme`. The one exception is the decorative tag/status **dots**, which keep a
+  fixed identity hue across colour modes (see Accessibility) (#151)
 
 ## Variants
 
@@ -31,10 +37,10 @@ Sortable data table for CRM list views. Used for contacts, search results, and o
 
 | Column | Content | Width |
 |---|---|---|
-| Name | AvatarCircle (36px) + Name (bold, `#1B2A4A`) + Title (muted, 12px) | ~30% |
-| Tags | Colored dots with "Group — Role" text, wrapping | ~30% |
-| Last Engagement | Relative time ("2 days ago", "1 week ago"), muted 13px | ~20% |
-| Account | Blue link to account | ~20% |
+| Name | AvatarCircle (36px) + Name (bold, `text-body`) + Title (`text-body-secondary`, 12px) | ~30% |
+| Tags | Semantic dots with "Group — Role" text, wrapping | ~30% |
+| Last Engagement | Relative time ("2 days ago", "1 week ago"), `text-body-secondary` 13px | ~20% |
+| Account | Adaptive link (`--bs-link-color`) to account | ~20% |
 
 ### Search Results Table (Screen 6)
 
@@ -46,17 +52,23 @@ Sortable data table for CRM list views. Used for contacts, search results, and o
 | Last Engaged | Relative time |
 | Status | Colored dot + status text (Active/Follow up) |
 
-## Tag Dot Colors
+## Tag & Status Dot Colors
 
-Dots use the tag group primary colors from `tokens/colors.md`:
+Dots are `bg-#{sem}` where `#{sem}` comes from `GROUP_VARIANTS` (tags) / `STATUS_VARIANTS`
+(status) — see `catalog/elements/tag-chip.md` § Semantic Mapping. `bg-*` reads
+`--bs-#{sem}-rgb`, a fixed hue across colour modes (decorative identity; the label carries the
+meaning). An unknown group or status falls back to `secondary` (#151).
 
-| Group | Dot Color |
-|---|---|
-| Buyers | `#E8733A` |
-| Press | `#2DA67E` |
-| Festivals | `#2E75B6` |
-| Sellers | `#8B5CF6` |
-| Internal | `#64748B` |
+| Group / Status | Semantic | Dot |
+|---|---|---|
+| Distribution | `danger` | `bg-danger` (red) |
+| Outreach | `success` | `bg-success` (green) |
+| Finance | `warning` | `bg-warning` (amber) |
+| Press/Festival · Production · Vendors | `primary` | `bg-primary` (blue) |
+| Internal | `secondary` | `bg-secondary` (grey) |
+| Status: Active | `success` | `bg-success` |
+| Status: Follow up | `warning` | `bg-warning` |
+| Status: Inactive | `secondary` | `bg-secondary` |
 
 ## States
 
@@ -65,7 +77,7 @@ Dots use the tag group primary colors from `tokens/colors.md`:
 | Default | Normal row display |
 | Hover | Subtle background highlight (Bootstrap `table-hover`) |
 | Selected | TBD — bulk selection pattern not yet designed |
-| Empty | Shows EmptyState component |
+| Empty | Renders the `<thead>` with an **empty `<tbody>`** — the component does not render an EmptyState (the consumer is responsible for an empty-state message around the table) |
 | Loading | Skeleton placeholder rows or spinner |
 
 ## Props / API
@@ -96,21 +108,35 @@ end
 
 ## Key Styles
 
+After #151 every colour comes from a Bootstrap utility; only geometry is declared inline
+(classes shown in comments, not the pinned hex they replaced):
+
 ```css
-th { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: #6C757D; }
-.contact-name { font-weight: 600; color: #1B2A4A; font-size: 14px; }
-.contact-title { font-size: 12px; color: #6C757D; }
-.tag-dot { width: 6px; height: 6px; border-radius: 50%; }
-.account-link { color: #2E75B6; font-size: 13px; }
-.meta-text { font-size: 13px; color: #6C757D; }
+/* th: classes `text-body-secondary border-bottom`; inline `--bs-border-width: 2px` widens
+   the border-bottom to 2px on the bottom edge only. */
+th            { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; }
+/* .contact-name: class `text-body` (div) + anchor `text-body text-decoration-none` */
+.contact-name { font-weight: 600; font-size: 14px; }
+/* .contact-title, .meta-text: class `text-body-secondary` */
+.contact-title { font-size: 12px; }
+.meta-text     { font-size: 13px; }
+/* .tag-dot: class `d-inline-block bg-#{sem}` (fill), geometry only inline */
+.tag-dot      { width: 6px; height: 6px; border-radius: 50%; }
+/* .account-link: NO colour class — paints --bs-link-color and keeps its underline */
+.account-link { font-size: 13px; }
+/* td: class `align-middle` */
 ```
 
 ## Accessibility
 
 - Use `<table>`, `<thead>`, `<tbody>`, `<th>`, `<td>` — proper semantic table markup
 - Sortable columns: `<th>` with `aria-sort="ascending|descending|none"`
-- Account links must be focusable and have descriptive text
-- Tag dots are decorative — the color meaning is conveyed by the text label
+- Account links must be focusable and have descriptive text; they keep their underline as the
+  navigation affordance and paint the adaptive `--bs-link-color` (AA in both colour modes)
+- Tag/status dots are **decorative** — the meaning is conveyed by the adjacent text label, so
+  the dots keep a **fixed identity hue across colour modes** (an intentional exception to the
+  table's otherwise theme-adaptive palette, mirroring the nav env-bar's fixed status hues).
+  Each dot is browser-proven ≥3:1 against **both** the light and dark row backdrops (#151)
 - Row selection (future): use `<input type="checkbox">` with `aria-label`
 
 ## Usage Guidelines

--- a/catalog/components/filter-chip-bar.md
+++ b/catalog/components/filter-chip-bar.md
@@ -11,7 +11,14 @@ Two filter bar patterns used in CRM list views. Group filter chips provide tag-g
 ## Design Decisions
 
 - **Group chips:** Pill-shaped buttons with counts, one per tag group. "All" chip is always first
-- **Selected chip:** Uses the tag group's own color (e.g., Distribution selected = orange border/background `#E8733A` / `#FEF3EC`)
+- **Selected chip:** Renders the group's **Bootstrap semantic** surface via `GROUP_VARIANTS`
+  (#151) — `bg-#{sem}-subtle text-#{sem}-emphasis border border-#{sem}-subtle rounded-pill`.
+  These derive from `--bs-*`, so the chip follows `data-bs-theme` and clears AA in both colour
+  modes (unlike the frozen hex pairs it replaced). Distribution → `danger` (red), Outreach →
+  `success` (green), Finance → `warning` (amber); the three cool categories collapse onto
+  `primary` (blue) because MPI maps `$info` → `$primary`. See `catalog/elements/tag-chip.md` §
+  Semantic Mapping
+- **Unselected chip:** Neutral adaptive surface — `border bg-body text-body rounded-pill`
 - **Active pills:** Filled primary pills using Bootstrap's `.rounded-pill.text-bg-primary`, whose background *and* foreground derive from the app's configured `$primary`. Do not hardcode `#2E75B6` — a literal desynchronises the moment a consumer overrides the token (every token is `!default`). The `×` remove button inherits the derived foreground (#130)
 - **Labels:** ALL-CAPS prefix labels — "GROUPS:" and "ACTIVE:" — 11px, `font-weight: 600` (`FilterChipBar`) / `700` (`ActiveFilterBar`), colored by Bootstrap's `.text-body-secondary` rather than a pinned gray
 - **Clear all:** Text link after active pills, `.text-body-secondary`. Note it does **not**
@@ -36,17 +43,23 @@ Two filter bar patterns used in CRM list views. Group filter chips provide tag-g
 | Group chip | Pill with group name + count (e.g., "Distribution 342") |
 | Selected chip | Border + background in group's color pair |
 
-### Group Chip Colors (Selected State)
+### Group Chip Colors (Selected State) — `GROUP_VARIANTS` (#151)
 
-| Group | Border/Text | Background |
+Post-#151 the selected chip no longer pins the group's frozen hex pair. It renders the
+group's Bootstrap **semantic** subtle/emphasis utilities, which adapt to `data-bs-theme`:
+
+| Group | Semantic | Utilities |
 |---|---|---|
-| Distribution | `#E8733A` | `#FEF3EC` |
-| Outreach | `#2DA67E` | `#ECF8F4` |
-| Press/Festival | `#2E75B6` | `#EBF3FB` |
-| Vendors | `#8B5CF6` | `#F3EFFE` |
-| Finance | `#D97706` | `#FEF9EC` |
-| Production | `#6366F1` | `#EEEFFE` |
-| Internal | `#64748B` | `#F1F5F9` |
+| Distribution | `danger` | `bg-danger-subtle text-danger-emphasis border-danger-subtle` |
+| Outreach | `success` | `bg-success-subtle text-success-emphasis border-success-subtle` |
+| Finance | `warning` | `bg-warning-subtle text-warning-emphasis border-warning-subtle` |
+| Press/Festival | `primary` | `bg-primary-subtle text-primary-emphasis border-primary-subtle` |
+| Production | `primary` | `bg-primary-subtle text-primary-emphasis border-primary-subtle` |
+| Vendors | `primary` | `bg-primary-subtle text-primary-emphasis border-primary-subtle` |
+| Internal | `secondary` | `bg-secondary-subtle text-secondary-emphasis border-secondary-subtle` |
+
+A selected chip whose group is unknown/absent falls back to the unselected neutral surface
+(`bg-body text-body`). Exact painted values are proven in `spec/features/contrast_spec.rb`.
 
 ## Active Filter Pills
 
@@ -55,16 +68,15 @@ Two filter bar patterns used in CRM list views. Group filter chips provide tag-g
 | Container | Horizontal flex row (`gap: 8px`) on a `.bg-body-secondary.rounded` bar — adaptive surface that follows `data-bs-theme`, replacing the pinned light `#F5F7FA` (#150) |
 | Label | "ACTIVE:" in gray, ALL-CAPS, 11px |
 | Pill | `.rounded-pill.text-bg-primary`, derived foreground, format: "Category: Value" |
-| Remove button | `×` icon (`bi-x`), `color: inherit` at full strength — **no opacity fade** |
+| Remove button | `×` icon (`bi-x`), `text-reset bg-transparent border-0` — inherits the pill's derived foreground at full strength, **no opacity fade** (#151) |
 | Clear all | Text link after pills, clears all active filters |
 
 ## States
 
 | State | Element | Description |
 |---|---|---|
-| Default | Group chip | White background, gray border (`#DEE2E6`), dark text |
-| Hover | Group chip | Blue border (`#2E75B6`) |
-| Selected | Group chip | Group color border + light background |
+| Default | Group chip | Adaptive body surface — `bg-body text-body border` (border colour from `--bs-border-color`) |
+| Selected | Group chip | Group's semantic `-subtle` surface + `-emphasis` text via `GROUP_VARIANTS` (#151) |
 | Default | Active pill | Filled primary, derived foreground |
 | Hover | Pill remove | No opacity change — the retired `opacity: 0.8` faded the foreground to 3.71:1, below the AA floor (#130) |
 
@@ -87,15 +99,19 @@ end
 
 - `d-flex`, `align-items-center`, `flex-wrap`, `gap-2` — layout
 - `.bg-body-secondary.rounded` — the `ActiveFilterBar` surface (adaptive, replaces the pinned light `#F5F7FA`; `.rounded` == `--bs-border-radius` == the retired 6px) (#150)
-- Custom `.group-chip` (pill, border, padding)
+- `rounded-pill d-inline-block text-decoration-none` — group chip shape (geometry-only inline style: 5px/12px padding, 13px, weight 500)
+- Selected chip: `bg-#{sem}-subtle text-#{sem}-emphasis border border-#{sem}-subtle` via `GROUP_VARIANTS` (#151)
+- Unselected chip: `border bg-body text-body`
 - `.rounded-pill.text-bg-primary` — active pill fill and derived foreground (replaces the former custom `.active-pill`)
+- `.text-reset.bg-transparent.border-0` — active pill's `×` remove button (inherits the pill's derived foreground; #151)
 - `.text-body-secondary` — labels, "Clear all", "Reset all"
 - `bi-x` — remove icon in active pills
 
 ## Key Styles
 
-Labels, pills and links carry **no colour of their own** — they use Bootstrap classes so the
-foreground derives from the app's palette and colour mode. Only geometry is declared. (#130)
+Labels, pills, links **and group chips** carry **no colour of their own** — they use Bootstrap
+classes so every colour derives from the app's palette and colour mode. Only geometry is
+declared. (#130 tokenised the labels/pill; #151 tokenised the group chips and the pill's `×`.)
 
 ```css
 /* Labels and links: class `text-body-secondary`, no `color` declaration.
@@ -104,14 +120,17 @@ foreground derives from the app's palette and colour mode. Only geometry is decl
 .clear-all { font-size: 13px; }
 
 /* Active pill: classes `rounded-pill text-bg-primary`, no `background`/`color`.
-   The retired literals duplicated $mpi-primary and pinned white against it. */
+   The retired literals duplicated $mpi-primary and pinned white against it.
+   Its `×` button: classes `text-reset bg-transparent border-0`, geometry only. */
 .active-pill { padding: 4px 10px; font-size: 12px; font-weight: 500; }
 
-/* Group chips still declare a fixed colour PAIR (both halves pinned together, so
-   they are internally coherent). Their contrast is tracked separately — all seven
-   tag pairs currently fail AA. See the #130 follow-up. */
-.group-chip { padding: 5px 12px; border-radius: 999px; border: 1px solid #DEE2E6; font-size: 13px; }
-.group-chip.selected { border-color: #E8733A; background: #FEF3EC; color: #E8733A; }
+/* Group chips carry NO colour of their own after #151 — geometry is the only inline
+   style; every colour comes from a Bootstrap semantic utility, so the chip tracks
+   data-bs-theme. Selected -> the group's -subtle/-emphasis family (AA in both modes);
+   unselected -> bg-body text-body. Classes shown, not the pinned hex they replaced. */
+.group-chip           { padding: 5px 12px; font-size: 13px; font-weight: 500; } /* + rounded-pill d-inline-block text-decoration-none */
+/* .group-chip.selected  -> bg-#{sem}-subtle text-#{sem}-emphasis border border-#{sem}-subtle */
+/* .group-chip:not(.selected) -> border bg-body text-body */
 ```
 
 ## Accessibility

--- a/catalog/elements/tag-chip.md
+++ b/catalog/elements/tag-chip.md
@@ -28,6 +28,32 @@ Color-coded tag chips for CRM contact and account classification. Each of the 7 
 | Production | `#6366F1` | `#EEEFFE` |
 | Internal | `#64748B` | `#F1F5F9` |
 
+## Semantic Mapping (`GROUP_VARIANTS`, #151)
+
+`GROUPS` above is the frozen brand-hex palette. `GROUP_VARIANTS` is a parallel map from
+each tag group onto a **Bootstrap semantic colour**, so consumers that need a
+theme-adaptive chip resolve colour from `--bs-*` (which follows `data-bs-theme`) instead of
+the frozen hex. `FilterChipBar` (selected chip) and `DataTable` (tag dots) consume it; the
+TagChip component itself still renders the hex pairs this phase.
+
+| Group | Semantic | Renders as |
+|---|---|---|
+| Press/Festival | `primary` | blue |
+| Production | `primary` | blue |
+| Vendors | `primary` | blue |
+| Outreach | `success` | green |
+| Finance | `warning` | amber |
+| Distribution | `danger` | red |
+| Internal | `secondary` | grey |
+
+MPI maps `$info` → `$primary` (`_tokens_values.scss`), so the palette offers **five**
+distinct adaptive hues, not seven: the three cool categories (Press/Festival, Production,
+Vendors) collapse onto `primary` (blue), and Distribution's warm orange approximates to
+`danger` (red). This is an accepted trade of the #151 conversion — the tag's always-present
+**text label** carries the category identity, so the hue is reinforcement, not the sole
+signal. Distinguishing all seven hues adaptively would require new brand tokens, deferred to
+the tag-palette follow-up.
+
 ## Variants
 
 | Variant | Description |
@@ -67,7 +93,15 @@ end
 
 ## Accessibility
 
-- All 7 color pairs verified for WCAG AA contrast (colored text on light background)
+- **The 7 hex color pairs do NOT meet WCAG AA for normal text.** Re-derived contrast ratios
+  range **2.77:1 to 4.34:1** (coloured text on its light background), all below the 4.5:1 AA
+  floor — the earlier "all verified for AA" claim was false (#130). The colour is reinforced
+  by the leading dot and the always-present text label, but the pairs should not be relied on
+  as the sole carrier of meaning. Fixing the pairs means changing shared brand tokens — a
+  designer-led decision tracked in the tag-palette follow-up, not silently absorbed here
+- Consumers that need an AA-clean, theme-adaptive chip should use `GROUP_VARIANTS` (above)
+  rather than these pairs — `FilterChipBar`'s selected chip renders `bg-#{sem}-subtle` +
+  `text-#{sem}-emphasis`, which Bootstrap derives to clear AA in both colour modes (#151)
 - Removable chips: `×` button must have `aria-label="Remove [tag name]"`
 - Group of chips should be wrapped in a list (`<ul>`) or described with `aria-label`
 - Focus indicator on remove button for keyboard navigation
@@ -76,6 +110,11 @@ end
 
 - **Use** on contact cards, contact list rows, and filter bars to show group/tag classification
 - **Use** removable variant in edit forms and active filter displays
-- **Do not** mix tag chip colors with badge semantic colors — they are separate systems
-- **Do not** create new color pairs without adding them to `tokens/colors.md`
+- **Two colour systems, bridged by `GROUP_VARIANTS`.** The chip's own rendering uses the
+  brand-hex pairs; do not hand-swap those for Bootstrap's `text-bg-*` badge utilities on the
+  TagChip itself. But the group→semantic bridge IS intentional for *list-view consumers*
+  (`FilterChipBar`, `DataTable`), which render the adaptive semantics via `GROUP_VARIANTS` so
+  they track `data-bs-theme` (#151). Prefer that bridge over inventing a new mapping
+- **Do not** create new color pairs without adding them to `tokens/colors.md` — and add the
+  matching `GROUP_VARIANTS` entry so converted consumers don't fall back to `secondary`
 - Tags always inherit their parent group's color — never assign colors to individual tags

--- a/catalog/previews/data-table.html
+++ b/catalog/previews/data-table.html
@@ -7,136 +7,156 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <style>
-    body { padding: 32px; background: #fff; }
+    /* Stock CDN Bootstrap ships indigo #0D6EFD and its own success/warning; the engine
+       compiles Bootstrap with MPI's tokens. After #151 the dots use `bg-#{sem}` and the
+       account link uses `--bs-link-color`, so without these overrides they would paint
+       Bootstrap's palette and contradict the component. Mirrors _tokens.scss. Avatars keep
+       hardcoded hex — AvatarCircle is a separate component and out of scope here. */
+    :root {
+      --bs-primary: #2E75B6;
+      --bs-primary-rgb: 46, 117, 182;
+      --bs-success: #22A06B;
+      --bs-success-rgb: 34, 160, 107;
+      --bs-warning: #D4772C;
+      --bs-warning-rgb: 212, 119, 44;
+      --bs-danger: #DC3545;
+      --bs-danger-rgb: 220, 53, 69;
+      --bs-link-color: #2E75B6;
+      --bs-link-color-rgb: 46, 117, 182;
+      --bs-body-color: #1B2A4A;
+      --bs-body-color-rgb: 27, 42, 74;
+      --bs-secondary-color: rgba(27, 42, 74, 0.75);
+    }
+
+    body { padding: 32px; }
     .preview-section { margin-bottom: 40px; }
-    .preview-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6C757D; margin-bottom: 8px; }
-    .badge { border-radius: 999px !important; }
+    .preview-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 8px; }
+    /* Avatar keeps its own hex palette (AvatarCircle, out of scope). */
     .avatar { display: inline-flex; align-items: center; justify-content: center; border-radius: 50%; color: #fff; font-weight: 600; flex-shrink: 0; }
     .avatar-md { width: 36px; height: 36px; font-size: 13px; }
+    /* th: classes `text-body-secondary border-bottom`; inline --bs-border-width: 2px
+       widens the bottom edge only. */
+    th { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; white-space: nowrap; --bs-border-width: 2px; }
+    /* Geometry only — foreground comes from text-body / text-body-secondary classes. */
+    .contact-name { font-weight: 600; font-size: 14px; }
+    .contact-title { font-size: 12px; }
+    .account-link { font-size: 13px; } /* no colour class -> --bs-link-color + underline */
+    .meta-text { font-size: 13px; }
     .tag { display: inline-flex; align-items: center; font-size: 13px; font-weight: 500; white-space: nowrap; }
+    /* Dot fill comes from `bg-#{sem}`; geometry only here. */
     .tag-dot { width: 6px; height: 6px; border-radius: 50%; margin-right: 6px; flex-shrink: 0; display: inline-block; }
-    th { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: #6C757D; white-space: nowrap; }
-    .contact-name { font-weight: 600; color: #1B2A4A; font-size: 14px; }
-    .contact-title { font-size: 12px; color: #6C757D; }
-    .account-link { color: #2E75B6; text-decoration: none; font-size: 13px; }
-    .account-link:hover { text-decoration: underline; }
-    .meta-text { font-size: 13px; color: #6C757D; }
-    .status-dot { display: inline-flex; align-items: center; font-size: 13px; font-weight: 500; }
-    .status-dot::before { content: ''; width: 7px; height: 7px; border-radius: 50%; margin-right: 6px; flex-shrink: 0; }
-    .status-active::before { background: #22A06B; }
-    .status-active { color: #22A06B; }
-    .status-followup::before { background: #D4772C; }
-    .status-followup { color: #D4772C; }
+    .status { display: inline-flex; align-items: center; font-size: 13px; font-weight: 500; }
+    .status-dot { width: 7px; height: 7px; border-radius: 50%; margin-right: 6px; flex-shrink: 0; display: inline-block; }
   </style>
 </head>
-<body>
-  <h4 class="mb-1" style="color:#1B2A4A;">DataTable</h4>
-  <p class="text-muted small mb-4">Sortable data table for list views. Columns match Figma: Name (avatar + title), Tags (dot + Group — Role), Last Engagement, Account.</p>
+<body class="bg-body text-body">
+  <h4 class="mb-1">DataTable</h4>
+  <p class="text-body-secondary small mb-4">Sortable data table for list views. Columns match Figma: Name (avatar + title), Tags (dot + Group — Role), Last Engagement, Account.</p>
 
   <!-- Contacts table — from Figma Screen 2 -->
   <div class="preview-section">
-    <div class="preview-label">Contacts Table — From Figma Screen 2</div>
+    <div class="preview-label text-body-secondary">Contacts Table — From Figma Screen 2</div>
     <table class="table table-hover" style="max-width:900px;">
       <thead>
         <tr>
-          <th>Name</th>
-          <th>Tags</th>
-          <th>Last Engagement</th>
-          <th>Account</th>
+          <th class="text-body-secondary border-bottom">Name</th>
+          <th class="text-body-secondary border-bottom">Tags</th>
+          <th class="text-body-secondary border-bottom">Last Engagement</th>
+          <th class="text-body-secondary border-bottom">Account</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td>
+          <td class="align-middle">
             <div class="d-flex align-items-center gap-2">
               <div class="avatar avatar-md" style="background:#1B2A4A;">SC</div>
               <div>
-                <div class="contact-name">Sarah Chen</div>
-                <div class="contact-title">Dir. of Acquisitions</div>
+                <div class="contact-name text-body">Sarah Chen</div>
+                <div class="contact-title text-body-secondary">Dir. of Acquisitions</div>
               </div>
             </div>
           </td>
           <td class="align-middle">
             <div class="d-flex flex-wrap gap-2">
-              <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Acquisitions</span>
-              <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Streaming</span>
-              <span class="tag"><span class="tag-dot" style="background:#2E75B6;"></span>Festival</span>
+              <span class="tag text-body"><span class="tag-dot bg-danger"></span>Acquisitions</span>
+              <span class="tag text-body"><span class="tag-dot bg-danger"></span>Streaming</span>
+              <span class="tag text-body"><span class="tag-dot bg-primary"></span>Festival</span>
             </div>
           </td>
-          <td class="align-middle meta-text">2 days ago</td>
+          <td class="align-middle meta-text text-body-secondary">2 days ago</td>
           <td class="align-middle"><a class="account-link" href="#">Magnolia Pictures</a></td>
         </tr>
         <tr>
-          <td>
+          <td class="align-middle">
             <div class="d-flex align-items-center gap-2">
               <div class="avatar avatar-md" style="background:#E8733A;">JP</div>
               <div>
-                <div class="contact-name">James Park</div>
-                <div class="contact-title">VP Content</div>
+                <div class="contact-name text-body">James Park</div>
+                <div class="contact-title text-body-secondary">VP Content</div>
               </div>
             </div>
           </td>
           <td class="align-middle">
-            <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Streaming</span>
+            <span class="tag text-body"><span class="tag-dot bg-danger"></span>Streaming</span>
           </td>
-          <td class="align-middle meta-text">1 week ago</td>
+          <td class="align-middle meta-text text-body-secondary">1 week ago</td>
           <td class="align-middle"><a class="account-link" href="#">MUBI</a></td>
         </tr>
         <tr>
-          <td>
+          <td class="align-middle">
             <div class="d-flex align-items-center gap-2">
               <div class="avatar avatar-md" style="background:#22A06B;">ML</div>
               <div>
-                <div class="contact-name">Maria Lopez</div>
-                <div class="contact-title">Acquisitions Manager</div>
+                <div class="contact-name text-body">Maria Lopez</div>
+                <div class="contact-title text-body-secondary">Acquisitions Manager</div>
               </div>
             </div>
           </td>
           <td class="align-middle">
             <div class="d-flex flex-wrap gap-2">
-              <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Buyer — All Rights</span>
-              <span class="tag"><span class="tag-dot" style="background:#2E75B6;"></span>Fest — Programmer</span>
+              <span class="tag text-body"><span class="tag-dot bg-danger"></span>Buyer — All Rights</span>
+              <span class="tag text-body"><span class="tag-dot bg-primary"></span>Fest — Programmer</span>
             </div>
           </td>
-          <td class="align-middle meta-text">3 days ago</td>
+          <td class="align-middle meta-text text-body-secondary">3 days ago</td>
           <td class="align-middle"><a class="account-link" href="#">Kino Lorber</a></td>
         </tr>
         <tr>
-          <td>
+          <td class="align-middle">
             <div class="d-flex align-items-center gap-2">
               <div class="avatar avatar-md" style="background:#4EA8DE;">AW</div>
               <div>
-                <div class="contact-name">Alex Wright</div>
-                <div class="contact-title">Sales Agent</div>
+                <div class="contact-name text-body">Alex Wright</div>
+                <div class="contact-title text-body-secondary">Sales Agent</div>
               </div>
             </div>
           </td>
           <td class="align-middle">
             <div class="d-flex flex-wrap gap-2">
-              <span class="tag"><span class="tag-dot" style="background:#8B5CF6;"></span>Seller — Sales Agent</span>
-              <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Buyer — Television</span>
+              <span class="tag text-body"><span class="tag-dot bg-primary"></span>Seller — Sales Agent</span>
+              <span class="tag text-body"><span class="tag-dot bg-danger"></span>Buyer — Television</span>
             </div>
           </td>
-          <td class="align-middle meta-text">5 days ago</td>
+          <td class="align-middle meta-text text-body-secondary">5 days ago</td>
           <td class="align-middle"><a class="account-link" href="#">Cinetic Media</a></td>
         </tr>
         <tr>
-          <td>
+          <td class="align-middle">
             <div class="d-flex align-items-center gap-2">
               <div class="avatar avatar-md" style="background:#DC3545;">RN</div>
               <div>
-                <div class="contact-name">Rachel Nakamura</div>
-                <div class="contact-title">Film Critic</div>
+                <div class="contact-name text-body">Rachel Nakamura</div>
+                <div class="contact-title text-body-secondary">Film Critic</div>
               </div>
             </div>
           </td>
           <td class="align-middle">
             <div class="d-flex flex-wrap gap-2">
-              <span class="tag"><span class="tag-dot" style="background:#2DA67E;"></span>Press — Online Critic</span>
-              <span class="tag"><span class="tag-dot" style="background:#2DA67E;"></span>Press — Podcaster</span>
+              <span class="tag text-body"><span class="tag-dot bg-success"></span>Press — Online Critic</span>
+              <span class="tag text-body"><span class="tag-dot bg-success"></span>Press — Podcaster</span>
             </div>
           </td>
-          <td class="align-middle meta-text">2 weeks ago</td>
+          <td class="align-middle meta-text text-body-secondary">2 weeks ago</td>
           <td class="align-middle"><a class="account-link" href="#">IndieWire</a></td>
         </tr>
       </tbody>
@@ -145,77 +165,77 @@
 
   <!-- Search results table — from Figma Screen 6 -->
   <div class="preview-section">
-    <div class="preview-label">Search Results Table — From Figma Screen 6 (with Match + Status columns)</div>
+    <div class="preview-label text-body-secondary">Search Results Table — From Figma Screen 6 (with Match + Status columns)</div>
     <table class="table table-hover" style="max-width:900px;">
       <thead>
         <tr>
-          <th>Name</th>
-          <th>Tags</th>
-          <th>Match Found In</th>
-          <th>Last Engaged</th>
-          <th>Status</th>
+          <th class="text-body-secondary border-bottom">Name</th>
+          <th class="text-body-secondary border-bottom">Tags</th>
+          <th class="text-body-secondary border-bottom">Match Found In</th>
+          <th class="text-body-secondary border-bottom">Last Engaged</th>
+          <th class="text-body-secondary border-bottom">Status</th>
         </tr>
       </thead>
       <tbody>
         <tr>
-          <td>
+          <td class="align-middle">
             <div class="d-flex align-items-center gap-2">
               <div class="avatar avatar-md" style="background:#DC3545;">DK</div>
               <div>
-                <div class="contact-name">David Kim</div>
-                <div class="contact-title"><strong>Investor</strong> Relations · Lionsgate</div>
+                <div class="contact-name text-body">David Kim</div>
+                <div class="contact-title text-body-secondary"><strong>Investor</strong> Relations · Lionsgate</div>
               </div>
             </div>
           </td>
           <td class="align-middle">
             <div class="d-flex flex-wrap gap-2">
-              <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Buyer — All Rights</span>
-              <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Acquisitions</span>
+              <span class="tag text-body"><span class="tag-dot bg-danger"></span>Buyer — All Rights</span>
+              <span class="tag text-body"><span class="tag-dot bg-danger"></span>Acquisitions</span>
             </div>
           </td>
-          <td class="align-middle meta-text">Title: <strong>Investor</strong> Relations</td>
-          <td class="align-middle meta-text">3 days ago</td>
-          <td class="align-middle"><span class="status-dot status-active">Active</span></td>
+          <td class="align-middle meta-text text-body-secondary">Title: <strong>Investor</strong> Relations</td>
+          <td class="align-middle meta-text text-body-secondary">3 days ago</td>
+          <td class="align-middle"><span class="status text-body-secondary"><span class="status-dot bg-success"></span>Active</span></td>
         </tr>
         <tr>
-          <td>
+          <td class="align-middle">
             <div class="d-flex align-items-center gap-2">
               <div class="avatar avatar-md" style="background:#2E75B6;">RP</div>
               <div>
-                <div class="contact-name">Rachel Patel</div>
-                <div class="contact-title">VP Acquisitions · A24</div>
+                <div class="contact-name text-body">Rachel Patel</div>
+                <div class="contact-title text-body-secondary">VP Acquisitions · A24</div>
               </div>
             </div>
           </td>
           <td class="align-middle">
             <div class="d-flex flex-wrap gap-2">
-              <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Acquisitions</span>
-              <span class="tag"><span class="tag-dot" style="background:#2E75B6;"></span>Festival</span>
+              <span class="tag text-body"><span class="tag-dot bg-danger"></span>Acquisitions</span>
+              <span class="tag text-body"><span class="tag-dot bg-primary"></span>Festival</span>
             </div>
           </td>
-          <td class="align-middle meta-text">Engagement note: "...checking <strong>investors</strong> on Q3 budget..."</td>
-          <td class="align-middle meta-text">1 week ago</td>
-          <td class="align-middle"><span class="status-dot status-active">Active</span></td>
+          <td class="align-middle meta-text text-body-secondary">Engagement note: "...checking <strong>investors</strong> on Q3 budget..."</td>
+          <td class="align-middle meta-text text-body-secondary">1 week ago</td>
+          <td class="align-middle"><span class="status text-body-secondary"><span class="status-dot bg-success"></span>Active</span></td>
         </tr>
         <tr>
-          <td>
+          <td class="align-middle">
             <div class="d-flex align-items-center gap-2">
               <div class="avatar avatar-md" style="background:#6366F1;">SC</div>
               <div>
-                <div class="contact-name">Sophie Clark</div>
-                <div class="contact-title">Director · Cinereach</div>
+                <div class="contact-name text-body">Sophie Clark</div>
+                <div class="contact-title text-body-secondary">Director · Cinereach</div>
               </div>
             </div>
           </td>
           <td class="align-middle">
             <div class="d-flex flex-wrap gap-2">
-              <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Buyer — All Rights</span>
-              <span class="tag"><span class="tag-dot" style="background:#64748B;"></span>Other — Service Provider</span>
+              <span class="tag text-body"><span class="tag-dot bg-danger"></span>Buyer — All Rights</span>
+              <span class="tag text-body"><span class="tag-dot bg-secondary"></span>Other — Service Provider</span>
             </div>
           </td>
-          <td class="align-middle meta-text">Engagement note: "...securing <strong>investor</strong> commitment..."</td>
-          <td class="align-middle meta-text">3 weeks ago</td>
-          <td class="align-middle"><span class="status-dot status-followup">Follow up</span></td>
+          <td class="align-middle meta-text text-body-secondary">Engagement note: "...securing <strong>investor</strong> commitment..."</td>
+          <td class="align-middle meta-text text-body-secondary">3 weeks ago</td>
+          <td class="align-middle"><span class="status text-body-secondary"><span class="status-dot bg-warning"></span>Follow up</span></td>
         </tr>
       </tbody>
     </table>

--- a/catalog/previews/filter-chip-bar.html
+++ b/catalog/previews/filter-chip-bar.html
@@ -7,19 +7,54 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <style>
-    body { padding: 32px; background: #fff; }
-    .preview-section { margin-bottom: 40px; }
-    .preview-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6C757D; margin-bottom: 8px; }
+    /* This file loads STOCK Bootstrap from the CDN, which ships indigo #0D6EFD and its
+       own success/warning. The engine compiles Bootstrap with MPI's tokens instead, so
+       without these overrides the semantic utilities below would paint Bootstrap's
+       palette and this mockup would contradict the component it documents. Mirrors
+       _tokens.scss + Bootstrap's derived subtle/emphasis for the tokens MPI overrides
+       (primary, success, warning); danger and secondary keep Bootstrap's defaults, which
+       MPI also uses. (Same pattern as pagination.html.) After #151 the group chips render
+       Bootstrap semantic utilities, so this block is what keeps them MPI-coloured. */
+    :root {
+      --bs-primary: #2E75B6;
+      --bs-primary-rgb: 46, 117, 182;
+      --bs-primary-text-emphasis: #122F49;
+      --bs-primary-bg-subtle: #D5E3F0;
+      --bs-primary-border-subtle: #ABC8E2;
+      --bs-success: #22A06B;
+      --bs-success-rgb: 34, 160, 107;
+      --bs-success-text-emphasis: #0E402B;
+      --bs-success-bg-subtle: #D3ECE1;
+      --bs-success-border-subtle: #A7D9C4;
+      --bs-warning: #D4772C;
+      --bs-warning-rgb: 212, 119, 44;
+      --bs-warning-text-emphasis: #553012;
+      --bs-warning-bg-subtle: #F6E4D5;
+      --bs-warning-border-subtle: #EEC9AB;
+      --bs-danger: #DC3545;
+      --bs-danger-rgb: 220, 53, 69;
+      --bs-link-color: #2E75B6;
+      --bs-link-color-rgb: 46, 117, 182;
+      --bs-body-color: #1B2A4A;
+      --bs-body-color-rgb: 27, 42, 74;
+      --bs-secondary-color: rgba(27, 42, 74, 0.75);
+    }
+    [data-bs-theme="dark"] {
+      --bs-primary-text-emphasis: #82ACD3;
+      --bs-success-text-emphasis: #A7D9C4;
+      --bs-warning-text-emphasis: #E5AD80;
+    }
 
-    /* Group filter chips — from Screen 2 */
-    .group-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: #6C757D; margin-right: 8px; white-space: nowrap; }
-    .group-chip { display: inline-flex; align-items: center; gap: 4px; padding: 5px 12px; border-radius: 999px; border: 1px solid #DEE2E6; background: #fff; font-size: 13px; font-weight: 500; color: #1B2A4A; text-decoration: none; white-space: nowrap; cursor: pointer; }
-    .group-chip:hover { border-color: #2E75B6; }
-    .group-chip .count { font-weight: 600; color: #6C757D; font-size: 12px; }
-    .group-chip.selected { border-color: #E8733A; background: #FEF3EC; color: #E8733A; }
-    .group-chip.selected .count { color: #E8733A; }
-    .group-chip.all { border-color: #DEE2E6; }
-    .group-chip.all .count { color: #6C757D; }
+    body { padding: 32px; }
+    .preview-section { margin-bottom: 40px; }
+    .preview-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 8px; }
+
+    /* Group filter chips — geometry only after #151. Colour comes from the Bootstrap
+       semantic utilities in the markup (bg-body/text-body when unselected;
+       bg-#{sem}-subtle / text-#{sem}-emphasis / border-#{sem}-subtle when selected), so
+       the chips follow the palette above. The count inherits the chip's own foreground. */
+    .group-chip { display: inline-flex; align-items: center; gap: 4px; padding: 5px 12px; border-radius: 999px; font-size: 13px; font-weight: 500; text-decoration: none; white-space: nowrap; cursor: pointer; }
+    .group-chip .count { font-weight: 600; font-size: 12px; }
 
     /* Active filter pills — from Screen 6 */
     .active-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--bs-secondary-color); margin-right: 8px; white-space: nowrap; }
@@ -65,45 +100,57 @@
        from --bs-secondary-color so it stays AA — the hardcoded #6C757D was 3.29:1 there. */
     [data-bs-theme="dark"] .preview-label { color: var(--bs-secondary-color); }
     .active-pill { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; font-size: 12px; font-weight: 500; text-decoration: none; white-space: nowrap; }
-    .active-pill .pill-close { font-size: 10px; cursor: pointer; margin-left: 2px; }
+    .active-pill .pill-close { font-size: 10px; cursor: pointer; margin-left: 2px; padding: 0; line-height: 1; }
     .active-pill .pill-close:hover { text-decoration: none; }
     .clear-all { font-size: 13px; color: var(--bs-secondary-color); text-decoration: none; margin-left: 8px; }
     .clear-all:hover { color: var(--bs-link-color); text-decoration: underline; }
   </style>
 </head>
-<body>
-  <h4 class="mb-1" style="color:#1B2A4A;">FilterChipBar</h4>
-  <p class="text-muted small mb-4">Two filter bar patterns used in CRM list views. Group filter chips for tag-group filtering, and active filter pills showing applied search/filter criteria.</p>
+<body class="bg-body text-body">
+  <h4 class="mb-1">FilterChipBar</h4>
+  <p class="text-body-secondary small mb-4">Two filter bar patterns used in CRM list views. Group filter chips for tag-group filtering, and active filter pills showing applied search/filter criteria.</p>
 
   <!-- Group filter chips — from Figma Screen 2 (Contact List) -->
   <div class="preview-section">
-    <div class="preview-label">Group Filter Chips — From Figma Screen 2 (Contact List View)</div>
+    <div class="preview-label text-body-secondary">Group Filter Chips — From Figma Screen 2 (Contact List View)</div>
     <div class="d-flex align-items-center flex-wrap gap-2" style="max-width:800px;">
-      <span class="group-label">GROUPS:</span>
-      <a class="group-chip all" href="#">All <span class="count">2,307</span></a>
-      <a class="group-chip selected" href="#">Buyers <span class="count">342</span></a>
-      <a class="group-chip" href="#">Press <span class="count">289</span></a>
-      <a class="group-chip" href="#">Festivals <span class="count">156</span></a>
-      <a class="group-chip" href="#">Sellers <span class="count">98</span></a>
-      <a class="group-chip" href="#">Institutional <span class="count">67</span></a>
-      <a class="group-chip" href="#">Organizations <span class="count">45</span></a>
-      <a class="group-chip" href="#">Internal <span class="count">23</span></a>
+      <span class="active-label text-body-secondary">GROUPS:</span>
+      <a class="group-chip border bg-body text-body" href="#">All <span class="count">2,307</span></a>
+      <a class="group-chip border border-danger-subtle bg-danger-subtle text-danger-emphasis" href="#" aria-current="page">Buyers <span class="count">342</span></a>
+      <a class="group-chip border bg-body text-body" href="#">Press <span class="count">289</span></a>
+      <a class="group-chip border bg-body text-body" href="#">Festivals <span class="count">156</span></a>
+      <a class="group-chip border bg-body text-body" href="#">Sellers <span class="count">98</span></a>
+      <a class="group-chip border bg-body text-body" href="#">Institutional <span class="count">67</span></a>
+      <a class="group-chip border bg-body text-body" href="#">Organizations <span class="count">45</span></a>
+      <a class="group-chip border bg-body text-body" href="#">Internal <span class="count">23</span></a>
     </div>
   </div>
 
   <!-- No selection state -->
   <div class="preview-section">
-    <div class="preview-label">Group Filter Chips — No Selection (Default)</div>
+    <div class="preview-label text-body-secondary">Group Filter Chips — No Selection (Default)</div>
     <div class="d-flex align-items-center flex-wrap gap-2" style="max-width:800px;">
-      <span class="group-label">GROUPS:</span>
-      <a class="group-chip all" href="#">All <span class="count">2,307</span></a>
-      <a class="group-chip" href="#">Buyers <span class="count">342</span></a>
-      <a class="group-chip" href="#">Press <span class="count">289</span></a>
-      <a class="group-chip" href="#">Festivals <span class="count">156</span></a>
-      <a class="group-chip" href="#">Sellers <span class="count">98</span></a>
-      <a class="group-chip" href="#">Institutional <span class="count">67</span></a>
-      <a class="group-chip" href="#">Organizations <span class="count">45</span></a>
-      <a class="group-chip" href="#">Internal <span class="count">23</span></a>
+      <span class="active-label text-body-secondary">GROUPS:</span>
+      <a class="group-chip border bg-body text-body" href="#">All <span class="count">2,307</span></a>
+      <a class="group-chip border bg-body text-body" href="#">Buyers <span class="count">342</span></a>
+      <a class="group-chip border bg-body text-body" href="#">Press <span class="count">289</span></a>
+      <a class="group-chip border bg-body text-body" href="#">Festivals <span class="count">156</span></a>
+      <a class="group-chip border bg-body text-body" href="#">Sellers <span class="count">98</span></a>
+      <a class="group-chip border bg-body text-body" href="#">Institutional <span class="count">67</span></a>
+      <a class="group-chip border bg-body text-body" href="#">Organizations <span class="count">45</span></a>
+      <a class="group-chip border bg-body text-body" href="#">Internal <span class="count">23</span></a>
+    </div>
+  </div>
+
+  <!-- Selected states across the five distinct semantic hues (#151) -->
+  <div class="preview-section">
+    <div class="preview-label text-body-secondary">Selected Chip — Semantic Hues (GROUP_VARIANTS)</div>
+    <div class="d-flex align-items-center flex-wrap gap-2" style="max-width:800px;">
+      <a class="group-chip border border-danger-subtle bg-danger-subtle text-danger-emphasis" href="#" aria-current="page">Distribution <span class="count">342</span></a>
+      <a class="group-chip border border-success-subtle bg-success-subtle text-success-emphasis" href="#" aria-current="page">Outreach <span class="count">128</span></a>
+      <a class="group-chip border border-warning-subtle bg-warning-subtle text-warning-emphasis" href="#" aria-current="page">Finance <span class="count">51</span></a>
+      <a class="group-chip border border-primary-subtle bg-primary-subtle text-primary-emphasis" href="#" aria-current="page">Press/Festival <span class="count">95</span></a>
+      <a class="group-chip border border-secondary-subtle bg-secondary-subtle text-secondary-emphasis" href="#" aria-current="page">Internal <span class="count">23</span></a>
     </div>
   </div>
 
@@ -112,9 +159,9 @@
     <div class="preview-label">Active Filter Pills — From Figma Screen 6 (Active Search Results)</div>
     <div class="bg-body-secondary rounded d-flex align-items-center flex-wrap gap-2" style="max-width:800px; padding:10px 16px;">
       <span class="active-label">ACTIVE:</span>
-      <span class="active-pill rounded-pill text-bg-primary">Keyword: investors <button style="background:none;border:none;color:inherit;padding:0;font-size:10px;cursor:pointer;margin-left:2px;" aria-label="Remove filter: Keyword: investors"><i class="bi bi-x"></i></button></span>
-      <span class="active-pill rounded-pill text-bg-primary">Group: Buyers <button style="background:none;border:none;color:inherit;padding:0;font-size:10px;cursor:pointer;margin-left:2px;" aria-label="Remove filter: Group: Buyers"><i class="bi bi-x"></i></button></span>
-      <span class="active-pill rounded-pill text-bg-primary">Activity: Engaged last 90 days <button style="background:none;border:none;color:inherit;padding:0;font-size:10px;cursor:pointer;margin-left:2px;" aria-label="Remove filter: Activity: Engaged last 90 days"><i class="bi bi-x"></i></button></span>
+      <span class="active-pill rounded-pill text-bg-primary">Keyword: investors <a class="pill-close text-reset bg-transparent border-0" href="#" aria-label="Remove filter: Keyword: investors"><i class="bi bi-x"></i></a></span>
+      <span class="active-pill rounded-pill text-bg-primary">Group: Buyers <a class="pill-close text-reset bg-transparent border-0" href="#" aria-label="Remove filter: Group: Buyers"><i class="bi bi-x"></i></a></span>
+      <span class="active-pill rounded-pill text-bg-primary">Activity: Engaged last 90 days <a class="pill-close text-reset bg-transparent border-0" href="#" aria-label="Remove filter: Activity: Engaged last 90 days"><i class="bi bi-x"></i></a></span>
       <a class="clear-all" href="#">Clear all</a>
     </div>
   </div>
@@ -124,7 +171,7 @@
     <div class="preview-label">Active Filter Pills — Single Filter</div>
     <div class="bg-body-secondary rounded d-flex align-items-center flex-wrap gap-2" style="max-width:800px; padding:10px 16px;">
       <span class="active-label">ACTIVE:</span>
-      <span class="active-pill rounded-pill text-bg-primary">Location: Los Angeles <button style="background:none;border:none;color:inherit;padding:0;font-size:10px;cursor:pointer;margin-left:2px;" aria-label="Remove filter: Location: Los Angeles"><i class="bi bi-x"></i></button></span>
+      <span class="active-pill rounded-pill text-bg-primary">Location: Los Angeles <a class="pill-close text-reset bg-transparent border-0" href="#" aria-label="Remove filter: Location: Los Angeles"><i class="bi bi-x"></i></a></span>
       <a class="clear-all" href="#">Clear all</a>
     </div>
   </div>
@@ -137,31 +184,27 @@
     <div class="preview-label">Active Filter Pills — Dark Mode (Adaptive Surface)</div>
     <div class="bg-body-secondary rounded d-flex align-items-center flex-wrap gap-2" style="max-width:800px; padding:10px 16px;">
       <span class="active-label">ACTIVE:</span>
-      <span class="active-pill rounded-pill text-bg-primary">Keyword: investors <button style="background:none;border:none;color:inherit;padding:0;font-size:10px;cursor:pointer;margin-left:2px;" aria-label="Remove filter: Keyword: investors"><i class="bi bi-x"></i></button></span>
-      <span class="active-pill rounded-pill text-bg-primary">Group: Buyers <button style="background:none;border:none;color:inherit;padding:0;font-size:10px;cursor:pointer;margin-left:2px;" aria-label="Remove filter: Group: Buyers"><i class="bi bi-x"></i></button></span>
+      <span class="active-pill rounded-pill text-bg-primary">Keyword: investors <a class="pill-close text-reset bg-transparent border-0" href="#" aria-label="Remove filter: Keyword: investors"><i class="bi bi-x"></i></a></span>
+      <span class="active-pill rounded-pill text-bg-primary">Group: Buyers <a class="pill-close text-reset bg-transparent border-0" href="#" aria-label="Remove filter: Group: Buyers"><i class="bi bi-x"></i></a></span>
       <a class="clear-all" href="#">Clear all</a>
     </div>
   </div>
 
   <!-- States -->
   <div class="preview-section">
-    <div class="preview-label">Chip States</div>
+    <div class="preview-label text-body-secondary">Chip States</div>
     <div class="d-flex gap-3 align-items-end">
       <div>
-        <div class="text-muted small mb-1">Default</div>
-        <span class="group-chip">Buyers <span class="count">342</span></span>
+        <div class="text-body-secondary small mb-1">Default</div>
+        <span class="group-chip border bg-body text-body">Buyers <span class="count">342</span></span>
       </div>
       <div>
-        <div class="text-muted small mb-1">Selected</div>
-        <span class="group-chip selected">Buyers <span class="count">342</span></span>
+        <div class="text-body-secondary small mb-1">Selected</div>
+        <span class="group-chip border border-danger-subtle bg-danger-subtle text-danger-emphasis">Buyers <span class="count">342</span></span>
       </div>
       <div>
-        <div class="text-muted small mb-1">Hover</div>
-        <span class="group-chip" style="border-color:#2E75B6;">Buyers <span class="count">342</span></span>
-      </div>
-      <div>
-        <div class="text-muted small mb-1">Active Pill</div>
-        <span class="active-pill rounded-pill text-bg-primary">Group: Buyers <button style="background:none;border:none;color:inherit;padding:0;font-size:10px;cursor:pointer;margin-left:2px;" aria-label="Remove filter: Group: Buyers"><i class="bi bi-x"></i></button></span>
+        <div class="text-body-secondary small mb-1">Active Pill</div>
+        <span class="active-pill rounded-pill text-bg-primary">Group: Buyers <a class="pill-close text-reset bg-transparent border-0" href="#" aria-label="Remove filter: Group: Buyers"><i class="bi bi-x"></i></a></span>
       </div>
     </div>
   </div>

--- a/catalog/previews/list-view.html
+++ b/catalog/previews/list-view.html
@@ -7,18 +7,34 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <style>
-    /* Stock CDN Bootstrap ships indigo #0D6EFD; the engine compiles it with MPI's
-       tokens. The converted pagination slice below uses semantic utilities, so
-       without these the bar would paint Bootstrap's palette instead of MPI's.
-       Mirrors _tokens.scss. (Same pattern as filter-chip-bar.html.) The rest of
-       this mockup still pins literals and is converted in later Track 2 phases. */
+    /* Stock CDN Bootstrap ships indigo #0D6EFD and its own success/warning; the engine
+       compiles it with MPI's tokens. The converted pagination (#149), FilterChipBar and
+       DataTable (#151) slices below use semantic utilities, so without these overrides
+       they would paint Bootstrap's palette instead of MPI's. Mirrors _tokens.scss +
+       Bootstrap's derived subtle/emphasis for the tokens MPI overrides. The nav,
+       sub-group pills, toolbar and health badges still pin literals and are converted in
+       later Track 2 phases. */
     :root {
       --bs-primary: #2E75B6;
       --bs-primary-rgb: 46, 117, 182;
       --bs-primary-text-emphasis: #122F49;
+      --bs-primary-bg-subtle: #D5E3F0;
+      --bs-primary-border-subtle: #ABC8E2;
+      --bs-success: #22A06B;
+      --bs-success-rgb: 34, 160, 107;
+      --bs-warning: #D4772C;
+      --bs-warning-rgb: 212, 119, 44;
+      --bs-danger: #DC3545;
+      --bs-danger-rgb: 220, 53, 69;
+      --bs-danger-text-emphasis: #58151C;
+      --bs-danger-bg-subtle: #F8D7DA;
+      --bs-danger-border-subtle: #F1AEB5;
+      --bs-link-color: #2E75B6;
+      --bs-link-color-rgb: 46, 117, 182;
       --bs-body-color: #1B2A4A;
       --bs-body-color-rgb: 27, 42, 74;
       --bs-secondary-color: rgba(27, 42, 74, 0.75);
+      --bs-border-color: #DEE2E6;
     }
     body { padding: 0; background: #F5F7FA; margin: 0; }
     .preview-wrapper { padding: 32px; }
@@ -38,12 +54,12 @@
 
     /* Filter chips */
     .group-label { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: #6C757D; margin-right: 6px; }
-    .group-chip { display: inline-flex; align-items: center; gap: 3px; padding: 4px 10px; border-radius: 999px; border: 1px solid #DEE2E6; background: #fff; font-size: 12px; font-weight: 500; color: #1B2A4A; text-decoration: none; }
-    .group-chip .count { font-weight: 600; color: #6C757D; font-size: 11px; }
-    .group-chip.selected { border-color: #E8733A; background: #FEF3EC; color: #E8733A; }
-    .group-chip.selected .count { color: #E8733A; }
-    .group-chip.selected-all { border-color: #2E75B6; background: #EBF3FB; color: #2E75B6; }
-    .group-chip.selected-all .count { color: #2E75B6; }
+    /* Group chips — geometry only after #151. Colour comes from Bootstrap semantic
+       utilities in the markup (bg-body/text-body unselected; bg-#{sem}-subtle /
+       text-#{sem}-emphasis / border-#{sem}-subtle selected), which paint the MPI palette
+       via the :root overrides above. */
+    .group-chip { display: inline-flex; align-items: center; gap: 3px; padding: 4px 10px; border-radius: 999px; font-size: 12px; font-weight: 500; text-decoration: none; }
+    .group-chip .count { font-weight: 600; font-size: 11px; }
 
     /* Sub-group filter pills */
     .subgroup-bar { display: flex; align-items: center; gap: 6px; margin-bottom: 16px; padding: 8px 12px; background: #fff; border: 1px solid #DEE2E6; border-radius: 6px; }
@@ -66,16 +82,22 @@
     .sort-dropdown { display: inline-flex; align-items: center; gap: 4px; padding: 4px 10px; border: 1px solid #DEE2E6; border-radius: 5px; background: #fff; font-size: 12px; color: #1B2A4A; cursor: pointer; }
     .sort-dropdown .bi { font-size: 10px; color: #6C757D; }
 
-    /* Table */
-    th { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: #6C757D; white-space: nowrap; }
+    /* Table — geometry only after #151; the DataTable text colour comes from Bootstrap
+       semantic utilities in the markup (text-body-secondary on th/title/meta, text-body
+       on contact/account names), which paint the MPI palette via the :root overrides
+       above. Matches the standalone data-table.html. The avatar keeps its own hex
+       palette (AvatarCircle, out of scope). */
+    th { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; white-space: nowrap; }
     .avatar { display: inline-flex; align-items: center; justify-content: center; border-radius: 50%; color: #fff; font-weight: 600; flex-shrink: 0; width: 32px; height: 32px; font-size: 11px; }
-    .contact-name { font-weight: 600; color: #1B2A4A; font-size: 13px; }
-    .contact-title { font-size: 11px; color: #6C757D; }
+    .contact-name { font-weight: 600; font-size: 13px; }
+    .contact-title { font-size: 11px; }
     .tag { display: inline-flex; align-items: center; font-size: 11px; font-weight: 500; white-space: nowrap; }
     .tag-dot { width: 5px; height: 5px; border-radius: 50%; margin-right: 4px; }
-    .account-link { color: #2E75B6; text-decoration: none; font-size: 12px; }
-    .meta-text { font-size: 12px; color: #6C757D; }
-    .account-name { font-weight: 600; color: #1B2A4A; font-size: 13px; }
+    /* No colour class -> paints --bs-link-color (MPI primary via :root) and keeps its
+       underline as the navigation affordance. (#151) */
+    .account-link { font-size: 12px; }
+    .meta-text { font-size: 12px; }
+    .account-name { font-weight: 600; font-size: 13px; }
 
     /* Health badge */
     .health-badge { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 999px; }
@@ -136,14 +158,14 @@
           <!-- Group filter chips -->
           <div class="d-flex align-items-center flex-wrap gap-2 mb-2">
             <span class="group-label">GROUPS:</span>
-            <a class="group-chip" href="#">All <span class="count">2,307</span></a>
-            <a class="group-chip selected" href="#">Buyers <span class="count">342</span></a>
-            <a class="group-chip" href="#">Press <span class="count">289</span></a>
-            <a class="group-chip" href="#">Festivals <span class="count">156</span></a>
-            <a class="group-chip" href="#">Sellers <span class="count">98</span></a>
-            <a class="group-chip" href="#">Institutional <span class="count">67</span></a>
-            <a class="group-chip" href="#">Organizations <span class="count">45</span></a>
-            <a class="group-chip" href="#">Internal <span class="count">23</span></a>
+            <a class="group-chip border bg-body text-body" href="#">All <span class="count">2,307</span></a>
+            <a class="group-chip border border-danger-subtle bg-danger-subtle text-danger-emphasis" href="#" aria-current="page">Buyers <span class="count">342</span></a>
+            <a class="group-chip border bg-body text-body" href="#">Press <span class="count">289</span></a>
+            <a class="group-chip border bg-body text-body" href="#">Festivals <span class="count">156</span></a>
+            <a class="group-chip border bg-body text-body" href="#">Sellers <span class="count">98</span></a>
+            <a class="group-chip border bg-body text-body" href="#">Institutional <span class="count">67</span></a>
+            <a class="group-chip border bg-body text-body" href="#">Organizations <span class="count">45</span></a>
+            <a class="group-chip border bg-body text-body" href="#">Internal <span class="count">23</span></a>
           </div>
 
           <!-- Sub-group filter pills (shown when Buyers is selected) -->
@@ -176,14 +198,14 @@
           </div>
 
           <!-- Data table -->
-          <div class="bg-white rounded" style="border:1px solid #DEE2E6;">
+          <div class="bg-body rounded border">
             <table class="table table-hover mb-0" style="font-size:13px;">
               <thead>
                 <tr>
-                  <th>Name</th>
-                  <th>Tags</th>
-                  <th>Last Engagement</th>
-                  <th>Account</th>
+                  <th class="text-body-secondary">Name</th>
+                  <th class="text-body-secondary">Tags</th>
+                  <th class="text-body-secondary">Last Engagement</th>
+                  <th class="text-body-secondary">Account</th>
                 </tr>
               </thead>
               <tbody>
@@ -191,46 +213,46 @@
                   <td>
                     <div class="d-flex align-items-center gap-2">
                       <div class="avatar" style="background:#1B2A4A;">SC</div>
-                      <div><div class="contact-name">Sarah Chen</div><div class="contact-title">Dir. of Acquisitions</div></div>
+                      <div><div class="contact-name text-body">Sarah Chen</div><div class="contact-title text-body-secondary">Dir. of Acquisitions</div></div>
                     </div>
                   </td>
                   <td class="align-middle">
                     <div class="d-flex flex-wrap gap-2">
-                      <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Acquisitions</span>
-                      <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Streaming</span>
-                      <span class="tag"><span class="tag-dot" style="background:#2E75B6;"></span>Festival</span>
+                      <span class="tag"><span class="tag-dot bg-danger"></span>Acquisitions</span>
+                      <span class="tag"><span class="tag-dot bg-danger"></span>Streaming</span>
+                      <span class="tag"><span class="tag-dot bg-primary"></span>Festival</span>
                     </div>
                   </td>
-                  <td class="align-middle meta-text">2 days ago</td>
+                  <td class="align-middle meta-text text-body-secondary">2 days ago</td>
                   <td class="align-middle"><a class="account-link" href="#">Magnolia Pictures</a></td>
                 </tr>
                 <tr>
                   <td>
                     <div class="d-flex align-items-center gap-2">
                       <div class="avatar" style="background:#E8733A;">JP</div>
-                      <div><div class="contact-name">James Park</div><div class="contact-title">VP Content</div></div>
+                      <div><div class="contact-name text-body">James Park</div><div class="contact-title text-body-secondary">VP Content</div></div>
                     </div>
                   </td>
                   <td class="align-middle">
-                    <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Streaming</span>
+                    <span class="tag"><span class="tag-dot bg-danger"></span>Streaming</span>
                   </td>
-                  <td class="align-middle meta-text">1 week ago</td>
+                  <td class="align-middle meta-text text-body-secondary">1 week ago</td>
                   <td class="align-middle"><a class="account-link" href="#">MUBI</a></td>
                 </tr>
                 <tr>
                   <td>
                     <div class="d-flex align-items-center gap-2">
                       <div class="avatar" style="background:#22A06B;">ML</div>
-                      <div><div class="contact-name">Maria Lopez</div><div class="contact-title">Acquisitions Manager</div></div>
+                      <div><div class="contact-name text-body">Maria Lopez</div><div class="contact-title text-body-secondary">Acquisitions Manager</div></div>
                     </div>
                   </td>
                   <td class="align-middle">
                     <div class="d-flex flex-wrap gap-2">
-                      <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Buyer — All Rights</span>
-                      <span class="tag"><span class="tag-dot" style="background:#2E75B6;"></span>Fest — Programmer</span>
+                      <span class="tag"><span class="tag-dot bg-danger"></span>Buyer — All Rights</span>
+                      <span class="tag"><span class="tag-dot bg-primary"></span>Fest — Programmer</span>
                     </div>
                   </td>
-                  <td class="align-middle meta-text">3 days ago</td>
+                  <td class="align-middle meta-text text-body-secondary">3 days ago</td>
                   <td class="align-middle"><a class="account-link" href="#">Kino Lorber</a></td>
                 </tr>
               </tbody>
@@ -285,13 +307,16 @@
           <!-- Group filter chips (All selected) -->
           <div class="d-flex align-items-center flex-wrap gap-2 mb-3">
             <span class="group-label">GROUPS:</span>
-            <a class="group-chip selected-all" href="#">All <span class="count">418</span></a>
-            <a class="group-chip" href="#">Buyers <span class="count">185</span></a>
-            <a class="group-chip" href="#">Press <span class="count">72</span></a>
-            <a class="group-chip" href="#">Festivals <span class="count">64</span></a>
-            <a class="group-chip" href="#">Sellers <span class="count">41</span></a>
-            <a class="group-chip" href="#">Institutional <span class="count">33</span></a>
-            <a class="group-chip" href="#">Organizations <span class="count">23</span></a>
+            <!-- "All" carries no group, so a selected "All" renders the NEUTRAL surface
+                 (bg-body text-body) with aria-current — the component gives a group-less
+                 chip no colour, only programmatic state. (#151) -->
+            <a class="group-chip border bg-body text-body" href="#" aria-current="page">All <span class="count">418</span></a>
+            <a class="group-chip border bg-body text-body" href="#">Buyers <span class="count">185</span></a>
+            <a class="group-chip border bg-body text-body" href="#">Press <span class="count">72</span></a>
+            <a class="group-chip border bg-body text-body" href="#">Festivals <span class="count">64</span></a>
+            <a class="group-chip border bg-body text-body" href="#">Sellers <span class="count">41</span></a>
+            <a class="group-chip border bg-body text-body" href="#">Institutional <span class="count">33</span></a>
+            <a class="group-chip border bg-body text-body" href="#">Organizations <span class="count">23</span></a>
           </div>
 
           <!-- Toolbar: showing count, list/card toggle, sort dropdown -->
@@ -311,17 +336,17 @@
           </div>
 
           <!-- Data table: Account columns -->
-          <div class="bg-white rounded" style="border:1px solid #DEE2E6;">
+          <div class="bg-body rounded border">
             <table class="table table-hover mb-0" style="font-size:13px;">
               <thead>
                 <tr>
-                  <th>Account</th>
-                  <th>Primary Contact</th>
-                  <th>Contacts</th>
-                  <th>Tag Groups</th>
-                  <th>Health</th>
-                  <th>Last Engaged</th>
-                  <th>Owner</th>
+                  <th class="text-body-secondary">Account</th>
+                  <th class="text-body-secondary">Primary Contact</th>
+                  <th class="text-body-secondary">Contacts</th>
+                  <th class="text-body-secondary">Tag Groups</th>
+                  <th class="text-body-secondary">Health</th>
+                  <th class="text-body-secondary">Last Engaged</th>
+                  <th class="text-body-secondary">Owner</th>
                 </tr>
               </thead>
               <tbody>
@@ -329,58 +354,58 @@
                   <td class="align-middle">
                     <div class="d-flex align-items-center gap-2">
                       <div class="avatar" style="background:#2E75B6; width:28px; height:28px; font-size:10px;">MP</div>
-                      <span class="account-name">Magnolia Pictures</span>
+                      <span class="account-name text-body">Magnolia Pictures</span>
                     </div>
                   </td>
-                  <td class="align-middle meta-text">Sarah Chen</td>
-                  <td class="align-middle meta-text" style="text-align:center;">4</td>
+                  <td class="align-middle meta-text text-body-secondary">Sarah Chen</td>
+                  <td class="align-middle meta-text text-body-secondary" style="text-align:center;">4</td>
                   <td class="align-middle">
                     <div class="group-dots">
-                      <span class="group-dot" style="background:#E8733A;" title="Distribution"></span>
-                      <span class="group-dot" style="background:#2E75B6;" title="Press/Festival"></span>
+                      <span class="group-dot bg-danger" title="Distribution"></span>
+                      <span class="group-dot bg-primary" title="Press/Festival"></span>
                     </div>
                   </td>
                   <td class="align-middle"><span class="health-badge health-good">Good</span></td>
-                  <td class="align-middle meta-text">2 days ago</td>
-                  <td class="align-middle meta-text">Badie Ali</td>
+                  <td class="align-middle meta-text text-body-secondary">2 days ago</td>
+                  <td class="align-middle meta-text text-body-secondary">Badie Ali</td>
                 </tr>
                 <tr>
                   <td class="align-middle">
                     <div class="d-flex align-items-center gap-2">
                       <div class="avatar" style="background:#8B5CF6; width:28px; height:28px; font-size:10px;">MU</div>
-                      <span class="account-name">MUBI</span>
+                      <span class="account-name text-body">MUBI</span>
                     </div>
                   </td>
-                  <td class="align-middle meta-text">James Park</td>
-                  <td class="align-middle meta-text" style="text-align:center;">2</td>
+                  <td class="align-middle meta-text text-body-secondary">James Park</td>
+                  <td class="align-middle meta-text text-body-secondary" style="text-align:center;">2</td>
                   <td class="align-middle">
                     <div class="group-dots">
-                      <span class="group-dot" style="background:#E8733A;" title="Distribution"></span>
+                      <span class="group-dot bg-danger" title="Distribution"></span>
                     </div>
                   </td>
                   <td class="align-middle"><span class="health-badge health-fair">Fair</span></td>
-                  <td class="align-middle meta-text">1 week ago</td>
-                  <td class="align-middle meta-text">Randy Burgess</td>
+                  <td class="align-middle meta-text text-body-secondary">1 week ago</td>
+                  <td class="align-middle meta-text text-body-secondary">Randy Burgess</td>
                 </tr>
                 <tr>
                   <td class="align-middle">
                     <div class="d-flex align-items-center gap-2">
                       <div class="avatar" style="background:#22A06B; width:28px; height:28px; font-size:10px;">KL</div>
-                      <span class="account-name">Kino Lorber</span>
+                      <span class="account-name text-body">Kino Lorber</span>
                     </div>
                   </td>
-                  <td class="align-middle meta-text">Maria Lopez</td>
-                  <td class="align-middle meta-text" style="text-align:center;">6</td>
+                  <td class="align-middle meta-text text-body-secondary">Maria Lopez</td>
+                  <td class="align-middle meta-text text-body-secondary" style="text-align:center;">6</td>
                   <td class="align-middle">
                     <div class="group-dots">
-                      <span class="group-dot" style="background:#E8733A;" title="Distribution"></span>
-                      <span class="group-dot" style="background:#2E75B6;" title="Press/Festival"></span>
-                      <span class="group-dot" style="background:#D97706;" title="Institutional"></span>
+                      <span class="group-dot bg-danger" title="Distribution"></span>
+                      <span class="group-dot bg-primary" title="Press/Festival"></span>
+                      <span class="group-dot bg-warning" title="Institutional"></span>
                     </div>
                   </td>
                   <td class="align-middle"><span class="health-badge health-good">Good</span></td>
-                  <td class="align-middle meta-text">3 days ago</td>
-                  <td class="align-middle meta-text">Badie Ali</td>
+                  <td class="align-middle meta-text text-body-secondary">3 days ago</td>
+                  <td class="align-middle meta-text text-body-secondary">Badie Ali</td>
                 </tr>
               </tbody>
             </table>

--- a/spec/components/mpi_design_system/admin/data_table/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/data_table/component_spec.rb
@@ -33,43 +33,95 @@ RSpec.describe MpiDesignSystem::Admin::DataTable::Component, type: :component do
     expect(page).to have_css("th[style*='text-transform: uppercase']", text: "Tags")
   end
 
+  # Header foreground derives from `text-body-secondary`; the 2px separator is the
+  # `border-bottom` utility (colour via the adaptive `--bs-border-color`) widened by
+  # an inline `--bs-border-width: 2px` on the bottom edge only. `border-2` would box
+  # all four sides of a `.table th` — the browser spec proves the geometry. (#151)
+  it "renders headers as muted cells with a 2px bottom border" do
+    render_inline(described_class.new(columns: columns, rows: rows))
+
+    expect(page).to have_css(
+      "th.text-body-secondary.border-bottom[style*='--bs-border-width: 2px']",
+      text: "Name"
+    )
+    expect(page).to have_css("th.text-body-secondary.border-bottom", count: 4)
+  end
+
+  it "vertically centres cells with the align-middle utility" do
+    render_inline(described_class.new(columns: columns, rows: rows))
+
+    expect(page).to have_css("td.align-middle", count: 4)
+  end
+
   it "renders a row with avatar and name" do
     render_inline(described_class.new(columns: columns, rows: rows))
 
     expect(page).to have_css("span.rounded-circle", text: "JS")
-    expect(page).to have_css("div[style*='font-weight: 600']", text: "John Smith")
+    expect(page).to have_css("div.text-body[style*='font-weight: 600']", text: "John Smith")
   end
 
   it "renders name as a link when name_href is provided" do
     render_inline(described_class.new(columns: columns, rows: rows))
 
-    expect(page).to have_css("a[href='/contacts/1']", text: "John Smith")
+    # Adaptive body foreground via `text-body`, no underline — the retired inline
+    # `color: inherit; text-decoration: none` is now the utility pair.
+    expect(page).to have_css("a.text-body.text-decoration-none[href='/contacts/1']", text: "John Smith")
+    expect(page).to have_no_css("a[href='/contacts/1'][style*='color']")
   end
 
-  it "renders contact title below name" do
+  it "renders contact title below name in muted body text" do
     render_inline(described_class.new(columns: columns, rows: rows))
 
-    expect(page).to have_css("div[style*='font-size: 12px']", text: "Theatrical Buyer")
+    expect(page).to have_css("div.text-body-secondary[style*='font-size: 12px']", text: "Theatrical Buyer")
   end
 
-  it "renders tag dots with group colors" do
-    render_inline(described_class.new(columns: columns, rows: rows))
+  # Looped over the whole mapping so a typo in GROUP_VARIANTS reddens. The table is
+  # scoped to a single tags column, so the ONLY dot present is the tag dot — asserting
+  # exactly one `d-inline-block` dot and that it carries `bg-#{variant}` means a bare
+  # `bg-secondary` cannot silently match some other dot (testing.md, Codex P1).
+  it "renders a tag dot in each group's semantic fill" do
+    described_class::GROUP_VARIANTS.each do |group, variant|
+      render_inline(described_class.new(
+        columns: [ { key: :tags, label: "Tags" } ],
+        rows: [ { tags: [ { label: group.to_s, group: group } ] } ]
+      ))
 
-    expect(page).to have_css("span[style*='background: #E8733A']")
-    expect(page).to have_text("Acquisitions")
+      expect(page).to have_css("span.d-inline-block", count: 1)
+      expect(page).to have_css("span.d-inline-block.bg-#{variant}", count: 1)
+      expect(page).to have_css("span.text-body", text: group.to_s)
+    end
   end
 
-  it "renders account as a blue link" do
+  it "falls back to a secondary tag dot for an unknown group" do
+    render_inline(described_class.new(
+      columns: [ { key: :tags, label: "Tags" } ],
+      rows: [ { tags: [ { label: "Mystery", group: :nope } ] } ]
+    ))
+
+    expect(page).to have_css("span.d-inline-block", count: 1)
+    expect(page).to have_css("span.d-inline-block.bg-secondary", count: 1)
+    expect(page).to have_css("span.text-body", text: "Mystery")
+  end
+
+  it "renders the account as a default-colour link with its underline intact" do
     render_inline(described_class.new(columns: columns, rows: rows))
 
-    expect(page).to have_css("a[style*='color: #2E75B6'][href='/accounts/1']", text: "Sony Pictures")
+    expect(page).to have_css("a[href='/accounts/1']", text: "Sony Pictures")
+
+    link = page.find("a[href='/accounts/1']")
+    # No class at all -> no `text-*` colour class and no `text-decoration-none`: the
+    # anchor paints Bootstrap's `--bs-link-color` and keeps its underline. Only the
+    # geometry survives inline, so the exact style pins the absence of a colour too.
+    # The browser spec proves the painted colour.
+    expect(link[:class]).to be_nil
+    expect(link[:style]).to eq("font-size: 13px;")
   end
 
   it "renders account as plain text when account_href is missing" do
     rows_no_href = [ { name: "Test User", account: "Acme Corp" } ]
     render_inline(described_class.new(columns: columns, rows: rows_no_href))
 
-    expect(page).to have_css("span", text: "Acme Corp")
+    expect(page).to have_css("span.text-body", text: "Acme Corp")
     expect(page).not_to have_css("a", text: "Acme Corp")
   end
 
@@ -104,25 +156,220 @@ RSpec.describe MpiDesignSystem::Admin::DataTable::Component, type: :component do
     expect(page).not_to have_css("tbody tr")
   end
 
-  it "renders search results variant with status column" do
-    search_columns = [
-      { key: :name, label: "Name" },
-      { key: :tags, label: "Tags" },
-      { key: :match_found_in, label: "Match Found In" },
-      { key: :status, label: "Status" }
-    ]
-    search_rows = [
-      {
-        name: "Jane Doe",
-        tags: [ { label: "Journalist", group: :outreach } ],
-        match_found_in: "Title contains <strong>investor</strong>",
-        status: "Active",
-        status_key: :active
-      }
-    ]
-    render_inline(described_class.new(columns: search_columns, rows: search_rows, variant: :search_results))
+  # Colour left these inline styles; geometry did not, and has no Bootstrap
+  # equivalent. The theme-adaptivity guards below only assert ABSENCE, so without this
+  # a wiped `*_styles` helper would ship green. Watched red by emptying each helper.
+  it "keeps the non-colour geometry that has no Bootstrap equivalent" do
+    render_inline(described_class.new(columns: columns, rows: rows))
 
-    expect(page).to have_css("span[style*='background: #22A06B']")
-    expect(page).to have_text("Active")
+    expect(page).to have_css(
+      "th[style*='font-size: 11px'][style*='letter-spacing: 0.06em'][style*='--bs-border-width: 2px']",
+      text: "Name"
+    )
+    expect(page).to have_css("div.text-body[style*='font-weight: 600'][style*='font-size: 14px']", text: "John Smith")
+    expect(page).to have_css("span.d-inline-block[style*='width: 6px'][style*='height: 6px'][style*='border-radius: 50%']")
+    # tag_text_styles and meta_text_styles each retain `font-size: 13px` inline (no
+    # Bootstrap equivalent). Pin them POSITIVELY — the theme-adaptivity guards below only
+    # assert ABSENCE, so without this, emptying either helper ships green. Watched red by
+    # emptying each. (#151, FIX 5)
+    expect(page).to have_css("span.text-body[style*='font-size: 13px']", text: "Acquisitions")
+    expect(page).to have_css("span.text-body-secondary[style*='font-size: 13px']", text: "2 days ago")
+  end
+
+  describe "search results variant" do
+    let(:search_columns) do
+      [
+        { key: :name, label: "Name" },
+        { key: :tags, label: "Tags" },
+        { key: :match_found_in, label: "Match Found In" },
+        { key: :status, label: "Status" }
+      ]
+    end
+
+    it "renders a keyword-highlighted match cell" do
+      render_inline(described_class.new(
+        columns: search_columns,
+        rows: [ { name: "Jane Doe", match_found_in: "Title contains <strong>investor</strong>", status: "Active", status_key: :active } ],
+        variant: :search_results
+      ))
+
+      expect(page).to have_css("td strong", text: "investor")
+    end
+
+    # Looped over the whole STATUS_VARIANTS mapping; the status-only table means the
+    # single dot present is the status dot, so count + fill together prevent a stray
+    # `bg-secondary` from matching the wrong element.
+    it "renders a status dot in each status's semantic fill" do
+      described_class::STATUS_VARIANTS.each do |status, variant|
+        render_inline(described_class.new(
+          columns: [ { key: :status, label: "Status" } ],
+          rows: [ { status: status.to_s, status_key: status } ],
+          variant: :search_results
+        ))
+
+        expect(page).to have_css("span.d-inline-block", count: 1)
+        expect(page).to have_css("span.d-inline-block.bg-#{variant}", count: 1)
+        expect(page).to have_css("span.text-body-secondary", text: status.to_s)
+      end
+    end
+
+    it "falls back to a secondary status dot for an unknown status" do
+      render_inline(described_class.new(
+        columns: [ { key: :status, label: "Status" } ],
+        rows: [ { status: "Weird", status_key: :nope } ],
+        variant: :search_results
+      ))
+
+      expect(page).to have_css("span.d-inline-block", count: 1)
+      expect(page).to have_css("span.d-inline-block.bg-secondary", count: 1)
+    end
+
+    # Unknown tag group AND unknown status in one row: both fall back to `secondary`.
+    # Two dots total, both `bg-secondary` — asserting the count proves neither is some
+    # other colour that merely happened to render.
+    it "falls back to secondary for both an unknown group and an unknown status in one row" do
+      render_inline(described_class.new(
+        columns: [ { key: :tags, label: "Tags" }, { key: :status, label: "Status" } ],
+        rows: [ { tags: [ { label: "Mystery", group: :nope } ], status: "Weird", status_key: :nope } ],
+        variant: :search_results
+      ))
+
+      expect(page).to have_css("span.d-inline-block", count: 2)
+      expect(page).to have_css("span.d-inline-block.bg-secondary", count: 2)
+    end
+  end
+
+  # #151 moved every DataTable colour (header, name, title, tag/status dots, tag/meta
+  # text, account link) onto Bootstrap semantic utilities so the table tracks
+  # `data-bs-theme`. Each guard pins its subject POSITIVELY before asserting an
+  # absence, and each was proven by watching it fail (testing.md, "A Guard Is Not Real
+  # Until You Have Watched It Fail"). The 12-entry fixed-scheme list is the exact one
+  # from pagination/component_spec.rb.
+  describe "theme-adaptivity guards" do
+    let(:fixed_scheme_utilities) do
+      %w[
+        bg-white bg-black bg-light bg-dark
+        text-white text-black text-light text-dark
+        border-white border-black border-light border-dark
+      ]
+    end
+
+    let(:hex_literal) { /#(?:\h{8}|\h{6}|\h{4}|\h{3})(?!\h)/ }
+
+    # A colour/border/opacity-bearing property, matched on the name to the LEFT of the
+    # colon. `--bs-border-width` (custom-property prefix) and `border-radius` (radius is
+    # not one of the side/attribute suffixes) fall OUTSIDE this pattern and stay allowed
+    # geometry — so a re-introduced `border: 1px solid red` or `border: none` is caught
+    # while the surviving `--bs-border-width: 2px` is not. (#151, FIX 3)
+    let(:colour_or_border_prop) do
+      /\A(color|background(-color)?|border(-(top|right|bottom|left|color|style|width))?|outline|box-shadow|opacity)\z/
+    end
+
+    # A colour literal in a declaration VALUE: hex, rgb()/hsl(), or a common named colour
+    # as a whole word — so a hue smuggled into an allowed property's value is still caught.
+    let(:colour_value_literal) do
+      /#(?:\h{3,8})|\brgb|\bhsl|\b(?:red|green|blue|white|black|orange|yellow|purple|gr[ae]y)\b/i
+    end
+
+    # Every surviving inline "property: value" declaration that names a colour/border
+    # property OR carries a colour literal in its value.
+    def offending_style_declarations(fragment)
+      fragment.css("[style]")
+              .flat_map { |el| el["style"].to_s.split(";") }
+              .map(&:strip).reject(&:empty?)
+              .select do |decl|
+        prop, value = decl.split(":", 2)
+        prop.to_s.strip.downcase.match?(colour_or_border_prop) ||
+          value.to_s.strip.downcase.match?(colour_value_literal)
+      end
+    end
+
+    let(:populated) do
+      described_class.new(
+        variant: :search_results,
+        columns: [
+          { key: :name, label: "Name", sortable: true },
+          { key: :tags, label: "Tags" },
+          { key: :last_engagement, label: "Last Engagement" },
+          { key: :account, label: "Account" },
+          { key: :status, label: "Status" }
+        ],
+        rows: [ {
+          name: "John Smith",
+          title: "Theatrical Buyer",
+          name_href: "/contacts/1",
+          tags: [ { label: "Acquisitions", group: :distribution }, { label: "Journalist", group: :outreach } ],
+          last_engagement: "2 days ago",
+          account: "Sony Pictures",
+          account_href: "/accounts/1",
+          status: "Active",
+          status_key: :active
+        } ],
+        sort_by: :name,
+        sort_dir: :asc
+      )
+    end
+
+    # DataTable embeds AvatarCircle, which legitimately still emits inline hex
+    # (`background-color: #22A06B; color: #000` from #130 — out of scope for #151).
+    # Strip ONLY that subtree so the scan proves DataTable's OWN markup carries no frozen
+    # colour, not the avatar's. AvatarCircle's default variant renders no dedicated class
+    # (its root is `d-inline-flex align-items-center justify-content-center rounded-circle
+    # fw-semibold`), so we pin its root by the `rounded-circle` + `justify-content-center`
+    # pair — narrower than bare `.rounded-circle`, a generic Bootstrap utility a future
+    # DataTable-owned element could reuse and thereby escape the scan (the FIX 4 defect).
+    # If AvatarCircle's classes ever change so this stops matching, its inline hex leaks
+    # INTO the scan and reddens the guard — a loud failure, not a silent over-strip.
+    def datatable_without_avatars
+      render_inline(populated)
+      fragment = Nokogiri::HTML::DocumentFragment.parse(rendered_content)
+      fragment.css(".rounded-circle.justify-content-center").remove
+      fragment
+    end
+
+    it "emits no literal colour in its own markup (avatars excluded — a separate component)" do
+      fragment = datatable_without_avatars
+
+      # Prove an avatar WAS present (else the exclusion would be masking nothing), and
+      # that the scanned fragment actually contains DataTable markup.
+      expect(page).to have_css("span.rounded-circle", text: "JS")
+      expect(fragment.at_css("th.border-bottom")).not_to be_nil
+      expect(fragment.at_css("span.bg-danger")).not_to be_nil
+
+      html = fragment.to_html
+      expect(html).not_to match(hex_literal)
+      expect(html).not_to include("rgb(")
+      expect(html).not_to include("hsl(")
+    end
+
+    it "emits no colour, border, or opacity declaration in the inline styles that remain" do
+      fragment = datatable_without_avatars
+
+      # Inline styles DO still exist (geometry) — without this the assertion below would
+      # pass on markup that emitted no style at all.
+      expect(fragment.css("[style*='--bs-border-width']")).not_to be_empty
+
+      # Only geometry may survive inline. Matching on the PROPERTY name catches a
+      # re-introduced `border: 1px solid red` or `border: none` (named colour / keyword)
+      # that a `[style*='color']` / `[style*='background']` substring scan let through;
+      # `--bs-border-width` and `border-radius` remain allowed. Proven by mutation: a
+      # `border: 1px solid red` injected into a style helper reddens this. (#151, FIX 3)
+      expect(offending_style_declarations(fragment)).to eq([])
+    end
+
+    it "pins no fixed-scheme utility that would break under data-bs-theme" do
+      render_inline(populated)
+
+      # The table and every descendant, enumerated — including the avatar, whose
+      # classes carry no fixed-scheme utility — rather than a [class*=…] substring hunt.
+      elements = page.all("table, table *")
+      expect(elements.size).to be > 1
+
+      applied = elements.flat_map { |el| el[:class].to_s.split }.uniq
+      expect(applied).to include(
+        "text-body", "text-body-secondary", "border-bottom", "bg-danger", "bg-success"
+      )
+      expect(applied & fixed_scheme_utilities).to be_empty
+    end
   end
 end

--- a/spec/components/mpi_design_system/admin/filter_chip_bar/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/filter_chip_bar/component_spec.rb
@@ -26,20 +26,53 @@ RSpec.describe MpiDesignSystem::Admin::FilterChipBar::Component, type: :componen
       expect(page).to have_css("a[href='/contacts?group=distribution']", text: "Distribution 342")
     end
 
-    it "highlights selected chip with group color" do
-      selected_groups = [
-        { label: "Distribution", count: 342, group: :distribution, selected: true, href: "#" }
-      ]
-      render_inline(described_class.new(groups: selected_groups))
+    # Looped over the whole mapping — a spot-check on one group would let a typo in
+    # GROUP_VARIANTS ship green (testing.md, "loop the constant"). Each selected chip
+    # renders its group's semantic `-subtle` surface + `-emphasis` foreground, which
+    # are theme-adaptive; the always-present count text pins WHICH chip is asserted.
+    it "renders a selected chip in its group's semantic subtle/emphasis utilities" do
+      described_class::GROUP_VARIANTS.each do |group, variant|
+        render_inline(described_class.new(groups: [
+          { label: group.to_s, count: 5, group: group, selected: true, href: "/contacts?group=#{group}" }
+        ]))
 
-      expect(page).to have_css("a[style*='border: 1px solid #E8733A'][style*='background: #FEF3EC']")
-      expect(page).to have_css("a[aria-current='page']")
+        expect(page).to have_css(
+          "a.rounded-pill.border.border-#{variant}-subtle.bg-#{variant}-subtle.text-#{variant}-emphasis[aria-current='page']",
+          text: "#{group} 5"
+        )
+      end
     end
 
-    it "renders unselected chips with default styling" do
+    it "renders unselected chips on the adaptive body surface" do
       render_inline(described_class.new(groups: groups))
 
-      expect(page).to have_css("[style*='border: 1px solid #DEE2E6'][style*='background: #fff']")
+      expect(page).to have_css("a.rounded-pill.border.bg-body.text-body", text: "Distribution 342")
+      expect(page).to have_css("a.rounded-pill.border.bg-body.text-body", text: "Outreach 128")
+    end
+
+    # A selected chip whose group is unknown gets the UNSELECTED treatment. `bg-body`
+    # is a state the selected branch cannot produce (it emits `-subtle`/`-emphasis`),
+    # so this distinguishes "fell back" from "was ignored" (testing.md False Green #1).
+    it "treats a selected chip with an unknown group as unselected" do
+      render_inline(described_class.new(groups: [
+        { label: "Mystery", count: 3, group: :nope, selected: true, href: "/contacts?group=nope" }
+      ]))
+
+      expect(page).to have_css("a.rounded-pill.border.bg-body.text-body[aria-current='page']", text: "Mystery 3")
+      expect(page).not_to have_css("a[class*='-subtle']")
+    end
+
+    # Colour left the chip's inline style; padding/size/weight did not, and have no
+    # Bootstrap equivalent. The theme-adaptivity guards below only assert ABSENCE, so
+    # without this a wiped group_chip_styles would ship green. Watched red by emptying
+    # that helper.
+    it "keeps the non-colour chip geometry inline" do
+      render_inline(described_class.new(groups: [ { label: "All", count: 5 } ]))
+
+      expect(page).to have_css(
+        "span.rounded-pill[style*='padding: 5px 12px'][style*='font-size: 13px'][style*='font-weight: 500']",
+        text: "All 5"
+      )
     end
 
     it "wraps in a role=group with aria-label" do
@@ -65,10 +98,7 @@ RSpec.describe MpiDesignSystem::Admin::FilterChipBar::Component, type: :componen
       expect(page).to have_text("Group: Distribution")
     end
 
-    # Previously asserted `background: #2E75B6` + `color: #fff` as literals.
-    # This component renders the same pill as ActiveFilterBar, and carried the
-    # same defects: a hardcoded duplicate of $mpi-primary, and a remove button
-    # faded to 3.71:1 by `opacity: 0.8`. Both now derive. (#130)
+    # The pill renders the same derived-foreground fill as ActiveFilterBar. (#130)
     it "renders pills with a Bootstrap-derived foreground rather than pinned white" do
       render_inline(described_class.new(active_filters: active_filters))
 
@@ -77,11 +107,31 @@ RSpec.describe MpiDesignSystem::Admin::FilterChipBar::Component, type: :componen
       expect(page).to have_no_css("span[style*='color: #fff']")
     end
 
-    it "does not fade the remove button, which eroded contrast to 3.71:1" do
+    # The retired `opacity: 0.8` faded white to 3.71:1 (#130); the retired inline
+    # `color: inherit; background: none; border: none` became the utility trio
+    # `text-reset bg-transparent border-0`, so the button pins no colour of its own
+    # while still inheriting the pill's derived foreground. (#151)
+    it "resets the remove button to the pill's own foreground without pinning colour" do
       render_inline(described_class.new(active_filters: active_filters))
 
-      expect(page).to have_css("a[style*='color: inherit']", count: 2)
+      expect(page).to have_css("a.text-reset.bg-transparent.border-0[aria-label='Remove filter: Keyword: investors']", count: 1)
+      expect(page).to have_css("a.text-reset.bg-transparent.border-0", count: 2)
+      expect(page).to have_no_css("a[style*='color']")
       expect(page).to have_no_css("a[style*='opacity']")
+    end
+
+    # remove_btn_styles keeps padding/font-size/line-height/cursor inline (no Bootstrap
+    # equivalent). Pin them POSITIVELY — the theme-adaptivity guards only assert ABSENCE,
+    # so without this, emptying remove_btn_styles ships green. Watched red by emptying it.
+    # (#151, FIX 5)
+    it "keeps the remove button's non-colour geometry inline" do
+      render_inline(described_class.new(active_filters: active_filters))
+
+      expect(page).to have_css(
+        "a.text-reset.bg-transparent.border-0[style*='padding: 0'][style*='font-size: inherit']" \
+        "[style*='line-height: 1'][style*='cursor: pointer']",
+        count: 2
+      )
     end
 
     it "derives the label and clear-all foreground rather than pinning #6C757D" do
@@ -169,18 +219,111 @@ RSpec.describe MpiDesignSystem::Admin::FilterChipBar::Component, type: :componen
 
       expect(page.native.to_html).not_to include("#6C757D")
     end
+  end
 
-    # Group chips are deliberately NOT changed here: they render the shared
-    # TagChip::GROUPS pairs, whose 7 colour/background combinations all fail AA
-    # (2.77:1–4.34:1). Fixing those means changing shared tag token values — a
-    # designer-led decision tracked in the #130 follow-up, not silently absorbed
-    # into this PR. This example pins the current behaviour so the exclusion is
-    # explicit rather than accidental.
-    it "leaves group chip colours untouched, pending the tag-palette follow-up" do
-      selected = [ { label: "Distribution", count: 50, group: :distribution, selected: true } ]
-      render_inline(described_class.new(groups: selected))
+  # #151 moved every chip colour (selected surface, unselected surface, remove button)
+  # onto Bootstrap semantic utilities so the bar tracks `data-bs-theme`. Each guard
+  # pins the element it is about POSITIVELY before asserting an absence, and each was
+  # proven by watching it fail against a mutation that trips it (testing.md, "A Guard
+  # Is Not Real Until You Have Watched It Fail"). The 12-entry fixed-scheme list is the
+  # exact one from pagination/component_spec.rb.
+  describe "theme-adaptivity guards" do
+    let(:fixed_scheme_utilities) do
+      %w[
+        bg-white bg-black bg-light bg-dark
+        text-white text-black text-light text-dark
+        border-white border-black border-light border-dark
+      ]
+    end
 
-      expect(page).to have_css("span[style*='color: #E8733A'][style*='background: #FEF3EC']")
+    # Matches 3-, 4-, 6- and 8-digit CSS hex; the trailing (?!\h) stops a 6-digit
+    # match inside a longer run and the 4/8 branches close the alpha forms.
+    let(:hex_literal) { /#(?:\h{8}|\h{6}|\h{4}|\h{3})(?!\h)/ }
+
+    # A colour/border/opacity-bearing property, matched on the name to the LEFT of the
+    # colon. `--bs-border-width` (custom-property prefix) and `border-radius` (radius is
+    # not one of the side/attribute suffixes) fall OUTSIDE this pattern and stay allowed
+    # geometry — so a re-introduced `border: 1px solid red` or `border: none` is caught
+    # while the surviving `--bs-border-width: 2px` is not. (#151, FIX 3)
+    let(:colour_or_border_prop) do
+      /\A(color|background(-color)?|border(-(top|right|bottom|left|color|style|width))?|outline|box-shadow|opacity)\z/
+    end
+
+    # A colour literal in a declaration VALUE: hex, rgb()/hsl(), or a common named colour
+    # as a whole word — so a hue smuggled into an allowed property's value is still caught.
+    let(:colour_value_literal) do
+      /#(?:\h{3,8})|\brgb|\bhsl|\b(?:red|green|blue|white|black|orange|yellow|purple|gr[ae]y)\b/i
+    end
+
+    # Every surviving inline "property: value" declaration that names a colour/border
+    # property OR carries a colour literal in its value.
+    def offending_style_declarations(fragment)
+      fragment.css("[style]")
+              .flat_map { |el| el["style"].to_s.split(";") }
+              .map(&:strip).reject(&:empty?)
+              .select do |decl|
+        prop, value = decl.split(":", 2)
+        prop.to_s.strip.downcase.match?(colour_or_border_prop) ||
+          value.to_s.strip.downcase.match?(colour_value_literal)
+      end
+    end
+
+    let(:populated) do
+      described_class.new(
+        groups: [
+          { label: "All", count: 2307 },
+          { label: "Distribution", count: 342, group: :distribution, selected: true, href: "/contacts?group=distribution" },
+          { label: "Outreach", count: 128, group: :outreach, href: "/contacts?group=outreach" }
+        ],
+        active_filters: [ { category: "Keyword", value: "investors", remove_url: "/contacts?remove=keyword" } ],
+        clear_all_url: "/contacts",
+        reset_all_url: "/contacts"
+      )
+    end
+
+    it "emits no literal colour anywhere in the markup" do
+      render_inline(populated)
+
+      # Prove the markup under scrutiny actually rendered — a scan over an empty
+      # string matches nothing and would pass forever.
+      expect(page).to have_css("a[aria-current='page']", text: "Distribution 342")
+      expect(page).to have_css("span.text-bg-primary", text: "Keyword: investors")
+
+      expect(rendered_content).not_to match(hex_literal)
+      expect(rendered_content).not_to include("rgb(")
+      expect(rendered_content).not_to include("hsl(")
+    end
+
+    it "emits no colour, border, or opacity declaration in the inline styles that remain" do
+      render_inline(populated)
+
+      # Inline styles DO still exist (geometry) — without this the assertion below would
+      # pass on a component that emitted no style at all.
+      expect(page).to have_css("[style*='padding: 5px 12px']")
+
+      # Only geometry may survive inline. Matching on the PROPERTY name catches a
+      # re-introduced `border: 1px solid red` / `border: none` (named colour / keyword) a
+      # `[style*='color']` / `[style*='background']` substring scan let through;
+      # `--bs-border-width` and `border-radius` remain allowed. Proven by mutation: a
+      # `border: 1px solid red` injected into a style helper reddens this. (#151, FIX 3)
+      fragment = Nokogiri::HTML::DocumentFragment.parse(rendered_content)
+      expect(offending_style_declarations(fragment)).to eq([])
+    end
+
+    it "pins no fixed-scheme utility that would break under data-bs-theme" do
+      render_inline(populated)
+
+      # Every element, enumerated — not a [class*=…] substring hunt, which would match
+      # `border-danger-subtle` for `border-dark`.
+      elements = page.all("*")
+      expect(elements.size).to be > 1
+
+      applied = elements.flat_map { |el| el[:class].to_s.split }.uniq
+      expect(applied).to include(
+        "text-body", "bg-body", "text-body-secondary",
+        "text-bg-primary", "bg-danger-subtle", "text-danger-emphasis"
+      )
+      expect(applied & fixed_scheme_utilities).to be_empty
     end
   end
 end

--- a/spec/components/mpi_design_system/admin/tag_chip/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/tag_chip/component_spec.rb
@@ -65,4 +65,45 @@ RSpec.describe MpiDesignSystem::Admin::TagChip::Component, type: :component do
 
     expect(page).to have_css("span[style*='border-radius: 999px']")
   end
+
+  # GROUP_VARIANTS is the shared tag-group -> Bootstrap-semantic mapping that
+  # FilterChipBar and DataTable consume (#151). Every GROUPS key must have a mapping,
+  # or a converted consumer would hit `nil` and silently fall back to `secondary`.
+  describe "GROUP_VARIANTS mapping (#151)" do
+    it "maps every GROUPS key to a semantic variant" do
+      expect(described_class::GROUP_VARIANTS.keys).to match_array(described_class::GROUPS.keys)
+    end
+
+    # The consumer loops (FilterChipBar/DataTable) read this same constant, so a
+    # semantic REMAP (e.g. distribution: :danger -> :success) would render and assert
+    # the new value identically and ship green there. Pinning the exact mapping makes
+    # any category recolour a deliberate, test-updating change — the crux design
+    # decision of #151 (info==primary collapses the three cool categories onto blue).
+    it "maps each category to its issue-specified semantic" do
+      expect(described_class::GROUP_VARIANTS).to eq(
+        press_festival: :primary,
+        production: :primary,
+        vendors: :primary,
+        outreach: :success,
+        finance: :warning,
+        distribution: :danger,
+        internal: :secondary
+      )
+    end
+
+    it "maps only to real Bootstrap theme colours" do
+      valid = %i[primary secondary success warning danger info light dark]
+      expect(described_class::GROUP_VARIANTS.values.uniq - valid).to be_empty
+    end
+
+    # TagChip's OWN rendering stays hex this phase — the conversion is limited to the
+    # two list-view consumers. This pins that scope: the chip still emits its frozen
+    # colour pair, so a future TagChip conversion is a deliberate, tested change rather
+    # than an accident. (#151 follow-up)
+    it "leaves TagChip's own rendering on the frozen hex palette" do
+      render_inline(described_class.new(label: "Distribution", group: :distribution))
+
+      expect(page).to have_css("span[style*='color: #E8733A'][style*='background-color: #FEF3EC']", text: "Distribution")
+    end
+  end
 end

--- a/spec/components/previews/mpi_design_system/admin/data_table/component_preview.rb
+++ b/spec/components/previews/mpi_design_system/admin/data_table/component_preview.rb
@@ -44,6 +44,15 @@ class MpiDesignSystem::Admin::DataTable::ComponentPreview < ApplicationComponent
     )
   end
 
+  # The #151 conversion in one view: the same table under both colour modes. The tag
+  # dots keep a fixed identity hue across themes (decorative — the label carries the
+  # meaning); header, name, muted text, borders and the account link all adapt.
+  #
+  # @label Dark Mode
+  def dark_mode
+    render_with_template
+  end
+
   private
 
   def sample_contacts

--- a/spec/components/previews/mpi_design_system/admin/data_table/component_preview/dark_mode.html.erb
+++ b/spec/components/previews/mpi_design_system/admin/data_table/component_preview/dark_mode.html.erb
@@ -1,0 +1,29 @@
+<%# Light and dark side by side. Each wrapper sets `data-bs-theme` and `bg-body`, so the
+    surface and the table inside it both resolve from the same colour mode — the claim of
+    the #151 conversion. Tag dots stay a fixed identity hue (decorative); everything else
+    adapts. %>
+<% columns = [
+     { key: :name, label: "Name", sortable: true },
+     { key: :tags, label: "Tags" },
+     { key: :last_engagement, label: "Last Engagement", sortable: true },
+     { key: :account, label: "Account" }
+   ] %>
+<% rows = [
+     { name: "Jane Cooper", title: "VP of Acquisitions", name_href: "#", tags: [ { group: :distribution, label: "Acquisitions" } ], last_engagement: "2 days ago", account: "Acme Films", account_href: "#" },
+     { name: "Robert Fox", title: "Festival Director", name_href: "#", tags: [ { group: :press_festival, label: "Festival" } ], last_engagement: "1 week ago", account: "Berlin Film Fest", account_href: "#" },
+     { name: "Emily Chen", title: "Press Manager", name_href: "#", tags: [ { group: :outreach, label: "Journalist" } ], last_engagement: "3 days ago", account: "Film Weekly", account_href: "#" }
+   ] %>
+
+<div data-bs-theme="light" class="bg-body p-3 mb-3">
+  <p class="text-body-secondary small mb-2">data-bs-theme="light"</p>
+  <%= render MpiDesignSystem::Admin::DataTable::Component.new(
+        columns: columns, rows: rows, sort_by: :name, sort_dir: :asc
+      ) %>
+</div>
+
+<div data-bs-theme="dark" class="bg-body p-3">
+  <p class="text-body-secondary small mb-2">data-bs-theme="dark"</p>
+  <%= render MpiDesignSystem::Admin::DataTable::Component.new(
+        columns: columns, rows: rows, sort_by: :name, sort_dir: :asc
+      ) %>
+</div>

--- a/spec/components/previews/mpi_design_system/admin/filter_chip_bar/component_preview.rb
+++ b/spec/components/previews/mpi_design_system/admin/filter_chip_bar/component_preview.rb
@@ -54,4 +54,13 @@ class MpiDesignSystem::Admin::FilterChipBar::ComponentPreview < ApplicationCompo
       reset_all_url: "#"
     )
   end
+
+  # The point of the #151 conversion: the same component, no variant flag, following
+  # Bootstrap's colour mode. Side-by-side so a designer can compare the selected chips'
+  # semantic subtle/emphasis surfaces on the light and dark backdrop in one view.
+  #
+  # @label Dark Mode
+  def dark_mode
+    render_with_template
+  end
 end

--- a/spec/components/previews/mpi_design_system/admin/filter_chip_bar/component_preview/dark_mode.html.erb
+++ b/spec/components/previews/mpi_design_system/admin/filter_chip_bar/component_preview/dark_mode.html.erb
@@ -1,0 +1,25 @@
+<%# Light and dark side by side. Each wrapper sets `data-bs-theme` and `bg-body`, so the
+    surface and the chips inside it both resolve from the same colour mode — which is the
+    whole claim of the #151 conversion. The selected chip carries its group's semantic
+    `-subtle`/`-emphasis` utilities; the remove button is `text-reset`. %>
+<% groups = [
+     { label: "All", count: 2307 },
+     { label: "Distribution", count: 342, group: :distribution, selected: true, href: "#" },
+     { label: "Outreach", count: 128, group: :outreach, href: "#" },
+     { label: "Finance", count: 51, group: :finance, href: "#" }
+   ] %>
+<% active = [ { category: "Keyword", value: "investors", remove_url: "#" } ] %>
+
+<div data-bs-theme="light" class="bg-body p-3 mb-3">
+  <p class="text-body-secondary small mb-2">data-bs-theme="light"</p>
+  <%= render MpiDesignSystem::Admin::FilterChipBar::Component.new(
+        groups: groups, active_filters: active, clear_all_url: "#"
+      ) %>
+</div>
+
+<div data-bs-theme="dark" class="bg-body p-3">
+  <p class="text-body-secondary small mb-2">data-bs-theme="dark"</p>
+  <%= render MpiDesignSystem::Admin::FilterChipBar::Component.new(
+        groups: groups, active_filters: active, clear_all_url: "#"
+      ) %>
+</div>

--- a/spec/dummy/app/views/contrast_demo/show.html.erb
+++ b/spec/dummy/app/views/contrast_demo/show.html.erb
@@ -16,6 +16,36 @@
      9 => "David Kim"
    } %>
 
+<%# DataTable fixture shared by the light (#datatable) and dark (#dark-datatable)
+    renders so both exercise the identical rows. Row 1's tags column carries one tag
+    per distinct GROUP_VARIANTS hue (press_festival->primary, outreach->success,
+    finance->warning, distribution->danger, internal->secondary) and the three rows'
+    status column carries one status per distinct STATUS_VARIANTS hue (active->success,
+    follow_up->warning, inactive->secondary), so contrast_spec can LOOP every tag-dot
+    and status-dot variant against the resting row backdrop in both colour modes. (#151) %>
+<% datatable_columns = [
+     { key: :name, label: "Name", sortable: true },
+     { key: :tags, label: "Tags" },
+     { key: :account, label: "Account" },
+     { key: :status, label: "Status" }
+   ] %>
+<% datatable_rows = [
+     {
+       name: "John Smith", title: "Theatrical Buyer", name_href: "/contacts/1",
+       tags: [
+         { label: "Festival", group: :press_festival },
+         { label: "Outreach", group: :outreach },
+         { label: "Finance", group: :finance },
+         { label: "Distribution", group: :distribution },
+         { label: "Internal", group: :internal }
+       ],
+       account: "Sony Pictures", account_href: "/accounts/1",
+       status: "Active", status_key: :active
+     },
+     { name: "Ada Lovelace", status: "Follow up", status_key: :follow_up },
+     { name: "Alan Turing", status: "Inactive", status_key: :inactive }
+   ] %>
+
 <main class="container py-4">
   <h1 class="h4 mb-3">Contrast Demo</h1>
 
@@ -64,10 +94,25 @@
 
   <section id="filter-chip-bar" class="mb-4">
     <%= render MpiDesignSystem::Admin::FilterChipBar::Component.new(
-          groups: [ { label: "All", count: 100 } ],
+          groups: [
+            { label: "All", count: 100 },
+            { label: "Finance", count: 51, group: :finance, selected: true, href: "#" }
+          ],
           active_filters: [ { category: "Tag", value: "Acquisitions", remove_url: "#" } ],
           clear_all_url: "#",
           reset_all_url: "#"
+        ) %>
+  </section>
+
+  <%# DataTable (#151) — theme-adaptive. The tag/status dots keep a FIXED identity hue
+      (decorative), so the spec asserts >=3:1 against the RESTING row backdrop rather than
+      the 4.5:1 text floor, looping every dot variant; header, name, muted text, borders
+      and the account link adapt and are asserted in both modes (the dark copy lives inside
+      #dark-mode below). %>
+  <section id="datatable" class="mb-4">
+    <%= render MpiDesignSystem::Admin::DataTable::Component.new(
+          variant: :search_results, columns: datatable_columns, rows: datatable_rows,
+          sort_by: :name, sort_dir: :asc
         ) %>
   </section>
 
@@ -106,9 +151,18 @@
     </div>
     <div id="dark-filter-chip-bar" class="mb-3">
       <%= render MpiDesignSystem::Admin::FilterChipBar::Component.new(
-            groups: [ { label: "All", count: 100 } ],
+            groups: [
+              { label: "All", count: 100 },
+              { label: "Finance", count: 51, group: :finance, selected: true, href: "#" }
+            ],
             active_filters: [ { category: "Tag", value: "Acquisitions", remove_url: "#" } ],
             clear_all_url: "#"
+          ) %>
+    </div>
+    <div id="dark-datatable" class="mb-3">
+      <%= render MpiDesignSystem::Admin::DataTable::Component.new(
+            variant: :search_results, columns: datatable_columns, rows: datatable_rows,
+            sort_by: :name, sort_dir: :asc
           ) %>
     </div>
     <div id="dark-pagination" class="mb-3">

--- a/spec/features/contrast_spec.rb
+++ b/spec/features/contrast_spec.rb
@@ -489,4 +489,150 @@ RSpec.describe "Derived foreground contrast", type: :feature, js: true do
         "label #{foreground} on inherited backdrop #{background} = #{measured.round(2)}:1"
     end
   end
+
+  # FilterChipBar selected chip (#151). The selected chip carries its group's semantic
+  # `-subtle` surface with its `-emphasis` foreground, both resolved from the compiled
+  # bundle — so the pair follows `data-bs-theme`. The demo's selected chip is Finance
+  # (-> warning). Exact painted values were measured against the compiled bundle, not
+  # derived by hand; the ratio alone would be a false green (inherited body text on the
+  # page also clears AA), so both the value and the ratio are asserted.
+  describe "FilterChipBar selected chip (#151)" do
+    {
+      "light" => { root: "#filter-chip-bar", foreground: "#553012", background: "#F6E4D5" },
+      "dark" => { root: "#dark-filter-chip-bar", foreground: "#E5AD80", background: "#2A1809" }
+    }.each do |mode, expected|
+      it "paints the selected chip's #{mode} emphasis-on-subtle above the AA floor" do
+        measured, foreground, background = ratio_for("#{expected[:root]} a[aria-current='page']")
+
+        expect(foreground).to eq(expected[:foreground])
+        expect(background).to eq(expected[:background])
+        expect(measured).to be >= 4.5,
+          "#{mode} selected chip #{foreground} on #{background} = #{measured.round(2)}:1"
+      end
+    end
+  end
+
+  # DataTable (#151). The conversion moved every DataTable colour onto Bootstrap
+  # utilities. Three things a render spec cannot prove and this layer must:
+  #   * the 2px header separator lands on the BOTTOM edge only — `border-2` would box
+  #     all four sides of a `.table th` (the P0 the conversion had to avoid);
+  #   * the account link paints Bootstrap's adaptive `--bs-link-color` (no pinned
+  #     `text-*` class), a different value per colour mode;
+  #   * the decorative dots keep a FIXED identity hue across themes (the documented
+  #     exception) and still clear the 3:1 non-text floor against each row backdrop.
+  describe "DataTable (#151)" do
+    # Expected solid fill per Bootstrap semantic, measured against the compiled engine
+    # bundle. Theme colours do not flip under data-bs-theme (only subtle/emphasis
+    # derivatives do), so each holds in both light and dark mode.
+    DOT_HEX = {
+      primary: "#2E75B6", success: "#22A06B", warning: "#D4772C",
+      danger: "#DC3545", secondary: "#6C757D"
+    }.freeze
+
+    def border_widths(selector)
+      page.evaluate_script(
+        "(() => { const e = document.querySelector(#{selector.to_json}); " \
+        "if (!e) throw new Error('no element matched'); const cs = getComputedStyle(e); " \
+        "return { top: cs.borderTopWidth, right: cs.borderRightWidth, " \
+        "bottom: cs.borderBottomWidth, left: cs.borderLeftWidth }; })()"
+      )
+    end
+
+    def border_bottom_color_of(selector)
+      page.evaluate_script(
+        "(() => { const e = document.querySelector(#{selector.to_json}); " \
+        "if (!e) throw new Error('no element matched'); " \
+        "return getComputedStyle(e).borderBottomColor; })()"
+      )
+    end
+
+    # A dot is an empty span whose FILL is its own background-color. Measure that fill
+    # against the first opaque ANCESTOR (never the dot itself, which is opaque), and
+    # composite any bg-opacity — mirroring the RESOLVE_JS approach for backgrounds.
+    def dot_contrast(selector)
+      js = <<~JS
+        (() => {
+          const parse = (v) => { const p = (v.match(/[\\d.]+/g) || []).map(Number);
+            return { r: p[0], g: p[1], b: p[2], a: p.length > 3 ? p[3] : 1 }; };
+          const over = (fg, bg) => ({ r: fg.r*fg.a + bg.r*(1-fg.a), g: fg.g*fg.a + bg.g*(1-fg.a), b: fg.b*fg.a + bg.b*(1-fg.a) });
+          const hex = (c) => '#' + [c.r, c.g, c.b].map((x) => Math.round(x).toString(16).padStart(2, '0')).join('').toUpperCase();
+          const el = document.querySelector(#{selector.to_json});
+          if (!el) return null;
+          let backdrop = { r: 255, g: 255, b: 255, a: 1 };
+          for (let n = el.parentElement; n; n = n.parentElement) {
+            const bg = parse(getComputedStyle(n).backgroundColor);
+            if (bg.a === 1) { backdrop = bg; break; }
+          }
+          const fill = over(parse(getComputedStyle(el).backgroundColor), backdrop);
+          return { fill: hex(fill), backdrop: hex(backdrop) };
+        })()
+      JS
+      result = page.evaluate_script(js)
+      raise "no element matched #{selector}" if result.nil?
+
+      result = result.transform_keys(&:to_sym)
+      [ MpiDesignSystem::ColorContrast.ratio(result[:fill], result[:backdrop]), result[:fill], result[:backdrop] ]
+    end
+
+    {
+      "light" => { root: "#datatable", surface: "#FFFFFF", link: "#2E75B6", border: "rgb(222, 226, 230)" },
+      "dark" => { root: "#dark-datatable", surface: "#212529", link: "#82ACD3", border: "rgb(73, 80, 87)" }
+    }.each do |mode, expected|
+      context "in #{mode} mode" do
+        let(:root) { expected[:root] }
+
+        it "puts the 2px header separator on the bottom edge alone" do
+          widths = border_widths("#{root} thead th")
+
+          expect(widths["bottom"]).to eq("2px")
+          expect(widths["top"]).to eq("0px")
+          expect(widths["right"]).to eq("0px")
+          expect(widths["left"]).to eq("0px")
+        end
+
+        it "tracks the colour mode with the header separator colour" do
+          expect(border_bottom_color_of("#{root} thead th")).to eq(expected[:border])
+        end
+
+        it "paints the account link in Bootstrap's adaptive link colour above the AA floor" do
+          measured, foreground, background = ratio_for("#{root} a[href='/accounts/1']")
+
+          expect(foreground).to eq(expected[:link])
+          expect(background).to eq(expected[:surface])
+          expect(measured).to be >= 4.5,
+            "#{mode} account link #{foreground} on #{background} = #{measured.round(2)}:1"
+        end
+
+        # Tag dots — row 1's tags column (2nd cell) carries one dot per distinct
+        # GROUP_VARIANTS hue. Loop the whole mapping (so a new/renamed variant is proven
+        # too), asserting each solid fill AND that it clears >=3:1 on the RESTING
+        # (non-hover) row backdrop. The dots are decorative (the adjacent label carries
+        # the meaning), so the transient table-hover dip below 3:1 is out of scope and
+        # deliberately not asserted — see the CHANGELOG dot note. (#151, P0)
+        MpiDesignSystem::Admin::DataTable::Component::GROUP_VARIANTS.values.uniq.each do |variant|
+          it "keeps the decorative #{variant} tag dot >=3:1 on the resting row backdrop" do
+            measured, fill, backdrop = dot_contrast("#{root} tbody td:nth-child(2) span.d-inline-block.bg-#{variant}")
+
+            expect(fill).to eq(DOT_HEX.fetch(variant))
+            expect(backdrop).to eq(expected[:surface])
+            expect(measured).to be >= 3.0,
+              "#{mode} #{variant} tag dot #{fill} on resting #{backdrop} = #{measured.round(2)}:1"
+          end
+        end
+
+        # Status dots — the status column (4th cell) carries one dot per distinct
+        # STATUS_VARIANTS hue across the three rows. Same resting-backdrop >=3:1 proof.
+        MpiDesignSystem::Admin::DataTable::Component::STATUS_VARIANTS.values.uniq.each do |variant|
+          it "keeps the decorative #{variant} status dot >=3:1 on the resting row backdrop" do
+            measured, fill, backdrop = dot_contrast("#{root} tbody td:nth-child(4) span.d-inline-block.bg-#{variant}")
+
+            expect(fill).to eq(DOT_HEX.fetch(variant))
+            expect(backdrop).to eq(expected[:surface])
+            expect(measured).to be >= 3.0,
+              "#{mode} #{variant} status dot #{fill} on resting #{backdrop} = #{measured.round(2)}:1"
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Converts `Admin::FilterChipBar` and `Admin::DataTable` from hardcoded-hex inline styles to theme-adaptive Bootstrap semantic utilities, so both follow `data-bs-theme` and a consuming app's mapped tokens. Track 2 **Phase 3** of epic [ISS#147](https://github.com/mpimedia/mpi-design-system/issues/147). Introduces a shared `TagChip::Component::GROUP_VARIANTS` map translating each CRM tag group onto a Bootstrap semantic colour.

Because MPI maps `$info → $primary`, the palette offers **five** distinct adaptive hues, so the three cool categories (press_festival/production/vendors) collapse onto `primary` (blue) and distribution's orange approximates to `danger` (red). This is the accepted trade of the smallest-blast conversion (HC-approved at the plan gate) — the tag's always-present text label carries the category identity, not the hue alone.

Closes #151
Part of #147

## Changes Made
- **`app/components/mpi_design_system/admin/tag_chip/component.rb`** — add `GROUP_VARIANTS` (single source of truth for the group→semantic mapping); TagChip's own rendering stays on the frozen hex pairs this phase.
- **`app/components/.../filter_chip_bar/component.{rb,html.erb}`** — split `group_chip_styles` into geometry + `group_chip_classes` (selected → `bg-#{sem}-subtle text-#{sem}-emphasis border border-#{sem}-subtle`; unselected → `border bg-body text-body`); remove button → `text-reset bg-transparent border-0`.
- **`app/components/.../data_table/component.{rb,html.erb}`** — add `STATUS_VARIANTS`, remove `STATUS_COLORS`/`TAG_DOT_COLORS`; header → `text-body-secondary border-bottom` + inline `--bs-border-width: 2px` (bottom edge only); name/tag text → `text-body`, title/meta → `text-body-secondary`; account link → default adaptive `--bs-link-color` with its underline restored; dots → solid `bg-#{variant}`; cells → `align-middle`.
- **Specs** — rewritten to loop the constants, scope dot assertions to their cell with a count, and add a mutation-tested theme-adaptivity guard block; `tag_chip` spec pins the exact mapping and confirms TagChip stays hex.
- **Browser** — `contrast_spec.rb` + `contrast_demo/show.html.erb` mount DataTable (light+dark) and a selected FilterChipBar chip, asserting exact computed fg/bg then WCAG ratio in both modes (header border 2px-bottom/0-else; account link exact `--bs-link-color`; dots ≥3:1 vs both row backdrops).
- **Previews** — dark-mode examples for both components via `render_with_template`, each with a matching template.
- **Catalog** — `tag-chip.md` records `GROUP_VARIANTS` and corrects the false "all 7 pairs pass AA" claim (actual 2.77:1–4.34:1); `data-table.md` corrects the false "renders EmptyState" claim; `filter-chip-bar.md` documents the semantic selected-chip mapping; the `.html` mockups and both `list-view.html` slices gain a `:root` MPI-token block so CDN-Bootstrap paints MPI colours.
- **CHANGELOG** — `[Unreleased]` entry for the conversion and the constant removal.

## Technical Approach
- **Decorative dots are a documented exception:** `bg-#{variant}` reads `--bs-#{variant}-rgb`, a fixed hue across colour modes rather than an adaptive one — a category/status *identity* colour should stay constant (mirroring the nav env-bar's fixed status hues), and the browser spec proves ≥3:1 on both the light and dark row backdrops.
- **Header P0 avoided:** `border-2` would widen all four sides of a `.table th`; using `border-bottom` + inline `--bs-border-width: 2px` keeps the 2px on the bottom edge only, with the colour still adaptive via `--bs-border-color` (browser-verified in both modes).
- **DataTable's hex scan strips AvatarCircle subtrees** (a separate component that legitimately still emits inline hex), and that strip is itself proven load-bearing.
- No public API change to either component's parameters; the removed `STATUS_COLORS`/`TAG_DOT_COLORS` were internal constants with no call sites (pre-1.0, documented as formally breaking only if referenced directly).

## Testing
- `bundle exec rubocop -a` — 159 files, 0 offenses.
- `bundle exec rspec` — 1021 examples, 0 failures (includes the browser feature specs against a real compiled bundle; the preview-render sweep stays green).
- Every load-bearing theme-adaptivity/survivor/geometry guard was watched RED against a source mutation, then reverted.

## Checklist
- [x] Tests pass
- [x] Linting passes

## Follow-up
A tracked issue will convert the remaining `GROUPS` consumers to `GROUP_VARIANTS` — TagChip's own rendering, `contact_card`, `engagement_card`, `account_list_row`, `contact_list_row`, and `account_detail_panel` (each still defines its own local `TAG_DOT_COLORS`/hex) — so the same category renders one consistent adaptive hue everywhere. Until then the transient cross-consumer inconsistency is expected and intentional.

— Claude Code (Fable 5)
