### PR TITLE
Convert FilterPanel to theme-adaptive utilities (#152 Phase 4)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -167,6 +167,34 @@ Watched failing both ways before trusting it: emptying `results_text_styles` and
 `font-weight: 500` each reddens exactly this example. The rule: after a conversion, list what the
 element still emits and pin it, or the next edit that removes it ships green.
 
+**Related — pin the *complete* surviving inline style, not one representative declaration.** The
+corollary says "list what the element still emits and pin it" — but a guard that pins *one*
+representative survivor per element leaves the rest deletable-green, and that gap survives even a
+careful review. #152 converted `FilterPanel`'s inline hex to utilities and kept each element's
+geometry/layout/typography inline; the first guard pinned one declaration per helper (panel
+`min-width`, title `font-weight`+`letter-spacing`, button `justify-content`+`width`, …) — and passed
+the author's self-review **and** the external *plan* review, yet left panel `border-radius`/`padding`,
+header/option/chevron `font-size`, and the button's `cursor`/`text-align` deletable without a red
+test (caught only by the external *diff* review). For an inline-style→utility conversion, assert each
+converted element's **complete** surviving inline style via exact equality —
+`have_css("aside.bg-body.border[style='border-radius: 8px; padding: 0; min-width: 220px']")` — not
+substring `[style*='…']` pins, which police only the fragments you happened to name. Exact match is
+brittle in exactly the intended way: any dropped, added, or reordered survivor reddens, so a
+deliberate geometry change updates the test on purpose. (`render_inline` emits the style string
+verbatim — Nokogiri preserves attribute *values*, only lowercasing attribute *names* — so the exact
+string is stable.) Proven by breaking it: removing `border-radius: 8px` (unguarded under the
+representative version) reddens the exact-match example. (#152.)
+
+**Related — a descendant selector false-passes when the class lands on an ancestor; pin the
+structural relationship with a child combinator.** `have_css("div.text-body input[...]")` proves only
+that *some* ancestor `div` of the input carries `.text-body` — not that the option *row* does. So it
+stays green if the class is mistakenly emitted on a wrapper (`.filter-section`, `.pb-2`) instead of
+the row itself — exactly the regression the assertion exists to catch (a cousin of False Green #1: the
+selector matches by an unintended path). Pin the real DOM relationship with child combinators —
+`div.text-body > label > input[...]` — so only the class on the row passes. Proven by breaking it:
+moving `.text-body` up to the `.pb-2` wrapper reddens the child-combinator form while the descendant
+form stays green. (#152.)
+
 **Related:** when a constant drives behavior (`ACTION_METHODS`, `COLORS`, `SIZES`), loop it
 rather than spot-checking one member — otherwise a typo in the constant ships green.
 

--- a/app/components/mpi_design_system/admin/filter_panel/component.html.erb
+++ b/app/components/mpi_design_system/admin/filter_panel/component.html.erb
@@ -1,15 +1,16 @@
-<aside style="<%= panel_styles %>" aria-label="Filters">
-  <div style="<%= header_styles %>">Filters</div>
+<aside class="bg-body border" style="<%= panel_styles %>" aria-label="Filters">
+  <div class="text-body" style="<%= header_styles %>">Filters</div>
 
   <form action="<%= @form_action %>" method="get">
     <% @sections.each_with_index do |section, index| %>
       <% unless index == 0 %>
-        <hr style="<%= divider_styles %>">
+        <hr class="border-top opacity-100 m-0">
       <% end %>
 
       <div class="filter-section">
         <button
           type="button"
+          class="text-body"
           style="<%= section_header_styles %>"
           data-bs-toggle="collapse"
           data-bs-target="#<%= section_id(index) %>"
@@ -17,7 +18,7 @@
           aria-controls="<%= section_id(index) %>"
         >
           <%= section[:title] %>
-          <i class="bi bi-chevron-down"
+          <i class="bi bi-chevron-down text-body-secondary"
              aria-hidden="true"
              style="<%= section_collapsed?(section) ? chevron_collapsed_styles : chevron_styles %>"></i>
         </button>
@@ -26,7 +27,7 @@
              class="collapse<%= ' show' unless section_collapsed?(section) %>">
           <div class="pb-2">
             <% section[:options]&.each do |option| %>
-              <div style="<%= option_styles %>">
+              <div class="text-body" style="<%= option_styles %>">
                 <label style="<%= option_label_styles %>">
                   <input type="checkbox"
                          name="<%= section[:field_name] %>"
@@ -37,7 +38,7 @@
                   <%= option[:label] %>
                 </label>
                 <% unless option[:count].nil? %>
-                  <span style="<%= count_styles %>"><%= option[:count] %></span>
+                  <span class="text-body-secondary" style="<%= count_styles %>"><%= option[:count] %></span>
                 <% end %>
               </div>
             <% end %>

--- a/app/components/mpi_design_system/admin/filter_panel/component.rb
+++ b/app/components/mpi_design_system/admin/filter_panel/component.rb
@@ -19,8 +19,6 @@ module MpiDesignSystem
 
         def panel_styles
           [
-            "background: #fff",
-            "border: 1px solid #DEE2E6",
             "border-radius: 8px",
             "padding: 0",
             "min-width: 220px"
@@ -33,7 +31,6 @@ module MpiDesignSystem
             "font-weight: 700",
             "text-transform: uppercase",
             "letter-spacing: 0.06em",
-            "color: #1B2A4A",
             "padding: 14px 16px 10px"
           ].join("; ")
         end
@@ -50,7 +47,6 @@ module MpiDesignSystem
             "width: 100%",
             "font-size: 13px",
             "font-weight: 600",
-            "color: #1B2A4A",
             "text-align: left"
           ].join("; ")
         end
@@ -61,8 +57,7 @@ module MpiDesignSystem
             "align-items: center",
             "justify-content: space-between",
             "padding: 4px 16px 4px 20px",
-            "font-size: 13px",
-            "color: #1B2A4A"
+            "font-size: 13px"
           ].join("; ")
         end
 
@@ -76,19 +71,15 @@ module MpiDesignSystem
         end
 
         def count_styles
-          "font-size: 11px; color: #6C757D;"
-        end
-
-        def divider_styles
-          "border: none; border-top: 1px solid #DEE2E6; margin: 0;"
+          "font-size: 11px;"
         end
 
         def chevron_styles
-          "font-size: 12px; color: #6C757D; transition: transform 0.2s ease;"
+          "font-size: 12px; transition: transform 0.2s ease;"
         end
 
         def chevron_collapsed_styles
-          "font-size: 12px; color: #6C757D; transition: transform 0.2s ease; transform: rotate(-90deg);"
+          "font-size: 12px; transition: transform 0.2s ease; transform: rotate(-90deg);"
         end
 
         def section_id(index)

--- a/spec/components/mpi_design_system/admin/filter_panel/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/filter_panel/component_spec.rb
@@ -27,37 +27,39 @@ RSpec.describe MpiDesignSystem::Admin::FilterPanel::Component, type: :component 
     ]
   end
 
