### PR TITLE
chore(release): v0.12.0 — theme-adaptive AvatarCircle tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ include breaking changes).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-24
+
 ### Added
 - **Theme-adaptive, re-brandable avatar colours** — `AvatarCircle`'s name-hash identity palette
   (and `AvatarStack`'s "+N" chip) now paint runtime custom properties
@@ -490,7 +492,8 @@ Initial internal version: the ViewComponent library, design tokens, Stimulus con
 and Lookbook previews, prior to the adoption-prep packaging corrections above. (No release
 tag was cut for 0.1.0.)
 
-[Unreleased]: https://github.com/mpimedia/mpi-design-system/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/mpimedia/mpi-design-system/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/mpimedia/mpi-design-system/compare/v0.8.0...v0.9.0

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ on where Bundler unpacks the gem.
 
 ```ruby
 # Gemfile
-gem "mpi_design_system", git: "git@github.com:mpimedia/mpi-design-system.git", tag: "v0.11.0"
+gem "mpi_design_system", git: "git@github.com:mpimedia/mpi-design-system.git", tag: "v0.12.0"
 ```
 
-Pin to a release tag (`tag: "v0.11.0"`) so upgrades are deliberate. Then:
+Pin to a release tag (`tag: "v0.12.0"`) so upgrades are deliberate. Then:
 
 ```bash
 bundle install

--- a/lib/mpi_design_system/version.rb
+++ b/lib/mpi_design_system/version.rb
@@ -1,3 +1,3 @@
 module MpiDesignSystem
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 end

--- a/spec/packaging/version_spec.rb
+++ b/spec/packaging/version_spec.rb
@@ -16,11 +16,13 @@ require "spec_helper"
 # the FilterChipBar/DataTable/TagChip semantic conversion (#151, phase 3) and the FilterPanel
 # theme-adaptive conversion (#152, phase 4 — the AvatarCircle half is split to #169); v0.11.0
 # (#153) makes Admin::Dashboard theme-adaptive — the largest inline-hex surface (Track 2 phase 5;
-# the caller-supplied Contacts-by-Group chart palette is split to #172). This spec
-# fails if the constant regresses, keeping lib/mpi_design_system/version.rb in lockstep
-# with CHANGELOG.md and the git tag.
+# the caller-supplied Contacts-by-Group chart palette is split to #172); v0.12.0 promotes
+# AvatarCircle's name-hash identity palette to theme-adaptive runtime `--mds-avatar-*` tokens
+# (#169, split from #152 — the engine's first hand-authored dark palette) and records the #172
+# chart-palette caller-owned decision. This spec fails if the constant regresses, keeping
+# lib/mpi_design_system/version.rb in lockstep with CHANGELOG.md and the git tag.
 RSpec.describe "MpiDesignSystem::VERSION" do
-  it "is 0.11.0" do
-    expect(MpiDesignSystem::VERSION).to eq("0.11.0")
+  it "is 0.12.0" do
+    expect(MpiDesignSystem::VERSION).to eq("0.12.0")
   end
 end


### PR DESCRIPTION
## Summary

Cuts **v0.12.0**, the release for the AvatarCircle theme-adaptive conversion ([ISS#169](https://github.com/mpimedia/mpi-design-system/issues/169) / [PR#177](https://github.com/mpimedia/mpi-design-system/pull/177), merged) plus the [ISS#172](https://github.com/mpimedia/mpi-design-system/issues/172) chart-palette caller-owned decision — everything merged to `main` since v0.11.0. Follows `CONTRIBUTING.md` § Release: a single 4-file commit; the tag is pushed **post-merge** (fail-closed on the merge SHA's CI), not in this PR.

## Changes Made

The exactly-four release files:

| File | Change |
|------|--------|
| `lib/mpi_design_system/version.rb` | `VERSION` `0.11.0` → `0.12.0` |
| `spec/packaging/version_spec.rb` | assertion + `it` description → `0.12.0`; appended the v0.12.0 lineage clause |
| `README.md` | Gemfile pin + explanatory line `tag: "v0.11.0"` → `"v0.12.0"` (both occurrences) |
| `CHANGELOG.md` | new dated `## [0.12.0] - 2026-07-24` (the former `[Unreleased]` content); `[Unreleased]` kept empty; `[0.12.0]` compare link added; `[Unreleased]` re-aimed to `v0.12.0...HEAD` |

## What v0.12.0 ships (since v0.11.0)

- **AvatarCircle / AvatarStack → theme-adaptive `--mds-avatar-*` runtime tokens** (#169) — non-breaking `var(token, fallback)`, optional `_avatar.scss` with a `[data-bs-theme="dark"]` block (the engine's first hand-authored dark palette), oracle-verified foregrounds both modes, runtime re-brand. Reviewed across three independent Codex rounds.
- **`Admin::Dashboard` chart palette — caller-owned decision recorded** (#172) — docs/decision only, no behaviour change.

## Testing

- `bundle exec rubocop -a` — 0 offenses.
- `bundle exec rspec` — full suite green (packaging guards now assert `0.12.0` and validate the CHANGELOG heading↔link parity).
- CHANGELOG date (2026-07-24) and compare URLs hand-checked (the changelog spec verifies label coverage, not correctness).

## ⚠️ Reviewer note — pre-existing missing tags (needs a decision)

While cutting this release I found that **`v0.9.0` and `v0.11.0` were never tagged** on the remote (their release commits are on `main`; the tag list jumps `v0.8.0 → v0.10.0`, and there's no `v0.11.0`). Consequences today:
- The **README currently pins `tag: "v0.11.0"`, which does not exist** — this PR fixes that by moving the pin to `v0.12.0` (to be tagged post-merge).
- The CHANGELOG compare links for `[0.10.0]` (`v0.9.0...`) and `[0.12.0]`/`[0.11.0]` reference the missing `v0.9.0`/`v0.11.0` tags, so those GitHub compare URLs 404 until the tags exist.

**Recommended fix** (separate from this PR, needs maintainer go-ahead — pushing tags is outward-facing): tag the existing release commits — `v0.11.0` at `0ccdff2` (merge of #175; CI confirmed green) and `v0.9.0` at its release commit — so the install contract and compare links resolve. Then push `v0.12.0` at this PR's merge commit per the runbook.

## Checklist
- [x] Exactly 4 release files (`CONTRIBUTING.md` § Release)
- [x] `[0.12.0]` section populated + dated; `[Unreleased]` kept empty
- [x] Tests pass (`bundle exec rspec`), Rubocop clean
- [ ] **Tag push deferred to post-merge** (fail-closed on the merge SHA's CI) — plus the missing `v0.9.0`/`v0.11.0` backfill above

— Claude Code (Fable 5)
