### PR TITLE
chore(release): v0.10.0 — theme-adaptive FilterChipBar/DataTable + FilterPanel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,21 @@ include breaking changes).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-22
+
 ### Changed
+- **`Admin::FilterPanel` is theme-adaptive** — the filter panel stopped pinning a light palette in
+  inline styles; every converted colour now resolves from a Bootstrap semantic utility, so it
+  follows `data-bs-theme` and the consuming app's mapped tokens. The `<aside>` card is
+  `bg-body border` (was `#fff` / `1px solid #DEE2E6`); the panel title, section-toggle buttons, and
+  option rows are `text-body` (was `#1B2A4A` = MPI navy = `--bs-body-color`, exact in light); the
+  option counts and chevrons are `text-body-secondary` (was the fixed neutral grey `#6C757D`; now the
+  adaptive `rgba(body-color, .75)` = `#545F77` light / `#AFB3B7` dark — the one deliberate visible
+  shift, matching the #149/#150 treatment). The inter-section divider becomes a classes-only
+  `<hr class="border-top opacity-100 m-0">` — the utilities are `!important`, so they override the
+  `<hr>` reboot to paint a crisp `--bs-border-color` line that flips to `#495057` in dark. All
+  geometry/layout/typography and the button `transparent`/`none` resets stay inline. (#152, phase 4;
+  the AvatarCircle half of phase 4 is split to #169.)
 - **`Admin::FilterChipBar` and `Admin::DataTable` are theme-adaptive** — both stopped pinning
   a light palette in inline styles; every colour now resolves from a Bootstrap semantic
   utility, so they follow `data-bs-theme` and the consuming app's mapped tokens. A new shared
@@ -419,7 +433,8 @@ Initial internal version: the ViewComponent library, design tokens, Stimulus con
 and Lookbook previews, prior to the adoption-prep packaging corrections above. (No release
 tag was cut for 0.1.0.)
 
-[Unreleased]: https://github.com/mpimedia/mpi-design-system/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/mpimedia/mpi-design-system/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.6.0...v0.7.0

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ on where Bundler unpacks the gem.
 
 ```ruby
 # Gemfile
-gem "mpi_design_system", git: "git@github.com:mpimedia/mpi-design-system.git", tag: "v0.9.0"
+gem "mpi_design_system", git: "git@github.com:mpimedia/mpi-design-system.git", tag: "v0.10.0"
 ```
 
-Pin to a release tag (`tag: "v0.9.0"`) so upgrades are deliberate. Then:
+Pin to a release tag (`tag: "v0.10.0"`) so upgrades are deliberate. Then:
 
 ```bash
 bundle install

--- a/lib/mpi_design_system/version.rb
+++ b/lib/mpi_design_system/version.rb
@@ -1,3 +1,3 @@
 module MpiDesignSystem
-  VERSION = "0.9.0"
+  VERSION = "0.10.0"
 end

--- a/spec/packaging/version_spec.rb
+++ b/spec/packaging/version_spec.rb
@@ -12,11 +12,13 @@ require "spec_helper"
 # components (#130), and the changelog release guard (#127); v0.8.0 (#149) makes
 # Admin::Pagination theme-adaptive — the Track 2 pilot conversion (epic #147);
 # v0.9.0 releases the NavBar/AppShell theme-adaptive conversion (#154, phase 6) and the
-# StatCard/AvatarStack/ActiveFilterBar small conversions (#150, phase 2). This spec
+# StatCard/AvatarStack/ActiveFilterBar small conversions (#150, phase 2); v0.10.0 batches
+# the FilterChipBar/DataTable/TagChip semantic conversion (#151, phase 3) and the FilterPanel
+# theme-adaptive conversion (#152, phase 4 — the AvatarCircle half is split to #169). This spec
 # fails if the constant regresses, keeping lib/mpi_design_system/version.rb in lockstep
 # with CHANGELOG.md and the git tag.
 RSpec.describe "MpiDesignSystem::VERSION" do
-  it "is 0.9.0" do
-    expect(MpiDesignSystem::VERSION).to eq("0.9.0")
+  it "is 0.10.0" do
+    expect(MpiDesignSystem::VERSION).to eq("0.10.0")
   end
 end


### PR DESCRIPTION
## Summary
Cuts **v0.10.0**, batching two already-merged Tier-2 Track 2 conversions (epic #147) into one release. Per `CONTRIBUTING.md` § Release, neither feature PR carried a version bump — both parked their notes under `[Unreleased]` — so this single `chore(release)` commit ships them together:

- **#151 (phase 3, PR #167)** — FilterChipBar + DataTable + TagChip `GROUP_VARIANTS` semantic conversion.
- **#152 (phase 4, PR #170)** — FilterPanel theme-adaptive conversion. *(The AvatarCircle half of phase 4 is split to #169 and is **not** in this release.)*

Batching (vs. one release per phase) is deliberate: both are **Tier-2** (Markaz-driven, not Harvest-blocking — nothing downstream waits per-phase), and `CONTRIBUTING.md` sanctions "one release per shipped unit" (e.g. `v0.7.0` batched three changes). One `v0.10.0` avoids a version collision between the two simultaneously-ready PRs and gives consumers one coordinated bump.

## Changes Made
The exact four-file release edit (`CONTRIBUTING.md` § Release):

| File | Change |
|------|--------|
| `lib/mpi_design_system/version.rb` | `VERSION` `0.9.0` → `0.10.0` |
| `spec/packaging/version_spec.rb` | assert `"0.10.0"` + `it "is 0.10.0"` + a release-lineage clause |
| `README.md` | `tag: "v0.10.0"` in **both** the Gemfile snippet and the explanatory line |
| `CHANGELOG.md` | add the FilterPanel entry into `[Unreleased]` (already holding #167's entry), move the block to `## [0.10.0] - 2026-07-22`, keep an empty `## [Unreleased]`, add the `[0.10.0]:` link def, retarget `[Unreleased]:` to `compare/v0.10.0...HEAD` |

## Technical Approach
The `changelog_spec.rb` invariants are satisfied: `[Unreleased]` remains present with its own link def, the current `VERSION` (`0.10.0`) has its own `## [0.10.0]` heading, and every bracketed heading has a matching link definition (exact multiset). `version_spec.rb` now pins `0.10.0` in lockstep with the constant and the tag.

## Testing
- `bundle exec rubocop -a` — 0 offenses (159 files)
- `bundle exec rspec` — 1058 examples, 0 failures (packaging gates `version_spec` + `changelog_spec` included; browser feature specs green)
- `bundle exec rspec spec/packaging/` — 27 examples, 0 failures

## Checklist
- [x] Tests pass
- [x] Linting passes

> **Post-merge — the tag.** The `v0.10.0` tag is cut on **this PR's merge SHA**, gated fail-closed on that SHA's CI being all-green (`CONTRIBUTING.md` § Release) — **never** from this branch. It is the only release artifact (consuming apps pin to the tag). After you merge, I'll run the hardened CI-green gate on the merge SHA and push the tag (or hand you the exact gated command), then the consuming-app pin bumps can follow.

Releases #151 (PR #167) and #152 (PR #170). Does not close an issue — both feature issues were already closed by their PRs.

— Claude Code (Fable 5)