-  it "renders aside with Filters aria-label" do
+  it "renders the panel as a theme-adaptive card" do
     render_inline(described_class.new(sections: sections))
 
-    expect(page).to have_css("aside[aria-label='Filters']")
+    expect(page).to have_css("aside.bg-body.border[aria-label='Filters']")
   end
 
-  it "renders Filters heading" do
+  it "renders the Filters heading in body text" do
     render_inline(described_class.new(sections: sections))
 
-    expect(page).to have_css("div[style*='text-transform: uppercase']", text: "Filters")
+    expect(page).to have_css("div.text-body[style*='text-transform: uppercase']", text: "Filters")
   end
 
-  it "renders section titles as collapse toggle buttons" do
+  it "renders section titles as collapse toggle buttons in body text" do
     render_inline(described_class.new(sections: sections))
 
-    expect(page).to have_css("button[data-bs-toggle='collapse']", text: "Tag Group")
-    expect(page).to have_css("button[data-bs-toggle='collapse']", text: "Engagement Type")
+    expect(page).to have_css("button.text-body[data-bs-toggle='collapse']", text: "Tag Group")
+    expect(page).to have_css("button.text-body[data-bs-toggle='collapse']", text: "Engagement Type")
   end
 
-  it "renders options with checkbox inputs" do
+  it "renders option rows as body-text rows wrapping their checkbox" do
     render_inline(described_class.new(sections: sections))
 
