### PR TITLE
chore(release): v0.11.0 — theme-adaptive Admin::Dashboard (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ include breaking changes).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-07-23
+
 ### Changed
 - **`Admin::Dashboard` is theme-adaptive** — the CRM dashboard stopped pinning a light
   palette in inline styles; every colour the component *selects* now resolves from a
@@ -459,7 +461,8 @@ Initial internal version: the ViewComponent library, design tokens, Stimulus con
 and Lookbook previews, prior to the adoption-prep packaging corrections above. (No release
 tag was cut for 0.1.0.)
 
-[Unreleased]: https://github.com/mpimedia/mpi-design-system/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/mpimedia/mpi-design-system/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.7.0...v0.8.0

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ on where Bundler unpacks the gem.
 
 ```ruby
 # Gemfile
-gem "mpi_design_system", git: "git@github.com:mpimedia/mpi-design-system.git", tag: "v0.10.0"
+gem "mpi_design_system", git: "git@github.com:mpimedia/mpi-design-system.git", tag: "v0.11.0"
 ```
 
-Pin to a release tag (`tag: "v0.10.0"`) so upgrades are deliberate. Then:
+Pin to a release tag (`tag: "v0.11.0"`) so upgrades are deliberate. Then:
 
 ```bash
 bundle install

--- a/lib/mpi_design_system/version.rb
+++ b/lib/mpi_design_system/version.rb
@@ -1,3 +1,3 @@
 module MpiDesignSystem
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
 end

--- a/spec/packaging/version_spec.rb
+++ b/spec/packaging/version_spec.rb
@@ -14,11 +14,13 @@ require "spec_helper"
 # v0.9.0 releases the NavBar/AppShell theme-adaptive conversion (#154, phase 6) and the
 # StatCard/AvatarStack/ActiveFilterBar small conversions (#150, phase 2); v0.10.0 batches
 # the FilterChipBar/DataTable/TagChip semantic conversion (#151, phase 3) and the FilterPanel
-# theme-adaptive conversion (#152, phase 4 — the AvatarCircle half is split to #169). This spec
+# theme-adaptive conversion (#152, phase 4 — the AvatarCircle half is split to #169); v0.11.0
+# (#153) makes Admin::Dashboard theme-adaptive — the largest inline-hex surface (Track 2 phase 5;
+# the caller-supplied Contacts-by-Group chart palette is split to #172). This spec
 # fails if the constant regresses, keeping lib/mpi_design_system/version.rb in lockstep
 # with CHANGELOG.md and the git tag.
 RSpec.describe "MpiDesignSystem::VERSION" do
-  it "is 0.10.0" do
-    expect(MpiDesignSystem::VERSION).to eq("0.10.0")
+  it "is 0.11.0" do
+    expect(MpiDesignSystem::VERSION).to eq("0.11.0")
   end
 end


### PR DESCRIPTION
## Summary
Cut **v0.11.0**, releasing the merged `Admin::Dashboard` theme-adaptive conversion (#153 / PR #173, merge `fcc4609`) — Track 2 phase 5 of epic #147, the largest inline-hex surface. The tag is the only release artifact; consuming apps resolve the gem from GitHub and pin to it.

## Changes Made
The single four-file `chore(release)` change per `CONTRIBUTING.md` § Release:

| File | Change |
|------|--------|
| `lib/mpi_design_system/version.rb` | `VERSION` `0.10.0` → `0.11.0` |
| `spec/packaging/version_spec.rb` | assert `0.11.0`; `it "is 0.11.0"`; append the v0.11.0 release-lineage clause |
| `README.md` | bump `tag: "v0.11.0"` in both the Gemfile install example and the explanatory line |
| `CHANGELOG.md` | move the Dashboard notes under a dated `## [0.11.0] - 2026-07-23`; keep `## [Unreleased]` (empty); add the `[0.11.0]` compare link; re-aim `[Unreleased]` to `v0.11.0...HEAD` |

## Technical Approach
- **Pre-1.0 minor bump**, consistent with every prior Track 2 conversion release (v0.8.0 #149 · v0.9.0 #150/#154 · v0.10.0 #151/#152). The Dashboard conversion removes the public constants `ACTIVITY_ICONS`/`FOLLOWUP_COLORS` (no external call sites), which pre-1.0 SemVer permits under a minor bump.
- One release per shipped unit — this releases exactly PR #173.

## Testing
- `bundle exec rubocop -a` — 0 offenses.
- `bundle exec rspec` — 1104 examples, 0 failures (incl. `spec/packaging/` version + changelog label-coverage guards on the new version).

## Post-merge (the tag is cut separately, gated on CI)
CI does not run on tag pushes, so per the runbook the tag is pushed onto this PR's **merge commit** only after its checks are green, via the fail-closed gate in `CONTRIBUTING.md` § Release (verifies the merge SHA's check-runs are all `success` and that `version.rb` at that SHA is exactly `0.11.0`). I will run that gated `git tag v0.11.0 <merge-sha> && git push` after you merge — I will not tag before then.

## Checklist
- [x] Tests pass
- [x] Linting passes

— Claude Code (Fable 5)

https://claude.ai/code/session_017Fz8tF6dZJex4jsCD7fCar
