### PR TITLE
Record #172 chart palette as caller-owned (Option C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ include breaking changes).
 
 ## [Unreleased]
 
+### Changed
+- **`Admin::Dashboard` Contacts-by-Group chart palette — decided caller-owned (#172, Option C).**
+  Records the decision the #153 conversion deferred: the chart's `group_data[:color]` is a
+  **deliberate, permanent consumer-owned data-viz passthrough**, not a pending conversion. The
+  design system does not own app-supplied chart *data*, so the theme-adaptive mandate governs the
+  component's own chrome, not the caller's values (which stay fixed-hue by design). Docs /
+  decision-recording only — no component behaviour, API, token, or SCSS change; every
+  component-owned Dashboard colour already adapts (shipped v0.11.0). Rejected: **(a)** mapping
+  groups onto Bootstrap semantics (collapses categories — `press_festival`/`vendors` land on the
+  same blue — and a solid `bg-#{semantic}` fill is fixed-hue anyway) and **(b)** real adaptive
+  `--mds-chart-*` tokens (kept as a future opt-in, shared with #169). (#172, epic #147.)
+
 ## [0.11.0] - 2026-07-23
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,22 @@ since the previous tag, and eyeball the URLs and date yourself. For the date, us
 author the release commit (the merge day in a normal same-day flow); if the PR lingers past
 midnight, amend the date before tagging.
 
+### Rebasing a feature PR's CHANGELOG edit across a release
+
+If your open PR edits an entry under `## [Unreleased]` and a per-phase release merges to `main`
+while the PR is in review, that release **moves your entry into the new `## [X.Y.Z]` section**.
+When you then rebase onto `main`, git can **silently auto-merge your edit into the now-released
+version entry — with no conflict**, because the surrounding context lines are identical. That
+rewrites shipped history to attribute your later change to a release it was never part of, and a
+clean rebase is *not* proof the edit landed where you meant it.
+
+So after rebasing any CHANGELOG change: `git diff origin/main -- CHANGELOG.md` and confirm your
+edit sits under `## [Unreleased]`, **not** under the released version. Leave shipped `## [X.Y.Z]`
+entries exactly as released (a "deferred to #NNN" there is accurate history, a legitimate exception
+to any "resolve the stale reference" sweep — like a pinned version or date); record the new change
+as a fresh `[Unreleased]` entry instead. (Hit on PR#176 / #172: v0.11.0 shipped the #153 Dashboard
+entry mid-review, and the rebase relocated the Option-C edit into `[0.11.0]` with no conflict.)
+
 ### Cutting the release
 
 1. **Branch from fresh `main`** so the shipped unit's `[Unreleased]` notes are present:

--- a/app/components/mpi_design_system/admin/dashboard/component.rb
+++ b/app/components/mpi_design_system/admin/dashboard/component.rb
@@ -51,7 +51,9 @@ module MpiDesignSystem
         # @param followup_count [Integer] Total follow-ups for "View all" link
         # @param followup_path [String] URL for "View all" link
         # @param quick_action_buttons [Array<Hash>] Each: { label: String, path: String, icon: String }
-        # @param group_data [Array<Hash>] Each: { label: String, count: Integer, color: String, percentage: Float }
+        # @param group_data [Array<Hash>] Each: { label: String, count: Integer, color: String, percentage: Float }.
+        #   `color` is a deliberate consumer-owned data-viz passthrough (decided #172); the component does
+        #   not own it. The caller supplies a trusted, consumer-validated CSS colour — see `bar_segment_styles`.
         def initialize(user_name:, greeting_time: :morning, current_date: nil,
                        activities: [], followups: [], followup_count: 0, followup_path: nil,
                        quick_action_buttons: [], group_data: [])
@@ -204,16 +206,17 @@ module MpiDesignSystem
           "height: 16px; border-radius: 8px; overflow: hidden; display: flex; width: 100%;"
         end
 
-        # Caller-owned data-viz palette. `group_data[:color]` is supplied by the consuming
-        # app, not selected by the component, so it is deliberately out of scope for the
-        # #153 theme-adaptive conversion and stays a fixed hex passthrough — tracked by the
-        # follow-up issue (split from #153, mirroring #152 -> #169). Geometry survives here.
+        # Deliberate consumer-owned data-viz passthrough (decided #172); the component does not
+        # own `group_data[:color]`. The consuming app supplies a trusted, consumer-validated CSS
+        # colour (preferably a hex value), so it is deliberately outside the #153 theme-adaptive
+        # mandate — that mandate governs the component's OWN chrome, not app-supplied chart data.
+        # Geometry survives here.
         def bar_segment_styles(group)
           "background: #{group[:color]}; width: #{group[:percentage]}%; height: 100%;"
         end
 
-        # Caller-owned data-viz palette — see `bar_segment_styles`. The dot mirrors its
-        # segment's fixed hex fill; geometry survives here.
+        # Deliberate consumer-owned data-viz passthrough (decided #172) — see `bar_segment_styles`.
+        # The dot mirrors its segment's caller-supplied fill; geometry survives here.
         def legend_dot_styles(color)
           "width: 10px; height: 10px; border-radius: 50%; background: #{color}; flex-shrink: 0;"
         end

--- a/catalog/layouts/dashboard.md
+++ b/catalog/layouts/dashboard.md
@@ -8,7 +8,7 @@
 
 CRM dashboard layout showing a personalized greeting, stat cards row, recent activity feed, quick actions, follow-up queue, and contacts by group chart. Renders inside the App Shell with CRM sub-nav active.
 
-Since #153 the layout is **theme-adaptive**: every colour the component selects resolves from a Bootstrap semantic utility (`bg-body`, `text-body`, `text-body-secondary`, the `-subtle`/`-emphasis` families) rather than a pinned hex, so it follows `data-bs-theme` and the consuming app's mapped tokens. The one exception is the Contacts-by-Group chart, whose colours are **caller-supplied** (`group_data[:color]`) and deliberately out of scope for #153 — tracked by #172.
+Since #153 the layout is **theme-adaptive**: every colour the component selects resolves from a Bootstrap semantic utility (`bg-body`, `text-body`, `text-body-secondary`, the `-subtle`/`-emphasis` families) rather than a pinned hex, so it follows `data-bs-theme` and the consuming app's mapped tokens. The one exception is the Contacts-by-Group chart, whose colours are **caller-supplied** (`group_data[:color]`). Per #172 this is **decided as a deliberate consumer-owned data-viz passthrough** — the design system does not own app-supplied chart data, so the theme-adaptive mandate governs the component's own chrome, not the values a consuming app feeds in (see the Chart Palette design decision below).
 
 ## Design Decisions
 
@@ -19,7 +19,7 @@ Since #153 the layout is **theme-adaptive**: every colour the component selects 
 - **Two-column body:** Left column (`col-lg-8`) has Recent Activity + Contacts by Group. Right column (`col-lg-4`) has Quick Actions + Follow-up Queue
 - **Recent Activity:** activity entries with type icons (28px circles). The icon chip is a theme-adaptive `bg-#{semantic}-subtle text-#{semantic}-emphasis` pair. Contact and account names are links with **no** colour class — Bootstrap's adaptive `--bs-link-color` with its natural underline as the affordance. Relative timestamps in `text-body-secondary`
 - **Follow-up Queue:** Priority list with avatars, description, and status. Status colours: overdue = `text-danger-emphasis`, due today = `text-danger-emphasis`, due tomorrow = `text-warning-emphasis`, future = `text-body-secondary`. "View all N &rarr;" link in header (same adaptive-link treatment as the activity links)
-- **Contacts by Group:** Horizontal stacked bar chart using **caller-supplied** group colours + legend with counts. Full-width within the left column. The bar carries `role="img"` and an `aria-label`; the legend labels/counts are `text-body-secondary` / `text-body`
+- **Contacts by Group:** Horizontal stacked bar chart using **caller-supplied** group colours (a deliberate consumer-owned data-viz passthrough, decided #172 — see the Chart Palette decision below) + legend with counts. Full-width within the left column. The bar carries `role="img"` and an `aria-label`; the legend labels/counts are `text-body-secondary` / `text-body`
 
 ### Activity Icon Types
 
@@ -45,6 +45,16 @@ Unknown type falls back to the Email (primary) pair.
 | Future | `text-body-secondary` | muted body | "In 3 days" |
 
 `-emphasis` (not base `text-danger` / `text-warning`) because the 12px status label is small text (AA 4.5:1), which base danger/warning fail; the emphasis tokens clear it and follow the colour mode. Unknown status falls back to the Future (`text-body-secondary`) class.
+
+### Chart Palette — Consumer-Owned Data-Viz Passthrough (decided #172)
+
+The Contacts-by-Group bar and legend draw their colours from `group_data[:color]`, supplied by the consuming app. After #153 made the rest of the Dashboard theme-adaptive, this was the only inline hex left in the component's own markup. #172 weighed three options and **chose (c)**:
+
+- **(a) Map each group onto a Bootstrap semantic** (`bg-#{semantic}`) — rejected. MPI's semantic palette yields only **five** distinct *adaptive* hues (`info` aliases to `primary`), so a multi-category group palette collapses — e.g. `press_festival`/`vendors` land on the same blue — and a solid `bg-#{semantic}` fill is a **fixed** hue anyway (it reads `--bs-#{semantic}-rgb`, which Bootstrap does not shift under `data-bs-theme`). So (a) would neither preserve per-category identity nor make the chart theme-adaptive.
+- **(b) Introduce real adaptive `--mds-chart-*` tokens** — deferred, not rejected. This remains available as a future opt-in (shared with #169) if per-category chart fidelity is later wanted. It is the real-token path — a designer decision — and out of scope here.
+- **(c) Keep it a caller-owned passthrough** — **chosen.** The colour here is app-supplied *data*, not system chrome. The design system does not own the values a consuming app charts, so the theme-adaptive mandate (component-owned colour resolves from Bootstrap semantics) deliberately does not extend to them. This passthrough is now a **permanent, documented** boundary, not a deferral.
+
+`group_data[:color]` is a **trusted, consumer-validated CSS colour** (preferably a hex value), supplied by the app — not arbitrary end-user input. The component interpolates it directly into an inline `style`, so the caller owns validating it; the design system adds no sanitisation (that would change behaviour and is out of scope for Option C).
 
 ## Layout Structure
 
@@ -101,7 +111,7 @@ class MpiDesignSystem::Admin::Dashboard::Component < ViewComponent::Base
   # @param followup_count [Integer]  # for the "View all" link
   # @param followup_path [String]    # for the "View all" link
   # @param quick_action_buttons [Array<Hash>] { label:, path:, icon: }
-  # @param group_data [Array<Hash>] { label:, count:, color:, percentage: }  # color is caller-supplied
+  # @param group_data [Array<Hash>] { label:, count:, color:, percentage: }  # color is a caller-owned data-viz passthrough (decided #172): a trusted, consumer-validated CSS colour the component does not own
   #
   # Composes these sub-components via slots (a slot bypasses the built-in markup entirely):
   # renders_many :stat_cards    # StatCard components
@@ -136,8 +146,8 @@ activity-icon: width: 28px; height: 28px; border-radius: 50%   (class: bg-#{sem}
 quick-action:  padding: 10px 14px; border-radius: 6px; text-decoration: none; display: block; text-align: left
                                                                (class: border bg-body text-body)
 group-bar:     height: 16px; border-radius: 8px; overflow: hidden; display: flex; width: 100%
-bar-segment:   background: #{caller hex}; width: #{pct}%; height: 100%   (caller-supplied colour — passthrough)
-legend-dot:    width: 10px; height: 10px; border-radius: 50%; background: #{caller hex}
+bar-segment:   background: #{caller hex}; width: #{pct}%; height: 100%   (caller-owned data-viz passthrough — decided #172)
+legend-dot:    width: 10px; height: 10px; border-radius: 50%; background: #{caller hex}   (caller-owned — mirrors its segment)
 ```
 
 ## Accessibility
@@ -151,7 +161,7 @@ Re-derived for the #153 conversion (a catalog entry's contrast claims are assert
 - Follow-up status text uses `-emphasis` tokens, AA-clean (≥4.5:1) on the widget surface in both colour modes at 12px; the status **label text** carries the meaning, not the colour
 - Quick action controls are keyboard-accessible links. Their `.border` is theme-adaptive but low-contrast against the card (≈1.3:1 light / 1.9:1 dark, below SC 1.4.11's 3:1 for a control boundary). Because the anchor drops its link colour and underline, the border is the only remaining boundary cue — a known, currently untracked affordance limitation, flagged for a design decision. It predates the conversion and is not a #153 regression (the control was navy-on-white in the same `#DEE2E6` border before), so it was surfaced rather than silently redesigned here
 - Follow-up queue items have clear status text alongside colour coding
-- Contacts by Group chart bar carries `role="img"` + `aria-label`, and a text legend below (label + count) — the bar alone is not the only representation. Bar/dot colours are caller-supplied and not guaranteed AA against each other; the text legend carries the data
+- Contacts by Group chart: the bar is programmatically named with `role="img"` and `aria-label="Contacts by group distribution"` — which *names* the image but carries none of the category values. The adjacent **text legend** independently exposes every category label and count, so the underlying data does not depend on distinguishing the segment colours (WCAG 2.1 SC 1.4.1). The bar/dot colours are the caller-owned data-viz passthrough (decided #172) and are not guaranteed AA against each other; that is acceptable precisely because the legend, not the colour, is what carries the data
 
 ## Usage Guidelines
 

--- a/catalog/previews/dashboard.html
+++ b/catalog/previews/dashboard.html
@@ -122,7 +122,7 @@
     .avatar-sm { display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 50%; color: #fff; font-weight: 600; font-size: 11px; flex-shrink: 0; }
     .followup-status { font-size: 11px; font-weight: 500; white-space: nowrap; }
 
-    /* Contacts by group bar — caller-supplied colours (passthrough, #153 follow-up). */
+    /* Contacts by group bar — caller-owned data-viz passthrough (decided #172). */
     .group-bar { height: 16px; border-radius: 8px; overflow: hidden; display: flex; }
     .group-bar-segment { height: 100%; }
     .group-legend { font-size: 11px; }
@@ -136,7 +136,7 @@
 <body>
   <div class="preview-wrapper">
     <h4 class="mb-1 text-body">Dashboard Layout</h4>
-    <p class="text-body-secondary small mb-4">Dashboard layout for CRM. Greeting, stat cards, recent activity feed, follow-up queue, contacts by group chart, and quick actions. Theme-adaptive after #153; the Contacts-by-Group palette is caller-supplied (deferred). From Figma Screen 7.</p>
+    <p class="text-body-secondary small mb-4">Dashboard layout for CRM. Greeting, stat cards, recent activity feed, follow-up queue, contacts by group chart, and quick actions. Theme-adaptive after #153; the Contacts-by-Group palette is a caller-owned data-viz passthrough (decided #172). From Figma Screen 7.</p>
 
     <div class="preview-section">
       <div class="preview-label">CRM Dashboard — From Figma Screen 7</div>

--- a/spec/components/mpi_design_system/admin/dashboard/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/dashboard/component_spec.rb
@@ -371,10 +371,12 @@ RSpec.describe MpiDesignSystem::Admin::Dashboard::Component, type: :component do
   #
   # #153 moved every colour Dashboard SELECTS onto Bootstrap semantic utilities so the
   # layout tracks `data-bs-theme`. The one exception is the Contacts-by-Group chart's
-  # CALLER-supplied `group_data[:color]`, a documented data-viz passthrough deferred to a
-  # follow-up issue. Each guard pins its subject positively before asserting an absence and
-  # was proven by watching it fail (testing.md, "A Guard Is Not Real Until You Have Watched
-  # It Fail"). Guard shapes are copied from `data_table/component_spec.rb`.
+  # CALLER-supplied `group_data[:color]` — a deliberate, permanent consumer-owned data-viz
+  # passthrough (decided #172): the component does not own app-supplied chart data, so it
+  # stays outside the theme-adaptive mandate by design, not by deferral. These guards are its
+  # standing proof. Each pins its subject positively before asserting an absence and was
+  # proven by watching it fail (testing.md, "A Guard Is Not Real Until You Have Watched It
+  # Fail"). Guard shapes are copied from `data_table/component_spec.rb`.
   describe "theme-adaptivity guards" do
     AVATAR_ROOT = ".rounded-circle.justify-content-center"
 
@@ -528,10 +530,11 @@ RSpec.describe MpiDesignSystem::Admin::Dashboard::Component, type: :component do
       expect(offending_style_declarations(fragment).sort).to eq(expected.sort)
     end
 
-    # GUARD 3 — caller-passthrough confinement. Every hex literal remaining in Dashboard's
-    # OWN markup (avatars stripped) is exactly the caller's `group_data[:color]` set, each
-    # appearing twice; and the segment/dot inline styles equal their expected strings. A new
-    # hex anywhere else — or an ALLOWED chart hex reused in another declaration (the ISS#150
+    # GUARD 3 — caller-passthrough confinement. This is the standing proof of the deliberate,
+    # permanent caller-owned passthrough (decided #172): every hex literal remaining in
+    # Dashboard's OWN markup (avatars stripped) is exactly the caller's `group_data[:color]`
+    # set, each appearing twice; and the segment/dot inline styles equal their expected strings.
+    # A new hex anywhere else — or an ALLOWED chart hex reused in another declaration (the ISS#150
     # same-hex-elsewhere mode) — pushes the multiset off and reddens this.
     it "confines every hex literal to the caller group colours, each appearing twice" do
       fragment = dashboard_fragment

--- a/spec/components/previews/mpi_design_system/admin/dashboard/component_preview.rb
+++ b/spec/components/previews/mpi_design_system/admin/dashboard/component_preview.rb
@@ -15,8 +15,8 @@ class MpiDesignSystem::Admin::Dashboard::ComponentPreview < ApplicationComponent
   # The same populated Dashboard rendered inside a `data-bs-theme="dark"` scope, so the
   # converted `bg-body` / `text-body` / `-subtle` / `-emphasis` utilities resolve to their
   # dark values (the precedent in pagination / data_table / filter_chip_bar). The chart's
-  # caller-supplied `group_data[:color]` stays a fixed hex — the documented passthrough
-  # deferred to the #153 follow-up.
+  # caller-supplied `group_data[:color]` stays a fixed hex — the deliberate consumer-owned
+  # passthrough (decided #172).
   def dark_mode
     render_with_template
   end

--- a/spec/dummy/app/views/contrast_demo/show.html.erb
+++ b/spec/dummy/app/views/contrast_demo/show.html.erb
@@ -52,8 +52,8 @@
     new_contact & call->success, note->warning); one follow-up of every status covers
     danger/warning emphasis + text-body-secondary on the widget surface; the contact and
     "View all" links exercise the adaptive --bs-link-color; the quick action exercises
-    text-body on bg-body plus the adaptive .border. group_data is the caller-supplied
-    passthrough (deferred to the #153 follow-up). %>
+    text-body on bg-body plus the adaptive .border. group_data is the deliberate
+    consumer-owned data-viz passthrough (decided #172). %>
 <% dashboard_args = {
      user_name: "Badie", greeting_time: :morning, current_date: "Tuesday, Feb 25",
      activities: [

--- a/spec/features/contrast_spec.rb
+++ b/spec/features/contrast_spec.rb
@@ -462,8 +462,8 @@ RSpec.describe "Derived foreground contrast", type: :feature, js: true do
   # emitted; only a browser proves the runtime `--bs-*` chains resolve AA-clean against the
   # compiled bundle. Each assertion pins the PAINTED value AND the ratio: inherited body
   # text clears AA in both modes, so a ratio-only check would be a false green (the #149
-  # rule). The chart's caller-supplied colours are the documented passthrough and are not
-  # asserted here. Painted values corroborated by the Pagination/StatCard/FilterChipBar
+  # rule). The chart's caller-supplied colours are the deliberate consumer-owned passthrough
+  # (decided #172) and are not asserted here. Painted values corroborated by the Pagination/StatCard/FilterChipBar
   # blocks above (same tokens, same formulas).
   describe "Dashboard (#153)" do
     {


### PR DESCRIPTION
## Summary

Resolves #172 via **Option C**: the Dashboard's Contacts-by-Group chart colour
(`group_data[:color]`) is formally recorded as a **deliberate, permanent consumer-owned
data-viz passthrough**. After #153 made the Dashboard theme-adaptive, this caller-supplied
colour was the only inline hex left in the component's own markup. The design system does not
own app-supplied chart *data*, so the theme-adaptive mandate governs the component's own
chrome, not the values a consuming app feeds in. This is **decision-recording only** — no
component behavior, API, payload, token, or SCSS changes, and **no release cut** (per the
issue DoD, a release is required only for options a/b).

The designer chose (c) over (a) semantic mapping — which would collapse `press_festival`/`vendors`
onto the same blue in the 5-group preview *and* be fixed-hue (not adaptive) — and over (b) real
`--mds-chart-*` tokens, which remains available as a future opt-in (shared with #169) if per-category
chart fidelity is later wanted.

## Changes Made

- `catalog/layouts/dashboard.md` — reframed the five passthrough spots (Overview,
  Contacts-by-Group bullet, `@param group_data`, Key Styles, Accessibility) from
  "deferred / tracked by #172" to "decided #172"; added a `### Chart Palette — Consumer-Owned
  Data-Viz Passthrough (decided #172)` block naming the a/b/c fork; corrected the a11y rationale
  to credit the **text legend** (not the `aria-label`) as the data carrier (WCAG 2.1 SC 1.4.1);
  documented `group_data[:color]` as a trusted, consumer-validated CSS value (no validation added).
- `app/components/mpi_design_system/admin/dashboard/component.rb` — doc comments on
  `bar_segment_styles`, `legend_dot_styles`, and `@param group_data` reframed (**comments only**,
  no code change).
- `spec/components/mpi_design_system/admin/dashboard/component_spec.rb` — guard-block preamble +
  GUARD 3 comment reframed as the **standing proof** of a permanent decision (no guard logic changed).
- `spec/components/previews/.../dashboard/component_preview.rb`, `catalog/previews/dashboard.html`,
  `spec/dummy/app/views/contrast_demo/show.html.erb`, `spec/features/contrast_spec.rb` — sibling
  mockup/fixture/feature-spec framing resolved to match (whole-repo deferral sweep).
- `CHANGELOG.md` — rewrote the existing Unreleased Dashboard entry **in place**: component-owned
  colours are adaptive; the caller chart data is a documented passthrough outside that contract, and
  those chart colours do not adapt by design (no version bump, no release cut).

## Technical Approach

Option C keeps the caller-owned boundary and documents it as **permanent** rather than deferred.
Every stale "deferred / #153 follow-up / tracked by #172" reference was swept across the whole repo
(`app/`, `spec/`, `catalog/`, CHANGELOG, the `contrast_demo` fixture) and resolved; the unrelated
TagChip seven-hue `tag-chip.md` deferral (#151/#169) was verified out of scope and left alone. The
existing **GUARD 2 / GUARD 3** assertions already confine every hex in the Dashboard's own markup to
the caller's `group_data[:color]` set — exactly the guarantee Option C makes permanent — so no new
spec logic was added, consistent with `.claude/rules/testing.md`. The reframed guards were re-proven
load-bearing (below).

## Testing

- **Mutation check (guard-is-real):** temporarily emitting a non-caller `background: #000` from
  `bar_segment_styles` reddens exactly **GUARD 2** ("emits no colour, border, or opacity declaration
  beyond the caller chart backgrounds") and **GUARD 3** ("confines every hex literal to the caller
  group colours, each appearing twice"); reverted, suite green, no leftover.
- `bundle exec rubocop -a` — 159 files, **0 offenses**.
- `bundle exec rspec` — **1104 examples, 0 failures** (preview-render sweep and Dashboard guards included).

## Checklist

- [x] Tests pass
- [x] Linting passes

— Claude Code (Fable 5)