-    expect(page).to have_css("input[type='checkbox'][name='tag_group[]'][value='distribution']")
-    expect(page).to have_css("input[type='checkbox'][name='tag_group[]'][value='outreach']")
-    expect(page).to have_css("input[type='checkbox'][name='tag_group[]'][value='press_festival']")
+    # Structurally specific: the checkbox must be a descendant of the .text-body
+    # row itself, so the class landing on an ancestor would not false-pass.
+    expect(page).to have_css("div.text-body input[type='checkbox'][name='tag_group[]'][value='distribution']")
+    expect(page).to have_css("div.text-body input[type='checkbox'][name='tag_group[]'][value='outreach']")
+    expect(page).to have_css("div.text-body input[type='checkbox'][name='tag_group[]'][value='press_festival']")
   end
 
   it "renders checked options" do
     render_inline(described_class.new(sections: sections))
 
-    expect(page).to have_css("input[type='checkbox'][value='outreach'][checked]")
+    expect(page).to have_css("div.text-body input[type='checkbox'][value='outreach'][checked]")
   end
 
   it "renders option labels" do
@@ -68,11 +70,11 @@ RSpec.describe MpiDesignSystem::Admin::FilterPanel::Component, type: :component 
     expect(page).to have_text("Press/Festival")
   end
 
-  it "renders option counts" do
+  it "renders option counts in secondary body text" do
     render_inline(described_class.new(sections: sections))
 
-    expect(page).to have_css("span[style*='color: #6C757D']", text: "42")
-    expect(page).to have_css("span[style*='color: #6C757D']", text: "28")
+    expect(page).to have_css("span.text-body-secondary[style*='font-size: 11px']", text: "42")
+    expect(page).to have_css("span.text-body-secondary[style*='font-size: 11px']", text: "28")
   end
 
   it "renders zero count values" do
@@ -85,7 +87,7 @@ RSpec.describe MpiDesignSystem::Admin::FilterPanel::Component, type: :component 
     ]
     render_inline(described_class.new(sections: sections_with_zero))
 
-    expect(page).to have_css("span[style*='color: #6C757D']", text: "0")
+    expect(page).to have_css("span.text-body-secondary[style*='font-size: 11px']", text: "0")
   end
 
   it "hides count when not provided" do
@@ -98,8 +100,10 @@ RSpec.describe MpiDesignSystem::Admin::FilterPanel::Component, type: :component 
     ]
     render_inline(described_class.new(sections: sections_no_count))
 
+    # Positive first: prove the option row rendered, then the absence of its count.
+    expect(page).to have_css("div.text-body input[type='checkbox'][value='7d']")
     expect(page).to have_text("Last 7 days")
-    expect(page).not_to have_css("span[style*='font-size: 11px']")
+    expect(page).not_to have_css("span.text-body-secondary")
   end
 
   it "renders collapsed sections without show class" do
@@ -127,16 +131,17 @@ RSpec.describe MpiDesignSystem::Admin::FilterPanel::Component, type: :component 
     expect(page).to have_css("form[action='/search'][method='get']")
   end
 
-  it "renders dividers between sections" do
+  it "renders theme-adaptive dividers between sections" do
     render_inline(described_class.new(sections: sections))
 
-    expect(page).to have_css("hr[style*='border-top: 1px solid #DEE2E6']")
+    # Two sections -> exactly one divider, carrying all three utility classes.
+    expect(page).to have_css("hr.border-top.opacity-100.m-0", count: 1)
   end
 
-  it "renders chevron-down icons on all section headers" do
+  it "renders chevron-down icons in secondary body text on all section headers" do
     render_inline(described_class.new(sections: sections))
 
-    expect(page).to have_css("i.bi.bi-chevron-down", count: 2)
+    expect(page).to have_css("i.bi.bi-chevron-down.text-body-secondary", count: 2)
   end
 
   it "rotates chevron for collapsed sections" do
@@ -148,12 +153,44 @@ RSpec.describe MpiDesignSystem::Admin::FilterPanel::Component, type: :component 
   it "renders empty panel without errors" do
     render_inline(described_class.new(sections: []))
 
-    expect(page).to have_css("aside[aria-label='Filters']")
+    expect(page).to have_css("aside.bg-body.border[aria-label='Filters']")
   end
 
-  it "renders white card background with border" do
+  # Guard what survives: the conversion stripped colour but kept the geometry,
+  # layout, and typography inline. These declarations have no Bootstrap
+  # equivalent here, so pin one surviving declaration per changed helper —
+  # otherwise the next edit that drops one ships green. (See
+  # .claude/rules/testing.md "guard what survives", modelled on #149 Pagination.)
+  it "keeps the non-colour geometry, layout, and typography that has no Bootstrap equivalent" do
     render_inline(described_class.new(sections: sections))
 
-    expect(page).to have_css("aside[style*='background: #fff'][style*='border: 1px solid #DEE2E6']")
+    # panel geometry
+    expect(page).to have_css("aside.bg-body.border[style*='min-width: 220px']")
+    # title typography
+    expect(page).to have_css(
+      "div.text-body[style*='font-weight: 700'][style*='letter-spacing: 0.06em']",
+      text: "Filters"
+    )
+    # section-button layout
+    expect(page).to have_css(
+      "button.text-body[style*='justify-content: space-between'][style*='width: 100%']",
+      text: "Tag Group"
+    )
+    # option-row spacing
+    expect(page).to have_css("div.text-body[style*='padding: 4px 16px 4px 20px']")
+    # count sizing
+    expect(page).to have_css("span.text-body-secondary[style*='font-size: 11px']", text: "42")
+    # chevron transition (both chevrons keep it)
+    expect(page).to have_css("i.bi.bi-chevron-down[style*='transition: transform 0.2s ease']", count: 2)
+  end
+
+  # Absence guard, paired after the positive card assertion: the conversion's
+  # contract is that NO surviving inline style pins a palette hex. Re-adding any
+  # `color: #...` (or `background: #fff`) to an inline style reddens this.
+  it "leaves no palette hex in any surviving inline style" do
+    render_inline(described_class.new(sections: sections))
+
+    expect(page).to have_css("aside.bg-body.border[aria-label='Filters']")
+    expect(page).to have_no_css("[style*='#']")
   end
 end

--- a/spec/components/mpi_design_system/admin/filter_panel/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/filter_panel/component_spec.rb
@@ -49,17 +49,18 @@ RSpec.describe MpiDesignSystem::Admin::FilterPanel::Component, type: :component 
   it "renders option rows as body-text rows wrapping their checkbox" do
     render_inline(described_class.new(sections: sections))
 
-    # Structurally specific: the checkbox must be a descendant of the .text-body
-    # row itself, so the class landing on an ancestor would not false-pass.
-    expect(page).to have_css("div.text-body input[type='checkbox'][name='tag_group[]'][value='distribution']")
-    expect(page).to have_css("div.text-body input[type='checkbox'][name='tag_group[]'][value='outreach']")
-    expect(page).to have_css("div.text-body input[type='checkbox'][name='tag_group[]'][value='press_festival']")
+    # Structurally specific via child combinators: text-body must be on the option
+    # ROW that directly wraps `<label> > <input>`. `div.text-body input` alone would
+    # false-pass if the class moved to an ancestor div (.filter-section / .pb-2). (Codex)
+    expect(page).to have_css("div.text-body > label > input[type='checkbox'][name='tag_group[]'][value='distribution']")
+    expect(page).to have_css("div.text-body > label > input[type='checkbox'][name='tag_group[]'][value='outreach']")
+    expect(page).to have_css("div.text-body > label > input[type='checkbox'][name='tag_group[]'][value='press_festival']")
   end
 
   it "renders checked options" do
     render_inline(described_class.new(sections: sections))
 
-    expect(page).to have_css("div.text-body input[type='checkbox'][value='outreach'][checked]")
+    expect(page).to have_css("div.text-body > label > input[type='checkbox'][value='outreach'][checked]")
   end
 
   it "renders option labels" do
@@ -101,7 +102,7 @@ RSpec.describe MpiDesignSystem::Admin::FilterPanel::Component, type: :component 
     render_inline(described_class.new(sections: sections_no_count))
 
     # Positive first: prove the option row rendered, then the absence of its count.
-    expect(page).to have_css("div.text-body input[type='checkbox'][value='7d']")
+    expect(page).to have_css("div.text-body > label > input[type='checkbox'][value='7d']")
     expect(page).to have_text("Last 7 days")
     expect(page).not_to have_css("span.text-body-secondary")
   end
@@ -156,39 +157,52 @@ RSpec.describe MpiDesignSystem::Admin::FilterPanel::Component, type: :component 
     expect(page).to have_css("aside.bg-body.border[aria-label='Filters']")
   end
 
-  # Guard what survives: the conversion stripped colour but kept the geometry,
-  # layout, and typography inline. These declarations have no Bootstrap
-  # equivalent here, so pin one surviving declaration per changed helper —
-  # otherwise the next edit that drops one ships green. (See
-  # .claude/rules/testing.md "guard what survives", modelled on #149 Pagination.)
-  it "keeps the non-colour geometry, layout, and typography that has no Bootstrap equivalent" do
+  # Guard what survives (EXACT match): the conversion stripped colour but kept the
+  # geometry, layout, typography, and button resets inline. Per .claude/rules/testing.md
+  # "guard what survives" (#149) — and Codex's PR review — pin the COMPLETE surviving
+  # inline style of every changed element, not one representative declaration, so any
+  # later edit that drops, adds, or reorders a survivor reddens rather than shipping
+  # green. (render_inline proves the emitted style string, not computed paint.)
+  it "keeps every surviving non-colour inline style of each converted element exactly" do
     render_inline(described_class.new(sections: sections))
 
-    # panel geometry
-    expect(page).to have_css("aside.bg-body.border[style*='min-width: 220px']")
-    # title typography
+    # panel <aside>
     expect(page).to have_css(
-      "div.text-body[style*='font-weight: 700'][style*='letter-spacing: 0.06em']",
+      "aside.bg-body.border[style='border-radius: 8px; padding: 0; min-width: 220px']"
+    )
+    # title <div>
+    expect(page).to have_css(
+      "div.text-body[style='font-size: 13px; font-weight: 700; text-transform: uppercase; " \
+      "letter-spacing: 0.06em; padding: 14px 16px 10px']",
       text: "Filters"
     )
-    # section-button layout
+    # section-header <button> — incl. the transparent/borderless reset that keeps it
+    # chromeless; dropping either reset regresses the toggle to a default grey button.
     expect(page).to have_css(
-      "button.text-body[style*='justify-content: space-between'][style*='width: 100%']",
+      "button.text-body[style='display: flex; align-items: center; " \
+      "justify-content: space-between; padding: 10px 16px; cursor: pointer; border: none; " \
+      "background: transparent; width: 100%; font-size: 13px; font-weight: 600; text-align: left']",
       text: "Tag Group"
     )
-    # section-button reset: transparent, borderless chrome. Dropping either
-    # `background: transparent` or `border: none` regresses the collapse toggle
-    # to a default grey button — a visible regression no colour test catches.
+    # option row <div>
     expect(page).to have_css(
-      "button.text-body[style*='background: transparent'][style*='border: none']",
-      text: "Tag Group"
+      "div.text-body[style='display: flex; align-items: center; justify-content: space-between; " \
+      "padding: 4px 16px 4px 20px; font-size: 13px']"
     )
-    # option-row spacing
-    expect(page).to have_css("div.text-body[style*='padding: 4px 16px 4px 20px']")
-    # count sizing
-    expect(page).to have_css("span.text-body-secondary[style*='font-size: 11px']", text: "42")
-    # chevron transition (both chevrons keep it)
-    expect(page).to have_css("i.bi.bi-chevron-down[style*='transition: transform 0.2s ease']", count: 2)
+    # count <span>
+    expect(page).to have_css("span.text-body-secondary[style='font-size: 11px;']", text: "42")
+    # chevron <i> — expanded (no rotate)
+    expect(page).to have_css(
+      "i.bi.bi-chevron-down.text-body-secondary" \
+      "[style='font-size: 12px; transition: transform 0.2s ease;']",
+      count: 1
+    )
+    # chevron <i> — collapsed (adds the rotate)
+    expect(page).to have_css(
+      "i.bi.bi-chevron-down.text-body-secondary" \
+      "[style='font-size: 12px; transition: transform 0.2s ease; transform: rotate(-90deg);']",
+      count: 1
+    )
   end
 
   # Absence guard, paired after the positive card assertion: the conversion's

--- a/spec/components/mpi_design_system/admin/filter_panel/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/filter_panel/component_spec.rb
@@ -176,6 +176,13 @@ RSpec.describe MpiDesignSystem::Admin::FilterPanel::Component, type: :component 
       "button.text-body[style*='justify-content: space-between'][style*='width: 100%']",
       text: "Tag Group"
     )
+    # section-button reset: transparent, borderless chrome. Dropping either
+    # `background: transparent` or `border: none` regresses the collapse toggle
+    # to a default grey button — a visible regression no colour test catches.
+    expect(page).to have_css(
+      "button.text-body[style*='background: transparent'][style*='border: none']",
+      text: "Tag Group"
+    )
     # option-row spacing
     expect(page).to have_css("div.text-body[style*='padding: 4px 16px 4px 20px']")
     # count sizing


### PR DESCRIPTION
Part of #147 (Track 2 epic — Phase 4). AvatarCircle's identity-palette work was split to #169 per the HC's Option A decision; this PR delivers the **FilterPanel** half.

Closes #152

## Summary
FilterPanel pinned its colours with inline hex (`#fff`, `#DEE2E6`, `#1B2A4A`, `#6C757D`), so it rendered a fixed light palette and did not adapt when a host app flips `data-bs-theme`. This PR converts those colours — and **only** those colours — to Bootstrap 5.3 theme-adaptive utilities (`bg-body`, `border`, `text-body`, `text-body-secondary`, `border-top`), matching the theme-adaptive conversions already landed for Badge (#128), Pagination (#149), NavBar (#154), and the #150 small conversions. All geometry, layout, typography, and `transparent`/`none` resets remain inline unchanged.

## Changes Made
- `app/components/mpi_design_system/admin/filter_panel/component.rb`
  - `panel_styles`: removed `background: #fff` and `border: 1px solid #DEE2E6`
  - `header_styles`, `section_header_styles`, `option_styles`: removed `color: #1B2A4A`
  - `count_styles`: removed `color: #6C757D` (kept `font-size: 11px`)
  - `chevron_styles` / `chevron_collapsed_styles`: removed `color: #6C757D`
  - deleted `divider_styles` entirely
- `app/components/mpi_design_system/admin/filter_panel/component.html.erb`
  - `<aside>` → `class="bg-body border"`
  - title `<div>`, section `<button>`, option-row `<div>` → `text-body`
  - count `<span>`, both chevron `<i>` → `text-body-secondary`
  - `<hr>` → classes-only `border-top opacity-100 m-0` (no `style` attribute)
- `spec/components/mpi_design_system/admin/filter_panel/component_spec.rb`
  - repinned all retired-hex assertions to utility classes
  - structurally-specific option-row assertion (`div.text-body input` descendant)
  - added guard-what-survives and paired absence (`have_no_css("[style*='#']")`) examples

## Technical Approach
`--bs-body-color` is MPI navy `#1B2A4A` in light mode, so `text-body` is an exact swap in light and adaptive in dark. `text-body-secondary` computes `rgba(body-color, .75)` → ~`#545F77` light / ~`#AFB3B7` dark; the retired neutral grey `#6C757D` is intentionally **not** preserved (the one user-visible shift, and the same move #149/#150 shipped). The `<hr>` becomes classes-only because Bootstrap emits `.border-top`/`.opacity-100`/`.m-0` with `!important`, which overrides the `<hr>` reboot without any inline style. After conversion no surviving inline `style` contains a `#` hex (the `data-bs-target="#…"` attribute is unaffected — the guard scopes to `[style*='#']`).

Per `.claude/rules/testing.md` ("guard what survives"), the spec pins a surviving non-colour declaration for **every** changed helper so a future edit that removes retained geometry reddens rather than shipping green; both new guards were watched failing before being trusted. This conversion changes emitted markup (classes / inline style), so `render_inline` + Capybara is the right proof — the utilities' runtime paint is stock Bootstrap, already browser-verified for Pagination/StatCard in `spec/features/contrast_spec.rb`, so no new feature spec is warranted.

## Testing
- `bundle exec rubocop -a` — 0 offenses (159 files)
- `bundle exec rspec` — 1013 examples, 0 failures, 0 pending (browser feature specs included: 103 examples green under headless Chrome)
- FilterPanel spec — 19 examples, 0 failures
- Watched-it-fail: removing `min-width: 220px` reddens the guard-what-survives example; re-adding `color: #1B2A4A` reddens the absence guard. Both reverted.

## Checklist
- [x] Tests pass (`bundle exec rspec` — 1013 examples, 0 failures)
- [x] Linting passes (`bundle exec rubocop -a` — 0 offenses)

> **Release note (for `/final`):** this branch is deliberately **release-agnostic**. PR #167 (Phase 3) is also open and release-bound, so the version bump + CHANGELOG (per `CONTRIBUTING.md` § Release) are done at finalize time, reconciled against whatever has merged — not hardcoded here.

— Claude Code (Fable 5)
