### PR TITLE
Converge every tag-group renderer on GROUP_VARIANTS (#168)

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -283,6 +283,23 @@ Rules:
   designer decision. (Reference: #151 mapped the 7-category `TagChip::Component::GROUPS`, and
   `press_festival`/`production`/`vendors` all collapsed onto blue — Codex's plan review caught the
   `info==primary` fact the plan had missed.)
+- **A decorative semantic dot's treatment depends on the surface it sits on — a solid
+  `bg-#{semantic}` fill *cannot* clear 3:1 inside a `-subtle` chip.** The rule below reserves
+  solid `bg-#{semantic}` for decorative marks and requires ≥3:1 on the resting surface. That is
+  satisfiable on a card/row backdrop (`bg-body`), but **not** on the element's own
+  `-subtle` surface: `bg-success` on `bg-success-subtle` measures **2.67:1**, `bg-warning` on
+  `bg-warning-subtle` **2.62:1** — both below the floor, because a subtle surface is by
+  construction a tint of the same hue. So pick by placement:
+  **dot inside a `-subtle` chip → `background-color: currentColor`** (inherits the chip's
+  `-emphasis` foreground: 9.34:1–10.52:1 light, 7.15:1–8.61:1 dark, adaptive by construction, no
+  second token needed); **dot on a plain card/row surface → solid `bg-#{semantic}`**, the
+  documented fixed-hue exception. Note `currentColor` is also the one value a theme-adaptivity
+  guard should *allow* in a `background-color` declaration, alongside `transparent`, `inherit`
+  and `var(--bs-*)`. Prove it in a browser by asserting the dot's computed
+  `background-color` **equals the chip's computed foreground** — a wrong fill is still "some
+  colour", so only the equality catches it. (Reference: #168 converted the remaining nine tag
+  renderers; the plan promised solid dots *and* a ≥3:1 test, which Codex's plan review showed
+  could not both hold.)
 - **A solid `bg-#{semantic}` fill is a *fixed* hue, not theme-adaptive — it reads
   `--bs-#{semantic}-rgb`, which Bootstrap does not shift under `data-bs-theme`.** Only
   `-subtle`/`-emphasis`, `bg-body`, `text-body`/`text-body-secondary` and `--bs-link-color`

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -300,6 +300,22 @@ Rules:
   colour", so only the equality catches it. (Reference: #168 converted the remaining nine tag
   renderers; the plan promised solid dots *and* a ≥3:1 test, which Codex's plan review showed
   could not both hold.)
+- **The dot rule's twin — a *foreground* is only safe to make adaptive where its *surface* adapts
+  too.** "Replace the frozen colour with `text-body`" is the reflexive fix, and it is correct only
+  on a surface that re-resolves with the theme. Applied to a component that paints its own
+  hardcoded `background: #fff`, `text-body` resolves to `#DEE2E6` in dark mode and paints
+  **1.30:1** on that still-white card — strictly worse than the frozen navy it replaced (14.22:1
+  there). So classify the surface before converting the foreground: a component with **no card of
+  its own** inherits the page → `text-body` (the frozen `#1B2A4A` measures 1.09:1 on a dark page);
+  a component **painting a fixed light background** → *keep* the frozen dark foreground until the
+  shell itself converts to `bg-body`, and pin that reasoning in a spec so a later "make it
+  adaptive" edit reddens instead of silently regressing. The shell conversion is the real fix, and
+  the pair must move together. **Audit every *state* of a surface you retint, not just resting** —
+  #168 fixed a dropdown option's resting text and left the hovered/keyboard-active variant at
+  **1.07:1**, because hover and keyboard highlighting are separate code paths and a resting-only
+  assertion cannot reach either. (Reference: #168 — `AccountListRow`/`ContactListRow` moved to
+  `text-body` while `EngagementCard` and `TagInput`'s dropdown kept navy; applying the rule
+  uniformly was both of that PR's round-1 P0s, and the state gap was its round-2 P0.)
 - **A solid `bg-#{semantic}` fill is a *fixed* hue, not theme-adaptive — it reads
   `--bs-#{semantic}-rgb`, which Bootstrap does not shift under `data-bs-theme`.** Only
   `-subtle`/`-emphasis`, `bg-body`, `text-body`/`text-body-secondary` and `--bs-link-color`

--- a/.claude/rules/self-review.md
+++ b/.claude/rules/self-review.md
@@ -32,6 +32,26 @@ HC the work is complete:
       - `bundle exec rubocop -a` — zero offenses
       - `bundle exec rspec` — zero failures
 
+## Re-Review the Review-Response Commit
+
+Fixes written in response to review are the one part of a PR that **nobody has reviewed**. The
+diff review ran against the original commit; the fixes landed after it. Nothing looks at them
+again unless you ask for it — and they are written fast, under the assumption that a reviewed
+finding has an obvious correction.
+
+#168 commissioned a second review pass on its own review-response commit and it returned
+**1 P0, 3 P1, 2 P2** — including a **P0 introduced while fixing a P0**: reverting a dropdown
+option's text to a frozen colour fixed the *resting* state, while a surface change made in the
+same commit left the hovered and keyboard-active states at **1.07:1**. The same pass found that
+neither of the commit's two guard fixes was isolated by its own test (see
+`.claude/rules/testing.md`, "A red suite is not a red *rule*").
+
+So: after addressing review findings, review the fix commit as its own diff — ideally with a
+second model, since the author who just wrote the fixes is the least able to see what they broke.
+Weight it toward the classes of defect that fixes specifically introduce: a correction applied
+more broadly than the finding warranted, a second state or code path the fix did not reach, and a
+new assertion that passes for a reason other than the one intended.
+
 ## Never Deflect Work
 
 - Never say "needs manual testing" without proving `render_inline` + Capybara matchers

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -198,6 +198,15 @@ form stays green. (#152.)
 **Related:** when a constant drives behavior (`ACTION_METHODS`, `COLORS`, `SIZES`), loop it
 rather than spot-checking one member — otherwise a typo in the constant ships green.
 
+**Related — when the mapping is many-to-one, loop the *domain*, not the codomain.** Looping the
+distinct *outputs* of a mapping feels equivalent to looping its keys and is not: keys that share an
+output are covered by whichever one the loop happens to reach, so a typo in any of the others ships
+green. `TagChip::Component::GROUP_VARIANTS` maps seven groups onto five semantics, with
+`press_festival`/`production`/`vendors` all on `primary` — a per-*hue* loop therefore leaves two of
+the seven keys entirely unproven, including in the JS mirror where the keys are duplicated by hand.
+Loop `GROUP_VARIANTS.each_key`, and assert the resolved value per key. (Reference: #168 — external
+review caught the per-hue loop; two duplicated JS keys had never been exercised.)
+
 **Related — `render_inline` lowercases SVG attribute names, so a camelCase selector silently
 matches nothing.** ViewComponent's `render_inline` parses output through Nokogiri's HTML parser,
 which downcases attribute *names* (`viewBox` → `viewbox`, `preserveAspectRatio` →
@@ -294,13 +303,38 @@ end
 Note the positive half: without it the example passes on a pattern that matches nothing at
 all. Proving a guard can fail does not exempt it from False Green #2.
 
-Two practical rules when mutation-testing:
+Three practical rules when mutation-testing:
 
 - **Isolate the spec file.** `version_spec.rb` independently pins the version, so bumping
   `VERSION` reddens it regardless — a full-suite red proves nothing about the guard you are
   testing. Run the single file.
 - **Never mutate with `git stash`** (shared stash stack, see `CLAUDE.md`). Edit, capture the
   failure, revert, then confirm `git diff` shows only the intended change.
+- **A red suite is not a red *rule* — when two checks can catch the same mutation, neither is
+  individually proven.** Isolating the *file* is not enough; overlapping checks inside it produce
+  the same false confidence. #168's theme-adaptivity guard ran a property scan and a literal scan.
+  Its recursive-fallback fix was *also* caught by the literal scan, and its independent-scans fix
+  was *also* caught by the property rule — so **either fix could be deleted with the suite still
+  green**, after the author had watched red and while every example passed. Exercise the unit
+  directly, assert *which* check produced the offence, and choose a fixture only the target check
+  can reject: #168's custom-property case used `chartreuse`, which the named-colour scan also
+  catches, and became isolating only as `papayawhip` — absent from the blacklist and not a
+  literal. Delete each rule one at a time and confirm the failure count changes by exactly what
+  that rule owns. (Reference: #168 round 2 — the sharpest of three review passes; round 1's fixes
+  were correct and effectively untested.)
+
+**A guard must fail *closed* on input it cannot parse.** A validator has three outcomes, not two —
+pass, fail, and *don't know* — and routing "don't know" to pass is how a guard ships fail-open with
+its own tests green. #168's `adaptive_value?` returned `nil` both for "this value has no fallback"
+and for "I could not parse this value", and `nil` meant adaptive; executed against the guard,
+`color: var(--bs-body-color, chartreuse) !important`, `text-shadow: 0 0 2px chartreuse`,
+`--x: chartreuse` and `caret-color: light-dark(chartreuse, papayawhip)` each returned **zero
+offences**. Make the unparseable branch reject, treat every un-excepted custom property as
+in-scope, and enumerate the bypasses by running them rather than by reasoning about coverage.
+Related: **do not describe a guard as a whitelist when one of its axes is a blacklist.** That
+file's doc comment claimed a "whitelist on both axes"; the value axis is a named-colour blacklist
+and can never be complete. Claiming a guarantee the code does not provide is the prose-only
+assurance this file warns about. (Reference: #168 round 2.)
 
 **Verify claims about a pattern by executing it, not by reading it.** #127's plan review
 produced a confident, wrong claim that `\[`/`\]` form a character class; a three-line Ruby
@@ -400,6 +434,13 @@ catches the fail-open you wrote and therefore cannot see. (The hardened block li
   `sort -u` CI gate was sound while the `gh` producer feeding it silently dropped a still-running
   check; the fail-open lived in the producer, and only an independent adversary caught it — see
   **A check written in documentation is still a check** above
+- Never treat a red suite as proof that a *specific* rule is load-bearing when a second check
+  catches the same mutation — assert which one fired — see **A red suite is not a red rule** above
+- Never let a guard pass input it could not parse; "don't know" must route to reject, and never
+  call a guard a whitelist when one of its axes is an unclosable blacklist — see **A guard must
+  fail closed** above
+- Never loop a many-to-one mapping by its distinct outputs — loop the keys, or the keys sharing an
+  output ship untested — see **when the mapping is many-to-one** above
 - Never test private methods — test through the rendered output
 - Never reference models, the database, or request specs — the engine has none (browser
   feature specs exist, but only for genuine JS behavior — see Stack; default to `render_inline`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ include breaking changes).
 
 ## [Unreleased]
 
+### Fixed
+- **Every CRM tag-group renderer is now theme-adaptive and WCAG AA clean (#168).** #167 moved
+  `FilterChipBar` and `DataTable` onto the shared
+  `TagChip::Component::GROUP_VARIANTS` mapping and deliberately left the other consumers on
+  frozen hex, producing a transient cross-consumer inconsistency. That is now closed: `TagChip`
+  itself, `Badge`'s `tag_group` variant, `ContactCard`, `EngagementCard`, `AccountListRow`,
+  `ContactListRow`, `AccountDetailPanel`, `ContactDetailPanel` and `TagInput` all resolve
+  category colour from the one mapping, so a category renders the same adaptive hue everywhere.
+  This also discharges **ISS#142 §1**: the retired hex pairs measured **2.77:1–4.34:1**, every
+  one below the AA floor. The `-subtle`/`-emphasis` pairs that replace them are
+  browser-measured at 9.34:1–10.52:1 (light) and 7.15:1–8.61:1 (dark), for all five distinct
+  hues in both colour modes.
+- **`tag_input_controller.js` painted six of seven tag groups grey (#168).** The Stimulus
+  controller carried its own frozen palette keyed on a stale vocabulary — `buyers`, `press`,
+  `festivals`, `sellers`, `institutional`, `organizations` — while the server sends the CRM
+  group names (`distribution`, `outreach`, `press_festival`, …). Only `internal` overlapped, so
+  every other group fell through to the grey fallback: a tag added interactively rendered grey
+  while the same tag rendered by the server rendered its category colour. The controller now
+  keys on the vocabulary the server actually sends and emits the same semantic classes as the
+  ERB, so an interactively-added chip is indistinguishable from a server-rendered one. Nothing
+  used the stale vocabulary, so this is not a consumer-facing rename.
+- **Faded remove controls (#130's opacity lesson, applied again).** `TagChip` and `TagInput`
+  paired a tag foreground with `opacity: 0.6`, compositing an already-sub-AA colour further
+  down. Both now use `text-reset bg-transparent border-0` and pin no colour or opacity.
+- Three false accessibility claims corrected in the catalog: `badge.md` ("All tag group color
+  pairs have been verified for WCAG AA compliance"), and `contact-card.md` ("Tag pill
+  text/background pairs all meet WCAG AA contrast" and "Avatar colors meet WCAG AA for white
+  text"). All three were false. `contact-card.md`'s palette table also documented a legacy
+  group vocabulary that no component has ever accepted.
+- `catalog/previews/filter-chip-bar.html`'s dark block declared three emphasis colours and **no**
+  `*-bg-subtle`, so a dark subtle chip kept its light surface; its dark success emphasis
+  (`#A7D9C4`) also disagreed with the compiled bundle (`#7AC6A6`). Pre-existing, fixed here.
+
+### Changed
+- **A tag dot's treatment now depends on its surface.** Inside a `-subtle` chip (`TagChip`,
+  `ContactCard`) the dot paints `background-color: currentColor`, inheriting the chip's
+  `-emphasis` foreground. It is **not** the solid `bg-#{semantic}` fill `DataTable` uses: a
+  solid semantic fill on its own `-subtle` surface measures **2.62:1–2.67:1**, below the 3:1
+  floor `.claude/rules/frontend.md` requires of a decorative semantic dot. Dots on a plain
+  card/row backdrop (`EngagementCard`, both list rows) keep the solid fill, where ≥3:1 holds.
+- `ContactCard`'s no-group/no-custom tag default now renders the adaptive `secondary` pair
+  instead of a frozen `#64748B` on `#F1F5F9` (4.34:1 — an ISS#142 failure). Caller-supplied
+  `color:` / `bg_color:` remain a deliberate passthrough (the ISS#172 principle) and are
+  unchanged, including their independent per-property fallbacks.
+- The tag labels beside the decorative dots in `AccountListRow`, `ContactListRow` and
+  `EngagementCard` moved to `text-body`. These are load-bearing, not an unrelated colour sweep:
+  the dots are `aria-hidden`, so the label is what carries the category — and the frozen
+  `#1B2A4A` navy measured **1.09:1** on Bootstrap's dark surface.
+- `spec/dummy/.../tag_input_demo` now uses the real CRM group vocabulary. It previously used the
+  controller's stale names, which is why the key mismatch went unnoticed: the one fixture anyone
+  would look at was written against the broken map's vocabulary.
+
+### Removed
+- `Badge::Component::TAG_GROUPS` — a byte-identical duplicate of `TagChip::Component::GROUPS`
+  that drifted independently. `Badge` reads `GROUP_VARIANTS` instead.
+- `AccountListRow::Component::TAG_DOT_COLORS` and `ContactListRow::Component::TAG_DOT_COLORS`.
+- `FilterChipBar::Component::GROUPS` — an alias left unused by #167.
+
+  All four are internal constants with no references outside this engine (verified across
+  Markaz, SFA, Garden and Harvest); pre-1.0, so formally breaking only if referenced directly.
+  **`TagChip::Component::GROUPS` is retained** — nothing renders from it, but it remains the
+  canonical group key set (`TagChip` validates `group:` against it, Badge's preview enumerates
+  it) and the record of the original brand hex.
+
 ## [0.12.0] - 2026-07-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,11 +51,18 @@ include breaking changes).
   instead of a frozen `#64748B` on `#F1F5F9` (4.34:1 — an ISS#142 failure). Caller-supplied
   `color:` / `bg_color:` remain a deliberate passthrough (the ISS#172 principle) and are
   unchanged, including their independent per-property fallbacks.
-- The tag labels beside the decorative dots in `AccountListRow`, `ContactListRow` and
-  `EngagementCard` moved to `text-body`. These are load-bearing, not an unrelated colour sweep:
-  the dots are `aria-hidden`, so the label is what carries the category — and the frozen
-  `#1B2A4A` navy measured **1.09:1** on Bootstrap's dark surface.
-- `spec/dummy/.../tag_input_demo` now uses the real CRM group vocabulary. It previously used the
+- **A tag label's foreground now depends on whether its component's surface adapts.** The dots
+  are `aria-hidden`, so the adjacent label is what carries the category and must stay legible in
+  both colour modes — but "adaptive" is only correct where the *surface* adapts too.
+  `AccountListRow` and `ContactListRow` have no card of their own and inherit the page, so their
+  labels moved to `text-body` (the frozen `#1B2A4A` measured **1.09:1** on a dark page).
+  `EngagementCard` and `TagInput`'s dropdown paint their own hardcoded `background: #fff`, so
+  theirs **keep** the navy: it measures 14.22:1 on that fixed white, whereas `text-body` would
+  resolve to `#DEE2E6` in dark mode and paint **1.30:1** on the same white card — a regression,
+  not a fix. Converting those two shells to `bg-body` is ISS#142 §3 work.
+- `spec/dummy/.../tag_input_demo` now uses the real CRM group vocabulary, and carries all seven
+  groups so the feature spec exercises every duplicated JS key (three share the `primary` hue, so
+  a per-hue loop would leave two unproven). It previously used the
   controller's stale names, which is why the key mismatch went unnoticed: the one fixture anyone
   would look at was written against the broken map's vocabulary.
 

--- a/app/components/mpi_design_system/admin/account_detail_panel/component.html.erb
+++ b/app/components/mpi_design_system/admin/account_detail_panel/component.html.erb
@@ -112,7 +112,7 @@
     <div style="<%= section_heading_styles %>">Tag Groups Represented</div>
     <div class="d-flex flex-wrap gap-1">
       <% @tag_groups.each do |tg| %>
-        <span style="<%= tag_group_chip_styles(tg[:group]) %>">
+        <span class="<%= tag_group_chip_classes(tg[:group]) %>" style="<%= tag_group_chip_styles %>">
           <%= tg[:label] %><% if tg[:count] %> (<%= tg[:count] %>)<% end %>
         </span>
       <% end %>

--- a/app/components/mpi_design_system/admin/account_detail_panel/component.rb
+++ b/app/components/mpi_design_system/admin/account_detail_panel/component.rb
@@ -4,6 +4,8 @@ module MpiDesignSystem
   module Admin
     module AccountDetailPanel
       class Component < ViewComponent::Base
+        GROUP_VARIANTS = MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS
+
         # @param name [String] Account name
         # @param account_type [String] Account type label (e.g., "Distributor", "Studio")
         # @param account_type_color [Symbol] Badge color :primary, :success, :danger, :warning, :info, :secondary (default: :primary)
@@ -118,18 +120,24 @@ module MpiDesignSystem
           "border: none; border-top: 1px solid #DEE2E6; margin: 16px 0;"
         end
 
-        def tag_group_chip_styles(group_sym)
-          colors = MpiDesignSystem::Admin::TagChip::Component::GROUPS[group_sym] || { color: "#64748B", bg: "#F1F5F9" }
+        # Colour comes from the shared group -> semantic mapping and re-resolves under
+        # `data-bs-theme`; an unknown group falls back to `secondary` (matching the
+        # frozen #64748B/#F1F5F9 pair this replaced, which ISS#142 measured at 4.34:1).
+        # `border-radius: 999px` -> `rounded-pill`, `display: inline-flex` /
+        # `align-items: center` / `gap: 4px` -> their utility equivalents. (#168)
+        def tag_group_chip_classes(group_sym)
+          variant = GROUP_VARIANTS[group_sym] || :secondary
+          "rounded-pill d-inline-flex align-items-center gap-1 " \
+            "bg-#{variant}-subtle text-#{variant}-emphasis"
+        end
+
+        # Geometry only — the 3px/10px padding, 12px size and 500 weight have no
+        # Bootstrap equivalent and stay inline deliberately. (#168)
+        def tag_group_chip_styles
           [
-            "display: inline-flex",
-            "align-items: center",
-            "gap: 4px",
             "padding: 3px 10px",
-            "border-radius: 999px",
             "font-size: 12px",
-            "font-weight: 500",
-            "color: #{colors[:color]}",
-            "background: #{colors[:bg]}"
+            "font-weight: 500"
           ].join("; ")
         end
 

--- a/app/components/mpi_design_system/admin/account_list_row/component.html.erb
+++ b/app/components/mpi_design_system/admin/account_list_row/component.html.erb
@@ -29,8 +29,8 @@
       <div class="d-flex flex-wrap gap-2">
         <% @tags.each do |tag| %>
           <span class="d-inline-flex align-items-center gap-1">
-            <span style="<%= tag_dot_style(tag[:group]) %>" aria-hidden="true"></span>
-            <span style="<%= tag_text_styles %>"><%= tag[:role] %></span>
+            <span class="<%= tag_dot_class(tag[:group]) %>" style="<%= tag_dot_style %>" aria-hidden="true"></span>
+            <span class="text-body" style="<%= tag_text_styles %>"><%= tag[:role] %></span>
           </span>
         <% end %>
       </div>

--- a/app/components/mpi_design_system/admin/account_list_row/component.rb
+++ b/app/components/mpi_design_system/admin/account_list_row/component.rb
@@ -10,7 +10,9 @@ module MpiDesignSystem
           cold: { color: "#DC3545", label: "Cold" }
         }.freeze
 
-        TAG_DOT_COLORS = MpiDesignSystem::Admin::TagChip::Component::GROUPS.transform_values { |v| v[:color] }.freeze
+        # Replaces the local TAG_DOT_COLORS hex map (derived from the frozen GROUPS
+        # palette) with the shared group -> semantic mapping. (#168)
+        GROUP_VARIANTS = MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS
 
         # @param name [String] Account/company name
         # @param type_label [String] Account type badge text (e.g., "Distributor", "Studio")
@@ -54,13 +56,26 @@ module MpiDesignSystem
           "font-size: 13px; color: #6C757D;"
         end
 
-        def tag_dot_style(group)
-          color = TAG_DOT_COLORS[group] || "#64748B"
-          "width: 6px; height: 6px; border-radius: 50%; background: #{color}; display: inline-block;"
+        # Decorative identity dot on the row surface (not inside a `-subtle` chip),
+        # so it keeps the solid `bg-#{variant}` treatment DataTable's browser spec
+        # already proves >=3:1 on both resting backdrops — a fixed hue across colour
+        # modes by design, with the adjacent label carrying the meaning (WCAG 2.1
+        # SC 1.4.11). An unknown group falls back to `secondary`. (#151, #168)
+        def tag_dot_class(group)
+          "d-inline-block bg-#{GROUP_VARIANTS[group] || :secondary}"
         end
 
+        # Geometry only. (#168)
+        def tag_dot_style
+          "width: 6px; height: 6px; border-radius: 50%;"
+        end
+
+        # The label beside the decorative dot IS the category's accessible carrier,
+        # so it must stay readable in both colour modes — the frozen #1B2A4A navy it
+        # used to paint measures 1.09:1 on Bootstrap's dark surface. `text-body` in
+        # the template. (#168)
         def tag_text_styles
-          "font-size: 13px; font-weight: 500; color: #1B2A4A;"
+          "font-size: 13px; font-weight: 500;"
         end
 
         def health_dot_style

--- a/app/components/mpi_design_system/admin/badge/component.html.erb
+++ b/app/components/mpi_design_system/admin/badge/component.html.erb
@@ -1,3 +1,3 @@
-<span class="<%= css_classes %>"<% if tag_group_styles %> style="<%= tag_group_styles %>"<% end %><% if @count %> aria-label="<%= @label %>: <%= @count %>"<% end %>>
+<span class="<%= css_classes %>"<% if @count %> aria-label="<%= @label %>: <%= @count %>"<% end %>>
   <%= display_text %>
 </span>

--- a/app/components/mpi_design_system/admin/badge/component.rb
+++ b/app/components/mpi_design_system/admin/badge/component.rb
@@ -8,15 +8,11 @@ module MpiDesignSystem
         VARIANTS = %i[filled outline tag_group].freeze
         SIZES = %i[sm md lg].freeze
 
-        TAG_GROUPS = {
-          production: { color: "#6366F1", bg: "#EEEFFE" },
-          distribution: { color: "#E8733A", bg: "#FEF3EC" },
-          finance: { color: "#D97706", bg: "#FEF9EC" },
-          press_festival: { color: "#2E75B6", bg: "#EBF3FB" },
-          internal: { color: "#64748B", bg: "#F1F5F9" },
-          vendors: { color: "#8B5CF6", bg: "#F3EFFE" },
-          outreach: { color: "#2DA67E", bg: "#ECF8F4" }
-        }.freeze
+        # Replaces the retired `TAG_GROUPS` hex map — a byte-identical duplicate of
+        # `TagChip::Component::GROUPS` that drifted independently. Reading the shared
+        # mapping means a category renders one adaptive hue here and in every other
+        # tag renderer. (#168)
+        GROUP_VARIANTS = MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS
 
         # @param label [String] Badge text
         # @param color [Symbol] :primary, :success, :danger, :warning, :info, :secondary
@@ -50,8 +46,20 @@ module MpiDesignSystem
           when :outline
             [ "border", "border-#{@color}", "text-#{@color}", "bg-transparent" ]
           when :tag_group
-            [] # Handled by inline styles
+            tag_group_classes
           end
+        end
+
+        # An unknown (or absent) `tag_group:` deliberately renders an UNSTYLED badge —
+        # the exact behaviour the retired `tag_group_styles` had when it returned nil
+        # and the template omitted the `style` attribute entirely. Preserved rather
+        # than defaulting to `secondary`, so the conversion changes colour source
+        # without changing which inputs produce a styled badge. (#168)
+        def tag_group_classes
+          variant = GROUP_VARIANTS[@tag_group]
+          return [] unless variant
+
+          [ "bg-#{variant}-subtle", "text-#{variant}-emphasis" ]
         end
 
         def size_class
@@ -59,15 +67,6 @@ module MpiDesignSystem
           when :sm then "fs-6"
           when :lg then "fs-6 px-3 py-1"
           end
-        end
-
-        def tag_group_styles
-          return unless @variant == :tag_group && @tag_group
-
-          group = TAG_GROUPS[@tag_group]
-          return unless group
-
-          "color: #{group[:color]}; background-color: #{group[:bg]};"
         end
 
         def display_text

--- a/app/components/mpi_design_system/admin/contact_card/component.html.erb
+++ b/app/components/mpi_design_system/admin/contact_card/component.html.erb
@@ -11,7 +11,7 @@
   <% if @tags.any? %>
     <div class="d-flex flex-wrap gap-1 mb-2">
       <% @tags.each do |tag| %>
-        <span style="<%= tag_pill_styles(tag) %>">
+        <span class="<%= tag_pill_classes(tag) %>" style="<%= tag_pill_styles(tag) %>">
           <span style="<%= tag_dot_styles(tag) %>" aria-hidden="true"></span>
           <%= tag[:label] %>
         </span>

--- a/app/components/mpi_design_system/admin/contact_card/component.rb
+++ b/app/components/mpi_design_system/admin/contact_card/component.rb
@@ -88,9 +88,15 @@ module MpiDesignSystem
           # Each half falls back independently, exactly as `resolve_color`/
           # `resolve_bg` did, so a caller supplying only one keeps the other's
           # historical default.
+          # `presence ||`, not a bare `||`. An empty string is truthy in Ruby, so the
+          # retired helpers emitted the invalid declaration `color: ;` for a blank value —
+          # and using `present?` in `custom_tag?` alone did not fix the MIXED case
+          # (`{ color: "", bg_color: "#654321" }` still took the custom branch and
+          # emitted the empty half). Both halves now fall back independently on BLANK,
+          # not merely on nil.
           geometry.push(
-            "color: #{tag[:color] || '#64748B'}",
-            "background-color: #{tag[:bg_color] || '#F1F5F9'}"
+            "color: #{tag[:color].presence || '#64748B'}",
+            "background-color: #{tag[:bg_color].presence || '#F1F5F9'}"
           ).join("; ")
         end
 

--- a/app/components/mpi_design_system/admin/contact_card/component.rb
+++ b/app/components/mpi_design_system/admin/contact_card/component.rb
@@ -56,6 +56,11 @@ module MpiDesignSystem
           GROUP_VARIANTS[tag[:group]]
         end
 
+        # `present?`, not a bare truthiness check, is one DELIBERATE difference from the
+        # retired `resolve_color`/`resolve_bg`. Those used `tag[:color] || default`, and an
+        # empty string is truthy in Ruby — so `color: ""` was treated as supplied and
+        # emitted the invalid declaration `color: ;`. A blank value now falls through to
+        # the semantic pair instead. Every non-blank value behaves exactly as before.
         def custom_tag?(tag)
           tag_variant(tag).nil? && (tag[:color].present? || tag[:bg_color].present?)
         end

--- a/app/components/mpi_design_system/admin/contact_card/component.rb
+++ b/app/components/mpi_design_system/admin/contact_card/component.rb
@@ -4,6 +4,8 @@ module MpiDesignSystem
   module Admin
     module ContactCard
       class Component < ViewComponent::Base
+        GROUP_VARIANTS = MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS
+
         # @param name [String] Contact full name
         # @param company [String] Company/organization name
         # @param tags [Array<Hash>] Each: { label: String, group: Symbol } or { label: String, color: String, bg_color: String }
@@ -45,51 +47,65 @@ module MpiDesignSystem
           "font-size: 13px; color: #6C757D;"
         end
 
-        def tag_pill_styles(tag)
-          color = resolve_color(tag)
-          bg = resolve_bg(tag)
-          [
-            "display: inline-flex",
-            "align-items: center",
-            "gap: 4px",
-            "padding: 2px 8px",
-            "border-radius: 999px",
-            "font-size: 11px",
-            "font-weight: 500",
-            "color: #{color}",
-            "background-color: #{bg}"
-          ].join("; ")
+        # A tag carrying caller-supplied colour is a deliberate consumer-owned
+        # passthrough (the ISS#172 principle: the design system does not own
+        # app-supplied values), so it keeps its exact inline hex. A known group, and
+        # the no-group/no-custom default, both render the adaptive semantic pair.
+        # A known group wins over custom colours, preserving today's precedence.
+        def tag_variant(tag)
+          GROUP_VARIANTS[tag[:group]]
         end
 
-        def tag_dot_styles(tag)
-          color = resolve_color(tag)
+        def custom_tag?(tag)
+          tag_variant(tag).nil? && (tag[:color].present? || tag[:bg_color].present?)
+        end
+
+        # `border-radius: 999px` -> `rounded-pill`; `display: inline-flex` /
+        # `align-items: center` / `gap: 4px` -> `d-inline-flex align-items-center
+        # gap-1` (matching TagChip's markup); colour -> the semantic pair.
+        #
+        # The no-group/no-custom fallback is now `secondary`, NOT the frozen
+        # #64748B on #F1F5F9 it used to paint — ISS#142 measured that pair at
+        # 4.34:1, below the AA floor. Only genuinely caller-supplied colour stays
+        # inline. (#168)
+        def tag_pill_classes(tag)
+          base = "rounded-pill d-inline-flex align-items-center gap-1"
+          return base if custom_tag?(tag)
+
+          variant = tag_variant(tag) || :secondary
+          "#{base} bg-#{variant}-subtle text-#{variant}-emphasis"
+        end
+
+        def tag_pill_styles(tag)
+          geometry = [ "padding: 2px 8px", "font-size: 11px", "font-weight: 500" ]
+          return geometry.join("; ") unless custom_tag?(tag)
+
+          # Each half falls back independently, exactly as `resolve_color`/
+          # `resolve_bg` did, so a caller supplying only one keeps the other's
+          # historical default.
+          geometry.push(
+            "color: #{tag[:color] || '#64748B'}",
+            "background-color: #{tag[:bg_color] || '#F1F5F9'}"
+          ).join("; ")
+        end
+
+        # Geometry only. `currentColor` inherits whatever the pill paints — the
+        # `-emphasis` foreground for a semantic tag, the caller's own colour for a
+        # custom one — so the dot needs no branch and can never contradict its pill.
+        # It also cannot repeat the solid-on-subtle contrast failure a `bg-#{variant}`
+        # fill would produce inside a `-subtle` pill (2.62:1-2.67:1). (#168)
+        def tag_dot_styles(_tag)
           [
             "width: 6px",
             "height: 6px",
             "border-radius: 50%",
-            "background-color: #{color}",
+            "background-color: currentColor",
             "flex-shrink: 0"
           ].join("; ")
         end
 
         def meta_styles
           "font-size: 11px; color: #ADB5BD;"
-        end
-
-        def resolve_color(tag)
-          if tag[:group] && MpiDesignSystem::Admin::TagChip::Component::GROUPS[tag[:group]]
-            MpiDesignSystem::Admin::TagChip::Component::GROUPS[tag[:group]][:color]
-          else
-            tag[:color] || "#64748B"
-          end
-        end
-
-        def resolve_bg(tag)
-          if tag[:group] && MpiDesignSystem::Admin::TagChip::Component::GROUPS[tag[:group]]
-            MpiDesignSystem::Admin::TagChip::Component::GROUPS[tag[:group]][:bg]
-          else
-            tag[:bg_color] || "#F1F5F9"
-          end
         end
       end
     end

--- a/app/components/mpi_design_system/admin/contact_detail_panel/component.html.erb
+++ b/app/components/mpi_design_system/admin/contact_detail_panel/component.html.erb
@@ -88,7 +88,7 @@
     <div style="<%= section_heading_styles %>">Groups (Auto)</div>
     <div class="d-flex flex-wrap gap-1">
       <% @auto_groups.each do |group| %>
-        <span style="<%= group_pill_styles(group[:group]) %>"><%= group[:label] %></span>
+        <span class="<%= group_pill_classes(group[:group]) %>" style="<%= group_pill_styles %>"><%= group[:label] %></span>
       <% end %>
     </div>
   <% end %>

--- a/app/components/mpi_design_system/admin/contact_detail_panel/component.rb
+++ b/app/components/mpi_design_system/admin/contact_detail_panel/component.rb
@@ -4,6 +4,8 @@ module MpiDesignSystem
   module Admin
     module ContactDetailPanel
       class Component < ViewComponent::Base
+        GROUP_VARIANTS = MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS
+
         # @param name [String] Contact full name
         # @param title [String] Contact job title
         # @param company [String] Company/organization name
@@ -97,17 +99,21 @@ module MpiDesignSystem
           "border: none; border-top: 1px solid #DEE2E6; margin: 16px 0;"
         end
 
-        def group_pill_styles(group_sym)
-          groups = MpiDesignSystem::Admin::TagChip::Component::GROUPS
-          config = groups[group_sym] || groups[:internal]
+        # Covers the auto-groups pills only — this panel's `@tags` render through a
+        # nested `TagChip::Component`, which carries its own conversion. An unknown
+        # group falls back to `secondary`, the semantic equivalent of the `:internal`
+        # pair this previously fell back to. (#168)
+        def group_pill_classes(group_sym)
+          variant = GROUP_VARIANTS[group_sym] || :secondary
+          "rounded-pill d-inline-block bg-#{variant}-subtle text-#{variant}-emphasis"
+        end
+
+        # Geometry only. (#168)
+        def group_pill_styles
           [
-            "display: inline-block",
             "padding: 2px 8px",
-            "border-radius: 999px",
             "font-size: 11px",
-            "font-weight: 500",
-            "color: #{config[:color]}",
-            "background-color: #{config[:bg]}"
+            "font-weight: 500"
           ].join("; ")
         end
 

--- a/app/components/mpi_design_system/admin/contact_list_row/component.html.erb
+++ b/app/components/mpi_design_system/admin/contact_list_row/component.html.erb
@@ -15,8 +15,8 @@
       <div class="d-flex flex-wrap gap-2">
         <% @tags.each do |tag| %>
           <span class="d-inline-flex align-items-center gap-1">
-            <span style="<%= tag_dot_style(tag[:group]) %>" aria-hidden="true"></span>
-            <span style="<%= tag_text_styles %>"><%= tag[:role] %></span>
+            <span class="<%= tag_dot_class(tag[:group]) %>" style="<%= tag_dot_style %>" aria-hidden="true"></span>
+            <span class="text-body" style="<%= tag_text_styles %>"><%= tag[:role] %></span>
           </span>
         <% end %>
       </div>

--- a/app/components/mpi_design_system/admin/contact_list_row/component.rb
+++ b/app/components/mpi_design_system/admin/contact_list_row/component.rb
@@ -6,7 +6,9 @@ module MpiDesignSystem
       class Component < ViewComponent::Base
         VARIANTS = %i[default search_result].freeze
 
-        TAG_DOT_COLORS = MpiDesignSystem::Admin::TagChip::Component::GROUPS.transform_values { |v| v[:color] }.freeze
+        # Replaces the local TAG_DOT_COLORS hex map (derived from the frozen GROUPS
+        # palette) with the shared group -> semantic mapping. (#168)
+        GROUP_VARIANTS = MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS
 
         STATUSES = %i[active inactive].freeze
 
@@ -42,13 +44,26 @@ module MpiDesignSystem
           "font-size: 12px; color: #6C757D;"
         end
 
-        def tag_dot_style(group)
-          color = TAG_DOT_COLORS[group] || "#64748B"
-          "width: 6px; height: 6px; border-radius: 50%; background: #{color}; display: inline-block;"
+        # Decorative identity dot on the row surface (not inside a `-subtle` chip),
+        # so it keeps the solid `bg-#{variant}` treatment DataTable's browser spec
+        # already proves >=3:1 on both resting backdrops — a fixed hue across colour
+        # modes by design, with the adjacent label carrying the meaning (WCAG 2.1
+        # SC 1.4.11). An unknown group falls back to `secondary`. (#151, #168)
+        def tag_dot_class(group)
+          "d-inline-block bg-#{GROUP_VARIANTS[group] || :secondary}"
         end
 
+        # Geometry only. (#168)
+        def tag_dot_style
+          "width: 6px; height: 6px; border-radius: 50%;"
+        end
+
+        # The label beside the decorative dot IS the category's accessible carrier,
+        # so it must stay readable in both colour modes — the frozen #1B2A4A navy it
+        # used to paint measures 1.09:1 on Bootstrap's dark surface. `text-body` in
+        # the template. (#168)
         def tag_text_styles
-          "font-size: 13px; font-weight: 500; color: #1B2A4A;"
+          "font-size: 13px; font-weight: 500;"
         end
 
         def meta_text_styles

--- a/app/components/mpi_design_system/admin/engagement_card/component.html.erb
+++ b/app/components/mpi_design_system/admin/engagement_card/component.html.erb
@@ -49,8 +49,8 @@
           <div class="mb-1">
             <% @tags.each do |tag| %>
               <span class="d-inline-flex align-items-center gap-1">
-                <span style="<%= tag_dot_style(tag) %>" aria-hidden="true"></span>
-                <span style="<%= tag_text_styles %>"><%= tag[:role] %></span>
+                <span class="<%= tag_dot_class(tag) %>" style="<%= tag_dot_style %>" aria-hidden="true"></span>
+                <span class="text-body" style="<%= tag_text_styles %>"><%= tag[:role] %></span>
               </span>
             <% end %>
           </div>

--- a/app/components/mpi_design_system/admin/engagement_card/component.html.erb
+++ b/app/components/mpi_design_system/admin/engagement_card/component.html.erb
@@ -50,7 +50,7 @@
             <% @tags.each do |tag| %>
               <span class="d-inline-flex align-items-center gap-1">
                 <span class="<%= tag_dot_class(tag) %>" style="<%= tag_dot_style %>" aria-hidden="true"></span>
-                <span class="text-body" style="<%= tag_text_styles %>"><%= tag[:role] %></span>
+                <span style="<%= tag_text_styles %>"><%= tag[:role] %></span>
               </span>
             <% end %>
           </div>

--- a/app/components/mpi_design_system/admin/engagement_card/component.rb
+++ b/app/components/mpi_design_system/admin/engagement_card/component.rb
@@ -4,6 +4,8 @@ module MpiDesignSystem
   module Admin
     module EngagementCard
       class Component < ViewComponent::Base
+        GROUP_VARIANTS = MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS
+
         TYPES = %i[email meeting call note].freeze
 
         TYPE_COLORS = {
@@ -122,13 +124,27 @@ module MpiDesignSystem
           "font-size: 12px; color: #6C757D;"
         end
 
-        def tag_dot_style(tag)
-          color = MpiDesignSystem::Admin::TagChip::Component::GROUPS.dig(tag[:group], :color) || "#64748B"
-          "width: 6px; height: 6px; border-radius: 50%; background: #{color}; display: inline-block;"
+        # Decorative identity dot on the card's own surface — NOT inside a `-subtle`
+        # chip — so it keeps the solid `bg-#{variant}` treatment DataTable's browser
+        # spec already proves >=3:1 on both resting backdrops. `bg-#{variant}` reads
+        # `--bs-#{variant}-rgb`, a fixed hue across colour modes; that is the
+        # documented exception, and the adjacent text label carries the meaning
+        # (WCAG 2.1 SC 1.4.11). An unknown group falls back to `secondary`. (#151, #168)
+        def tag_dot_class(tag)
+          "d-inline-block bg-#{GROUP_VARIANTS[tag[:group]] || :secondary}"
         end
 
+        # Geometry only. (#168)
+        def tag_dot_style
+          "width: 6px; height: 6px; border-radius: 50%;"
+        end
+
+        # The label beside the decorative dot IS the category's accessible carrier, so
+        # it must stay readable in both colour modes — the frozen #1B2A4A navy it used
+        # to paint measures 1.09:1 on Bootstrap's dark surface. `text-body` in the
+        # template. (#168)
         def tag_text_styles
-          "font-size: 12px; color: #1B2A4A;"
+          "font-size: 12px;"
         end
 
         def title_link_styles

--- a/app/components/mpi_design_system/admin/engagement_card/component.rb
+++ b/app/components/mpi_design_system/admin/engagement_card/component.rb
@@ -139,12 +139,16 @@ module MpiDesignSystem
           "width: 6px; height: 6px; border-radius: 50%;"
         end
 
-        # The label beside the decorative dot IS the category's accessible carrier, so
-        # it must stay readable in both colour modes — the frozen #1B2A4A navy it used
-        # to paint measures 1.09:1 on Bootstrap's dark surface. `text-body` in the
-        # template. (#168)
+        # Keeps the frozen navy DELIBERATELY, unlike the list rows' equivalent label.
+        # This card paints its own hardcoded `background: #fff` (`card_styles`), so the
+        # label sits on a fixed white surface in BOTH colour modes: navy measures
+        # 14.22:1 there, while an adaptive `text-body` would resolve to #DEE2E6 in dark
+        # mode and paint 1.30:1 on that same white card — a regression, not a fix.
+        # `text-body` is correct only where the surface adapts too (AccountListRow /
+        # ContactListRow inherit the page background and have no card of their own).
+        # Converting this card to `bg-body` is ISS#142 §3 work. (#168)
         def tag_text_styles
-          "font-size: 12px;"
+          "font-size: 12px; color: #1B2A4A;"
         end
 
         def title_link_styles

--- a/app/components/mpi_design_system/admin/filter_chip_bar/component.rb
+++ b/app/components/mpi_design_system/admin/filter_chip_bar/component.rb
@@ -4,7 +4,6 @@ module MpiDesignSystem
   module Admin
     module FilterChipBar
       class Component < ViewComponent::Base
-        GROUPS = MpiDesignSystem::Admin::TagChip::Component::GROUPS
         GROUP_VARIANTS = MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS
 
         # @param groups [Array<Hash>] Group chip data:

--- a/app/components/mpi_design_system/admin/tag_chip/component.html.erb
+++ b/app/components/mpi_design_system/admin/tag_chip/component.html.erb
@@ -1,12 +1,13 @@
-<span class="d-inline-flex align-items-center gap-1 fw-semibold" style="<%= chip_styles %>">
+<span class="d-inline-flex align-items-center gap-1 fw-semibold <%= chip_classes %>" style="<%= chip_styles %>">
   <span style="<%= dot_styles %>" aria-hidden="true"></span>
   <%= @label %>
   <% if @removable && @remove_url %>
-    <%= link_to @remove_url, style: remove_button_styles, aria: { label: "Remove #{@label}" }, data: { turbo_method: "delete", turbo_confirm: "Remove this tag?" } do %>
+    <%= link_to @remove_url, class: "text-reset bg-transparent border-0", style: remove_button_styles, aria: { label: "Remove #{@label}" }, data: { turbo_method: "delete", turbo_confirm: "Remove this tag?" } do %>
       <i class="bi bi-x-lg" aria-hidden="true"></i>
     <% end %>
   <% elsif @removable %>
     <button type="button"
+            class="text-reset bg-transparent border-0"
             style="<%= remove_button_styles %>"
             aria-label="Remove <%= @label %>">
       <i class="bi bi-x-lg" aria-hidden="true"></i>

--- a/app/components/mpi_design_system/admin/tag_chip/component.rb
+++ b/app/components/mpi_design_system/admin/tag_chip/component.rb
@@ -4,6 +4,15 @@ module MpiDesignSystem
   module Admin
     module TagChip
       class Component < ViewComponent::Base
+        # DEPRECATED FOR RENDERING (#168). No component paints from this map any more —
+        # `GROUP_VARIANTS` below is the live mapping. It is retained for two reasons:
+        # it remains the canonical **key set** for the CRM tag vocabulary (this
+        # component validates `group:` against it, and Badge's Lookbook preview
+        # enumerates it), and it documents the original brand hex for designers.
+        #
+        # These pairs are also the palette ISS#142 measured at 2.77:1-4.34:1 — every
+        # one below the WCAG AA floor. That is *why* nothing renders from them now.
+        # Do not reintroduce them as a colour source.
         GROUPS = {
           production: { color: "#6366F1", bg: "#EEEFFE" },
           distribution: { color: "#E8733A", bg: "#FEF3EC" },
@@ -14,20 +23,19 @@ module MpiDesignSystem
           outreach: { color: "#2DA67E", bg: "#ECF8F4" }
         }.freeze
 
-        # Maps each CRM tag group onto a Bootstrap semantic colour so consumers that
-        # want a theme-adaptive chip (FilterChipBar's selected chip, DataTable's tag
-        # dots) resolve their colour from `--bs-*` rather than the frozen hex above.
-        # This is the single source of truth for that mapping — every key in GROUPS
-        # has an entry (asserted in the spec).
+        # Maps each CRM tag group onto a Bootstrap semantic colour, so a category
+        # resolves from `--bs-*` and tracks `data-bs-theme`. This is the single source
+        # of truth for that mapping — every key in GROUPS has an entry (asserted in
+        # the spec) — and since #168 **every** engine renderer of tag-group colour
+        # reads it: this component, Badge's `:tag_group` variant, the contact/
+        # engagement cards, both list rows, both detail panels, TagInput (server and
+        # its Stimulus controller), FilterChipBar and DataTable.
         #
         # MPI maps `$info` -> `$primary` (`_tokens_values.scss`), so `info` would
         # render the same blue as `primary`; the palette therefore offers five
         # distinct adaptive hues, and the three cool categories collapse onto
         # `primary` (blue). This is an accepted trade of Option A (#151) — the tag's
-        # always-present text label carries the identity, not the hue alone. The
-        # remaining `GROUPS` consumers (TagChip's own rendering, contact/engagement
-        # cards, list rows, detail panels) still render the frozen hex this phase;
-        # unifying them is the tracked #151 follow-up.
+        # always-present text label carries the identity, not the hue alone.
         GROUP_VARIANTS = {
           press_festival: :primary,
           production: :primary,
@@ -53,37 +61,55 @@ module MpiDesignSystem
 
         private
 
-        def colors
-          GROUPS[@group]
+        def variant
+          GROUP_VARIANTS[@group] || :secondary
         end
 
+        # The chip's surface and foreground come from the semantic `-subtle`/
+        # `-emphasis` pair, which Bootstrap derives to clear AA in both colour modes
+        # (measured 9.34:1-9.43:1 in light) and which re-resolves under
+        # `data-bs-theme`. Replaces the frozen brand-hex pair that ISS#142 measured
+        # below the AA floor. (#168)
+        def chip_classes
+          "rounded-pill bg-#{variant}-subtle text-#{variant}-emphasis"
+        end
+
+        # Geometry only. `border-radius: 999px` moved to `rounded-pill`; colour moved
+        # to `chip_classes`. The em padding, per-size font-size and line-height have
+        # no Bootstrap equivalent and stay inline deliberately. (#168)
         def chip_styles
           [
-            "color: #{colors[:color]}",
-            "background-color: #{colors[:bg]}",
             "font-size: #{@size == :sm ? '12px' : '13px'}",
             "padding: 0.25em 0.75em",
-            "border-radius: 999px",
             "line-height: 1.4"
           ].join("; ")
         end
 
+        # `currentColor` — NOT a solid `bg-#{variant}` like DataTable's dots. This dot
+        # sits INSIDE the `-subtle` chip, and a solid semantic fill on its own subtle
+        # surface measures 2.67:1 (success) / 2.62:1 (warning) — below the 3:1 floor
+        # `.claude/rules/frontend.md` requires for a decorative semantic dot. Painting
+        # `currentColor` inherits the chip's `-emphasis` foreground instead (9.43:1 /
+        # 9.34:1), is adaptive by construction, and needs no second token. Dots on a
+        # plain card/row backdrop keep the solid `bg-#{variant}` treatment, where the
+        # DataTable browser spec already proves >=3:1. (#168)
         def dot_styles
           [
             "width: 8px",
             "height: 8px",
             "border-radius: 50%",
-            "background-color: #{colors[:color]}",
+            "background-color: currentColor",
             "flex-shrink: 0"
           ].join("; ")
         end
 
+        # Geometry only. Colour, background and border come from
+        # `text-reset bg-transparent border-0` in the template, so the button inherits
+        # the chip's `-emphasis` foreground and pins nothing of its own. The retired
+        # `opacity: 0.6` faded an already-sub-AA foreground further — the same defect
+        # #130 removed from FilterChipBar at 0.8. (#130, #168)
         def remove_button_styles
           [
-            "color: #{colors[:color]}",
-            "opacity: 0.6",
-            "background: none",
-            "border: none",
             "padding: 0",
             "font-size: inherit",
             "line-height: 1",

--- a/app/components/mpi_design_system/admin/tag_input/component.html.erb
+++ b/app/components/mpi_design_system/admin/tag_input/component.html.erb
@@ -9,14 +9,15 @@
     <%# Selected tags rendered as styled chips matching TagChip appearance %>
     <div class="d-flex flex-wrap gap-1 mb-1" data-mpi--tag-input-target="selectedTags">
       <% @selected_tags.each do |tag| %>
-        <span class="d-inline-flex align-items-center gap-1 fw-semibold"
-              style="color: <%= tag_color(tag[:group]) %>; background-color: <%= tag_bg(tag[:group]) %>; font-size: 13px; padding: 0.25em 0.75em; border-radius: 999px; line-height: 1.4;"
+        <span class="d-inline-flex align-items-center gap-1 fw-semibold <%= tag_chip_classes(tag[:group]) %>"
+              style="<%= tag_chip_styles %>"
               data-mpi--tag-input-target="tag"
               data-tag-label="<%= tag[:label] %>"
               data-tag-group="<%= tag[:group] %>">
           <%= tag[:label] %>
           <button type="button"
-                  style="color: <%= tag_color(tag[:group]) %>; opacity: 0.6; background: none; border: none; padding: 0; font-size: inherit; line-height: 1; cursor: pointer;"
+                  class="text-reset bg-transparent border-0"
+                  style="<%= tag_remove_button_styles %>"
                   aria-label="Remove <%= tag[:label] %>"
                   data-action="mpi--tag-input#removeTag">
             <i class="bi bi-x-lg" aria-hidden="true"></i>
@@ -50,7 +51,7 @@
       <div style="<%= section_heading_styles %>">Auto-Derived Groups</div>
       <div class="d-flex flex-wrap gap-1">
         <% derived_groups.each do |group_sym| %>
-          <span style="<%= derived_group_styles(group_sym) %>"><%= derived_group_label(group_sym) %></span>
+          <span class="<%= derived_group_classes(group_sym) %>" style="<%= derived_group_styles %>"><%= derived_group_label(group_sym) %></span>
         <% end %>
       </div>
     </div>

--- a/app/components/mpi_design_system/admin/tag_input/component.rb
+++ b/app/components/mpi_design_system/admin/tag_input/component.rb
@@ -4,6 +4,8 @@ module MpiDesignSystem
   module Admin
     module TagInput
       class Component < ViewComponent::Base
+        GROUP_VARIANTS = MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS
+
         # @param available_tags [Array<Hash>] Each: { label: String, group: Symbol }
         # @param selected_tags [Array<Hash>] Each: { label: String, group: Symbol }
         # @param name [String] Form field name for hidden inputs (default: "tags[]")
@@ -58,16 +60,36 @@ module MpiDesignSystem
           @available_tags.map { |t| { label: t[:label], group: t[:group].to_s } }.to_json
         end
 
-        def tag_color(group_sym)
-          groups = MpiDesignSystem::Admin::TagChip::Component::GROUPS
-          config = groups[group_sym] || groups[:internal]
-          config[:color]
+        # Mirrors `TagChip`'s own chip treatment, so a tag looks identical whether it
+        # is rendered here or by the component. An unknown group falls back to
+        # `secondary`, the semantic equivalent of the `:internal` pair this replaced.
+        # The Stimulus controller emits the same classes for chips added after load —
+        # keep the two in step. (#168)
+        def tag_chip_classes(group_sym)
+          variant = GROUP_VARIANTS[group_sym] || :secondary
+          "rounded-pill bg-#{variant}-subtle text-#{variant}-emphasis"
         end
 
-        def tag_bg(group_sym)
-          groups = MpiDesignSystem::Admin::TagChip::Component::GROUPS
-          config = groups[group_sym] || groups[:internal]
-          config[:bg]
+        # Geometry only, matching `TagChip#chip_styles`. (#168)
+        def tag_chip_styles
+          [
+            "font-size: 13px",
+            "padding: 0.25em 0.75em",
+            "line-height: 1.4"
+          ].join("; ")
+        end
+
+        # Geometry only. Colour/background/border come from
+        # `text-reset bg-transparent border-0`, so the button inherits the chip's
+        # `-emphasis` foreground. The retired `opacity: 0.6` faded an already-sub-AA
+        # foreground further. (#130, #168)
+        def tag_remove_button_styles
+          [
+            "padding: 0",
+            "font-size: inherit",
+            "line-height: 1",
+            "cursor: pointer"
+          ].join("; ")
         end
 
         def derived_groups
@@ -82,17 +104,17 @@ module MpiDesignSystem
           group_sym.to_s.tr("_", " ").split.map(&:capitalize).join(" ")
         end
 
-        def derived_group_styles(group_sym)
-          groups = MpiDesignSystem::Admin::TagChip::Component::GROUPS
-          config = groups[group_sym] || groups[:internal]
+        def derived_group_classes(group_sym)
+          variant = GROUP_VARIANTS[group_sym] || :secondary
+          "rounded-pill d-inline-block bg-#{variant}-subtle text-#{variant}-emphasis"
+        end
+
+        # Geometry only. (#168)
+        def derived_group_styles
           [
-            "display: inline-block",
             "padding: 2px 8px",
-            "border-radius: 999px",
             "font-size: 11px",
-            "font-weight: 500",
-            "color: #{config[:color]}",
-            "background-color: #{config[:bg]}"
+            "font-weight: 500"
           ].join("; ")
         end
 

--- a/app/javascript/mpi_design_system/controllers/tag_input_controller.js
+++ b/app/javascript/mpi_design_system/controllers/tag_input_controller.js
@@ -1,14 +1,29 @@
 import { Controller } from "@hotwired/stimulus"
 
-const GROUP_COLORS = {
-  buyers: { color: "#E8733A", bg: "#FEF3EC" },
-  press: { color: "#2DA67E", bg: "#ECF8F4" },
-  festivals: { color: "#2E75B6", bg: "#EBF3FB" },
-  sellers: { color: "#8B5CF6", bg: "#F3EFFE" },
-  institutional: { color: "#D97706", bg: "#FEF9EC" },
-  organizations: { color: "#6366F1", bg: "#EEEFFE" },
-  internal: { color: "#64748B", bg: "#F1F5F9" }
+// Mirror of `TagChip::Component::GROUP_VARIANTS` (Ruby cannot be read from here, so
+// the two must be kept in step — the component spec pins the Ruby side, and the
+// Stimulus feature spec pins what this renders).
+//
+// This REPLACES a frozen hex map keyed on a stale vocabulary — `buyers`, `press`,
+// `festivals`, `sellers`, `institutional`, `organizations` — which never matched the
+// group names the server actually sends via `available_tags_value` (`production`,
+// `distribution`, `finance`, `press_festival`, `internal`, `vendors`, `outreach`).
+// Only `internal` overlapped, so six of the seven groups silently fell through to the
+// grey fallback: a tag added after page load painted grey while the same tag rendered
+// by the server painted its category colour. Keying on the vocabulary the server sends
+// fixes that, and emitting semantic classes keeps interactively-added chips
+// theme-adaptive and AA-clean like their server-rendered counterparts. (#168)
+const GROUP_VARIANTS = {
+  press_festival: "primary",
+  production: "primary",
+  vendors: "primary",
+  outreach: "success",
+  finance: "warning",
+  distribution: "danger",
+  internal: "secondary"
 }
+
+const variantFor = group => GROUP_VARIANTS[group] || "secondary"
 
 export default class extends Controller {
   static targets = ["input", "dropdown", "selectedTags", "wrapper", "tag"]
@@ -142,13 +157,14 @@ export default class extends Controller {
     this.activeIndex = -1
 
     this.dropdownTarget.innerHTML = matches.map(tag => {
-      const colors = GROUP_COLORS[tag.group] || GROUP_COLORS.internal
+      const variant = variantFor(tag.group)
       return `<div role="option"
-                   style="padding: 8px 12px; cursor: pointer; font-size: 13px; color: #1B2A4A;"
+                   class="text-body"
+                   style="padding: 8px 12px; cursor: pointer; font-size: 13px;"
                    data-tag-label="${this.escapeHtml(tag.label)}"
                    data-tag-group="${this.escapeHtml(tag.group)}"
                    data-action="click->mpi--tag-input#onDropdownItemClick mouseover->mpi--tag-input#onDropdownItemHover">
-        <span style="display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: ${colors.color}; margin-right: 8px;"></span>
+        <span class="d-inline-block bg-${variant}" style="width: 8px; height: 8px; border-radius: 50%; margin-right: 8px;"></span>
         ${this.escapeHtml(tag.label)}
       </div>`
     }).join("")
@@ -161,16 +177,23 @@ export default class extends Controller {
     this.selectTag(item.dataset.tagLabel, item.dataset.tagGroup)
   }
 
+  // The active/hover surface resolves from Bootstrap's adaptive tertiary background
+  // rather than the frozen #F5F7FA it used to paint. Converting the option's text to
+  // `text-body` (adaptive) while leaving a fixed LIGHT hover behind it would put
+  // near-white text on a near-white surface in dark mode — so the pair moves
+  // together. (#168)
+  static ACTIVE_SURFACE = "var(--bs-tertiary-bg)"
+
   onDropdownItemHover(event) {
     const items = this.dropdownTarget.querySelectorAll("[role='option']")
     items.forEach(el => el.style.background = "")
-    event.currentTarget.style.background = "#F5F7FA"
+    event.currentTarget.style.background = this.constructor.ACTIVE_SURFACE
     this.activeIndex = Array.from(items).indexOf(event.currentTarget)
   }
 
   highlightItem(items) {
     items.forEach((el, i) => {
-      el.style.background = i === this.activeIndex ? "#F5F7FA" : ""
+      el.style.background = i === this.activeIndex ? this.constructor.ACTIVE_SURFACE : ""
     })
     if (items[this.activeIndex]) {
       items[this.activeIndex].scrollIntoView({ block: "nearest" })
@@ -178,17 +201,20 @@ export default class extends Controller {
   }
 
   addTagChip(label, group) {
-    const colors = GROUP_COLORS[group] || GROUP_COLORS.internal
+    const variant = variantFor(group)
 
     const chip = document.createElement("span")
-    chip.className = "d-inline-flex align-items-center gap-1 fw-semibold"
-    chip.style.cssText = `color: ${colors.color}; background-color: ${colors.bg}; font-size: 13px; padding: 0.25em 0.75em; border-radius: 999px; line-height: 1.4;`
+    // Must match the server-rendered chip in `component.html.erb` exactly, so a tag
+    // added after load is indistinguishable from one present at load. (#168)
+    chip.className = `d-inline-flex align-items-center gap-1 fw-semibold rounded-pill bg-${variant}-subtle text-${variant}-emphasis`
+    chip.style.cssText = "font-size: 13px; padding: 0.25em 0.75em; line-height: 1.4;"
     chip.setAttribute("data-mpi--tag-input-target", "tag")
     chip.dataset.tagLabel = label
     chip.dataset.tagGroup = group
     chip.innerHTML = `${this.escapeHtml(label)}
       <button type="button"
-              style="color: ${colors.color}; opacity: 0.6; background: none; border: none; padding: 0; font-size: inherit; line-height: 1; cursor: pointer;"
+              class="text-reset bg-transparent border-0"
+              style="padding: 0; font-size: inherit; line-height: 1; cursor: pointer;"
               aria-label="Remove ${this.escapeHtml(label)}"
               data-action="mpi--tag-input#removeTag">
         <i class="bi bi-x-lg" aria-hidden="true"></i>

--- a/app/javascript/mpi_design_system/controllers/tag_input_controller.js
+++ b/app/javascript/mpi_design_system/controllers/tag_input_controller.js
@@ -181,12 +181,14 @@ export default class extends Controller {
     this.selectTag(item.dataset.tagLabel, item.dataset.tagGroup)
   }
 
-  // The active/hover surface resolves from Bootstrap's adaptive tertiary background
-  // rather than the frozen #F5F7FA it used to paint. Converting the option's text to
-  // `text-body` (adaptive) while leaving a fixed LIGHT hover behind it would put
-  // near-white text on a near-white surface in dark mode — so the pair moves
-  // together. (#168)
-  static ACTIVE_SURFACE = "var(--bs-tertiary-bg)"
+  // A FIXED light neutral, deliberately — the dropdown panel paints a hardcoded white
+  // background and its option text is frozen navy, so the hover surface has to be frozen
+  // too or the pair desynchronises. An earlier revision made this
+  // `var(--bs-tertiary-bg)`, which resolves to ~#2B3035 in dark mode and left navy text
+  // at 1.07:1 on a hovered option — fixing the resting state while breaking the
+  // interactive one. Navy on this neutral measures 13.25:1. The whole dropdown converts
+  // together, or not at all; doing that is ISS#142 §3. (#168)
+  static ACTIVE_SURFACE = "#F5F7FA"
 
   onDropdownItemHover(event) {
     const items = this.dropdownTarget.querySelectorAll("[role='option']")

--- a/app/javascript/mpi_design_system/controllers/tag_input_controller.js
+++ b/app/javascript/mpi_design_system/controllers/tag_input_controller.js
@@ -158,9 +158,13 @@ export default class extends Controller {
 
     this.dropdownTarget.innerHTML = matches.map(tag => {
       const variant = variantFor(tag.group)
+      // The dropdown panel paints a hardcoded white background (`dropdown_styles`), so
+      // the option keeps the frozen navy: 14.22:1 on that fixed surface in both colour
+      // modes, where an adaptive `text-body` would drop to 1.30:1 in dark mode. The
+      // category DOT below is a solid semantic fill, which is a fixed hue and therefore
+      // safe on white. Converting the panel itself is ISS#142 §3. (#168)
       return `<div role="option"
-                   class="text-body"
-                   style="padding: 8px 12px; cursor: pointer; font-size: 13px;"
+                   style="padding: 8px 12px; cursor: pointer; font-size: 13px; color: #1B2A4A;"
                    data-tag-label="${this.escapeHtml(tag.label)}"
                    data-tag-group="${this.escapeHtml(tag.group)}"
                    data-action="click->mpi--tag-input#onDropdownItemClick mouseover->mpi--tag-input#onDropdownItemHover">

--- a/catalog/components/contact-card.md
+++ b/catalog/components/contact-card.md
@@ -56,15 +56,26 @@ end
 
 ## Tag Group Color Pairs
 
-| Group | Text Color | Background |
+| Group | Semantic | Rendered classes |
 |---|---|---|
-| Buyers | `#E8733A` | `#FEF3EC` |
-| Press | `#2DA67E` | `#ECF8F4` |
-| Festivals | `#2E75B6` | `#EBF3FB` |
-| Sellers | `#8B5CF6` | `#F3EFFE` |
-| Institutional | `#D97706` | `#FEF9EC` |
-| Organizations | `#6366F1` | `#EEEFFE` |
-| Internal | `#64748B` | `#F1F5F9` |
+| Press/Festival | `primary` | `bg-primary-subtle text-primary-emphasis` |
+| Production | `primary` | `bg-primary-subtle text-primary-emphasis` |
+| Vendors | `primary` | `bg-primary-subtle text-primary-emphasis` |
+| Outreach | `success` | `bg-success-subtle text-success-emphasis` |
+| Finance | `warning` | `bg-warning-subtle text-warning-emphasis` |
+| Distribution | `danger` | `bg-danger-subtle text-danger-emphasis` |
+| Internal | `secondary` | `bg-secondary-subtle text-secondary-emphasis` |
+
+Colour resolves from `TagChip::Component::GROUP_VARIANTS` and follows `data-bs-theme`.
+Because MPI maps `$info` → `$primary`, the seven categories collapse onto **five** distinct
+hues; the always-present text label carries the identity. See `catalog/elements/tag-chip.md`
+for the full mapping rationale and the per-surface treatment table. (#168)
+
+> **Naming note.** This table previously listed the groups as Buyers / Press / Festivals /
+> Sellers / Institutional / Organizations — a legacy vocabulary that no component has ever
+> accepted, and which contradicted `badge.md` and `tag-chip.md`. The keys above are the ones
+> `GROUP_VARIANTS` actually validates. The legacy names still appear in the unused
+> `$mpi-tag-*` SCSS tokens and `tokens/colors.md`; reconciling those is tracked in ISS#181.
 
 ## Bootstrap Classes
 
@@ -86,8 +97,15 @@ end
 ## Accessibility
 
 - Entire card is a clickable link (`<a>`) — ensure focus ring is visible
-- Avatar colors meet WCAG AA for white text
-- Tag pill text/background pairs all meet WCAG AA contrast
+- Avatar foregrounds are derived per background by `MpiDesignSystem::ColorContrast`,
+  so each meets WCAG AA. (The earlier "white text on all backgrounds" claim was false —
+  7 of 10 palette colours measured below the floor; fixed in #130.)
+- Tag pills render `bg-{semantic}-subtle` + `text-{semantic}-emphasis` from the shared
+  `GROUP_VARIANTS` map, which Bootstrap derives AA-clean in both colour modes. The
+  earlier claim that the *hex* pairs "all meet WCAG AA contrast" was false — every one
+  measured 2.77:1–4.34:1 (ISS#142 §1), including the no-group default at 4.34:1 (#168)
+- A tag carrying caller-supplied `color:`/`bg_color:` is a deliberate passthrough and is
+  the **caller's** contrast responsibility
 - Metadata text in `#ADB5BD` is supplementary (not critical info), but consider `#6C757D` if contrast is borderline
 
 ## Usage Guidelines

--- a/catalog/elements/badge.md
+++ b/catalog/elements/badge.md
@@ -37,15 +37,20 @@ Pill-shaped badges used for status indicators, counts, and labels across all MPI
 
 ### Tag Group Colors
 
-| Group | Text | Background |
+| Group | Semantic | Rendered classes |
 |---|---|---|
-| Distribution | `#E8733A` | `#FEF3EC` |
-| Outreach | `#2DA67E` | `#ECF8F4` |
-| Press/Festival | `#2E75B6` | `#EBF3FB` |
-| Vendors | `#8B5CF6` | `#F3EFFE` |
-| Finance | `#D97706` | `#FEF9EC` |
-| Production | `#6366F1` | `#EEEFFE` |
-| Internal | `#64748B` | `#F1F5F9` |
+| Press/Festival | `primary` | `bg-primary-subtle text-primary-emphasis` |
+| Production | `primary` | `bg-primary-subtle text-primary-emphasis` |
+| Vendors | `primary` | `bg-primary-subtle text-primary-emphasis` |
+| Outreach | `success` | `bg-success-subtle text-success-emphasis` |
+| Finance | `warning` | `bg-warning-subtle text-warning-emphasis` |
+| Distribution | `danger` | `bg-danger-subtle text-danger-emphasis` |
+| Internal | `secondary` | `bg-secondary-subtle text-secondary-emphasis` |
+
+Colour resolves from `TagChip::Component::GROUP_VARIANTS` and follows `data-bs-theme`.
+Because MPI maps `$info` → `$primary`, the seven categories collapse onto **five** distinct
+hues; the always-present text label carries the identity. See `catalog/elements/tag-chip.md`
+for the full mapping rationale and the per-surface treatment table. (#168)
 
 ## Sizes
 
@@ -91,7 +96,13 @@ end
 - Filled badges derive their foreground via Bootstrap's `text-bg-*` utilities, so every
   semantic color meets WCAG AA automatically (previously `success` paired a hardcoded
   `text-white` for only 3.33:1 — see #128)
-- All tag group color pairs have been verified for WCAG AA compliance
+- The `tag_group` variant renders `bg-{semantic}-subtle` + `text-{semantic}-emphasis`
+  from the shared `TagChip::Component::GROUP_VARIANTS` map, so Bootstrap derives an
+  AA-clean pair per colour mode — browser-measured 9.34:1–10.52:1 light and
+  7.15:1–8.61:1 dark. This replaced Badge's own `TAG_GROUPS` hex duplicate, whose
+  seven pairs all measured **below** the 4.5:1 floor (2.77:1–4.34:1, ISS#142 §1) —
+  the earlier "all verified for WCAG AA" claim here was false (#168)
+- An unknown `tag_group:` renders an unstyled badge rather than guessing a colour
 - Use `aria-label` when badge text alone is insufficient context (e.g., a count badge)
 
 ## Usage Guidelines

--- a/catalog/elements/tag-chip.md
+++ b/catalog/elements/tag-chip.md
@@ -16,25 +16,33 @@ Color-coded tag chips for CRM contact and account classification. Each of the 7 
 - **Remove button:** `×` button for removable variant, opacity increases on hover
 - **Font size:** 13px default, 12px when used inline on cards
 
-## Color Pairs
+## Color Pairs (historical reference — NOT rendered, #168)
 
-| Group | Text Color | Background Color |
-|---|---|---|
-| Distribution | `#E8733A` | `#FEF3EC` |
-| Outreach | `#2DA67E` | `#ECF8F4` |
-| Press/Festival | `#2E75B6` | `#EBF3FB` |
-| Vendors | `#8B5CF6` | `#F3EFFE` |
-| Finance | `#D97706` | `#FEF9EC` |
-| Production | `#6366F1` | `#EEEFFE` |
-| Internal | `#64748B` | `#F1F5F9` |
+`GROUPS` still exists as the canonical group **key set** and as a record of the original
+brand hex, but **nothing renders from it**. Every tag renderer in the engine now resolves
+colour through `GROUP_VARIANTS` below.
 
-## Semantic Mapping (`GROUP_VARIANTS`, #151)
+| Group | Text Color | Background Color | Measured contrast |
+|---|---|---|---|
+| Distribution | `#E8733A` | `#FEF3EC` | 2.77:1 ❌ |
+| Outreach | `#2DA67E` | `#ECF8F4` | 2.81:1 ❌ |
+| Press/Festival | `#2E75B6` | `#EBF3FB` | 4.32:1 ❌ |
+| Vendors | `#8B5CF6` | `#F3EFFE` | 3.75:1 ❌ |
+| Finance | `#D97706` | `#FEF9EC` | 3.03:1 ❌ |
+| Production | `#6366F1` | `#EEEFFE` | 3.92:1 ❌ |
+| Internal | `#64748B` | `#F1F5F9` | 4.34:1 ❌ |
 
-`GROUPS` above is the frozen brand-hex palette. `GROUP_VARIANTS` is a parallel map from
-each tag group onto a **Bootstrap semantic colour**, so consumers that need a
-theme-adaptive chip resolve colour from `--bs-*` (which follows `data-bs-theme`) instead of
-the frozen hex. `FilterChipBar` (selected chip) and `DataTable` (tag dots) consume it; the
-TagChip component itself still renders the hex pairs this phase.
+Every pair is below the 4.5:1 AA floor (ISS#142 §1). That is why they were retired as a
+colour source — do not reintroduce them.
+
+## Semantic Mapping (`GROUP_VARIANTS`)
+
+`GROUP_VARIANTS` maps each tag group onto a **Bootstrap semantic colour**, so a chip
+resolves colour from `--bs-*` (which follows `data-bs-theme`) instead of frozen hex. Since
+#168 it is the single source of truth for **every** tag-group renderer in the engine:
+`TagChip` itself, `Badge`'s `tag_group` variant, `ContactCard`, `EngagementCard`, both list
+rows, both detail panels, `TagInput` (server render *and* its Stimulus controller),
+`FilterChipBar` and `DataTable`.
 
 | Group | Semantic | Renders as |
 |---|---|---|
@@ -53,6 +61,15 @@ Vendors) collapse onto `primary` (blue), and Distribution's warm orange approxim
 **text label** carries the category identity, so the hue is reinforcement, not the sole
 signal. Distinguishing all seven hues adaptively would require new brand tokens, deferred to
 the tag-palette follow-up.
+
+### How each surface renders it
+
+| Surface | Treatment | Why |
+|---|---|---|
+| Chip / pill body | `bg-{sem}-subtle` + `text-{sem}-emphasis` | Bootstrap derives an AA-clean pair per colour mode — browser-measured 9.34:1–10.52:1 light, 7.15:1–8.61:1 dark |
+| Dot **inside** a chip | `background-color: currentColor` | Inherits the chip's `-emphasis` foreground. A solid `bg-{sem}` here measures **2.62:1–2.67:1** on its own `-subtle` surface — below the 3:1 decorative floor |
+| Dot on a **card/row** surface | `bg-{sem}` (solid, fixed hue) | The documented decorative exception; ≥3:1 on both resting backdrops, meaning carried by the adjacent label (WCAG 2.1 SC 1.4.11) |
+| Remove control | `text-reset bg-transparent border-0` | Inherits the chip foreground; pins no colour and **no `opacity`** |
 
 ## Variants
 
@@ -93,7 +110,12 @@ end
 
 ## Accessibility
 
-- **The 7 hex color pairs do NOT meet WCAG AA for normal text.** Re-derived contrast ratios
+- **The chip renders an AA-clean, theme-adaptive pair.** `bg-{sem}-subtle` +
+  `text-{sem}-emphasis` is browser-measured at 9.34:1–10.52:1 in light mode and
+  7.15:1–8.61:1 in dark, for all five distinct hues (`spec/features/contrast_spec.rb`).
+  The remove control inherits that foreground and is not faded — the retired `opacity: 0.6`
+  composited it well below the floor.
+- **Historical:** the retired hex pairs did NOT meet WCAG AA. Re-derived contrast ratios
   range **2.77:1 to 4.34:1** (coloured text on its light background), all below the 4.5:1 AA
   floor — the earlier "all verified for AA" claim was false (#130). The colour is reinforced
   by the leading dot and the always-present text label, but the pairs should not be relied on
@@ -110,11 +132,13 @@ end
 
 - **Use** on contact cards, contact list rows, and filter bars to show group/tag classification
 - **Use** removable variant in edit forms and active filter displays
-- **Two colour systems, bridged by `GROUP_VARIANTS`.** The chip's own rendering uses the
-  brand-hex pairs; do not hand-swap those for Bootstrap's `text-bg-*` badge utilities on the
-  TagChip itself. But the group→semantic bridge IS intentional for *list-view consumers*
-  (`FilterChipBar`, `DataTable`), which render the adaptive semantics via `GROUP_VARIANTS` so
-  they track `data-bs-theme` (#151). Prefer that bridge over inventing a new mapping
+- **One colour system, `GROUP_VARIANTS` (#168).** Every tag-group renderer resolves through
+  the shared mapping, so a category renders the same adaptive hue everywhere. This reverses
+  the #151-era guidance that the chip's own rendering should stay on brand hex: that split
+  existed only to keep #151's blast radius small, and it shipped a cross-consumer
+  inconsistency plus seven sub-AA pairs. Do not reintroduce a second colour path — and in
+  particular do not pair a `-subtle` surface with a solid `bg-{sem}` dot, which fails the
+  decorative 3:1 floor
 - **Do not** create new color pairs without adding them to `tokens/colors.md` — and add the
   matching `GROUP_VARIANTS` entry so converted consumers don't fall back to `secondary`
 - Tags always inherit their parent group's color — never assign colors to individual tags

--- a/catalog/previews/avatar-circle.html
+++ b/catalog/previews/avatar-circle.html
@@ -64,6 +64,14 @@
       --mds-avatar-placeholder: #787F86; --mds-avatar-placeholder-fg: #000;
       --mds-avatar-overflow: #707E91; --mds-avatar-overflow-fg: #000;
     }
+    /* Dark semantic pair for the two converted tag badges. Declaring these light-only
+       left them on the light pair under a global dark theme, since the light :root here
+       is declared after the avatar dark block. (#168) */
+    [data-bs-theme="dark"] {
+      --bs-primary-bg-subtle: #091724; --bs-primary-text-emphasis: #82ACD3;
+      --bs-success-bg-subtle: #072015; --bs-success-text-emphasis: #7AC6A6;
+      --bs-danger-bg-subtle: #2C0B0E;  --bs-danger-text-emphasis: #EA868F;
+    }
     .avatar {
       display: inline-flex; align-items: center; justify-content: center;
       border-radius: 50%; font-weight: 600;

--- a/catalog/previews/avatar-circle.html
+++ b/catalog/previews/avatar-circle.html
@@ -147,12 +147,12 @@
         <tr>
           <td style="width: 48px;"><div class="avatar avatar-md avatar-c0">JS</div></td>
           <td><strong>John Smith</strong><br><span class="text-body-secondary small">Acme Studios</span></td>
-          <td class="text-end"><span class="badge" style="color: #E8733A; background: #FEF3EC; border-radius: 999px;">Buyer</span></td>
+          <td class="text-end"><span class="badge bg-danger-subtle text-danger-emphasis" style="border-radius: 999px;">Buyer</span></td>
         </tr>
         <tr>
           <td style="width: 48px;"><div class="avatar avatar-md avatar-c1">AD</div></td>
           <td><strong>Alice Dupont</strong><br><span class="text-body-secondary small">Canal+ Distribution</span></td>
-          <td class="text-end"><span class="badge" style="color: #2DA67E; background: #ECF8F4; border-radius: 999px;">Press</span></td>
+          <td class="text-end"><span class="badge bg-success-subtle text-success-emphasis" style="border-radius: 999px;">Outreach</span></td>
         </tr>
       </tbody>
     </table>

--- a/catalog/previews/avatar-circle.html
+++ b/catalog/previews/avatar-circle.html
@@ -23,6 +23,18 @@
       the foreground is DERIVED per background (issue #130 — 7 of the 10 light palette
       colours fail WCAG AA with white text), carried by the `-fg` token / fallback.
     */
+    /* Semantic tokens for the two converted tag badges below. This file already had a
+       :root block for the avatar palette, which is why the shared converter skipped it —
+       without these the badges would paint stock CDN Bootstrap's green/red, not MPI's.
+       Values are the compiled engine bundle's. (#168) */
+    :root, [data-bs-theme="light"] {
+      --bs-primary: #2E75B6; --bs-primary-rgb: 46, 117, 182;
+      --bs-success: #22A06B; --bs-success-rgb: 34, 160, 107;
+      --bs-danger: #DC3545;  --bs-danger-rgb: 220, 53, 69;
+      --bs-primary-bg-subtle: #D5E3F0; --bs-primary-text-emphasis: #122F49;
+      --bs-success-bg-subtle: #D3ECE1; --bs-success-text-emphasis: #0E402B;
+      --bs-danger-bg-subtle: #F8D7DA;  --bs-danger-text-emphasis: #58151C;
+    }
     :root,
     [data-bs-theme="light"] {
       --mds-avatar-0: #2E75B6; --mds-avatar-0-fg: #fff;

--- a/catalog/previews/badge.html
+++ b/catalog/previews/badge.html
@@ -12,6 +12,32 @@
   <title>Badge — MPI Design System</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
+    /* MPI tokens. These mockups load STOCK Bootstrap from a CDN, whose --bs-primary is
+       #0d6efd. Without this block every semantic utility below would paint Bootstrap's
+       indigo/cyan/grey instead of MPI's palette — looking converted while contradicting
+       the component it documents. Values are the compiled engine bundle's, verified in a
+       browser. (#168, see .claude/rules/frontend.md) */
+    :root, [data-bs-theme="light"] {
+      --bs-primary: #2E75B6; --bs-primary-rgb: 46, 117, 182;
+      --bs-success: #22A06B; --bs-success-rgb: 34, 160, 107;
+      --bs-warning: #D4772C; --bs-warning-rgb: 212, 119, 44;
+      --bs-danger: #DC3545;  --bs-danger-rgb: 220, 53, 69;
+      --bs-secondary: #6C757D; --bs-secondary-rgb: 108, 117, 125;
+      --bs-body-color: #1B2A4A; --bs-body-color-rgb: 27, 42, 74;
+      --bs-primary-bg-subtle: #D5E3F0;   --bs-primary-text-emphasis: #122F49;
+      --bs-success-bg-subtle: #D3ECE1;   --bs-success-text-emphasis: #0E402B;
+      --bs-warning-bg-subtle: #F6E4D5;   --bs-warning-text-emphasis: #553012;
+      --bs-danger-bg-subtle: #F8D7DA;    --bs-danger-text-emphasis: #58151C;
+      --bs-secondary-bg-subtle: #E2E3E5; --bs-secondary-text-emphasis: #2B2F32;
+    }
+    [data-bs-theme="dark"] {
+      --bs-body-color: #DEE2E6; --bs-body-color-rgb: 222, 226, 230;
+      --bs-primary-bg-subtle: #091724;   --bs-primary-text-emphasis: #82ACD3;
+      --bs-success-bg-subtle: #072015;   --bs-success-text-emphasis: #7AC6A6;
+      --bs-warning-bg-subtle: #2A1809;   --bs-warning-text-emphasis: #E5AD80;
+      --bs-danger-bg-subtle: #2C0B0E;    --bs-danger-text-emphasis: #EA868F;
+      --bs-secondary-bg-subtle: #161719; --bs-secondary-text-emphasis: #A7ACB1;
+    }
     body { padding: 32px; background: #fff; }
     .preview-section { margin-bottom: 32px; }
     .preview-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6C757D; margin-bottom: 8px; }
@@ -71,12 +97,12 @@
         <tr>
           <td>John Smith</td>
           <td><span class="badge" style="background-color: #22A06B; color: #000;">Active</span></td>
-          <td><span class="badge" style="color: #E8733A; background: #FEF3EC;">Buyer</span></td>
+          <td><span class="badge bg-danger-subtle text-danger-emphasis" >Buyer</span></td>
         </tr>
         <tr>
           <td>Jane Doe</td>
           <td><span class="badge" style="color: #D4772C; background: #FEF9EC;">Pending</span></td>
-          <td><span class="badge" style="color: #2DA67E; background: #ECF8F4;">Press</span></td>
+          <td><span class="badge bg-success-subtle text-success-emphasis" >Outreach</span></td>
         </tr>
       </tbody>
     </table>

--- a/catalog/previews/contact-card.html
+++ b/catalog/previews/contact-card.html
@@ -7,6 +7,32 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <style>
+    /* MPI tokens. These mockups load STOCK Bootstrap from a CDN, whose --bs-primary is
+       #0d6efd. Without this block every semantic utility below would paint Bootstrap's
+       indigo/cyan/grey instead of MPI's palette — looking converted while contradicting
+       the component it documents. Values are the compiled engine bundle's, verified in a
+       browser. (#168, see .claude/rules/frontend.md) */
+    :root, [data-bs-theme="light"] {
+      --bs-primary: #2E75B6; --bs-primary-rgb: 46, 117, 182;
+      --bs-success: #22A06B; --bs-success-rgb: 34, 160, 107;
+      --bs-warning: #D4772C; --bs-warning-rgb: 212, 119, 44;
+      --bs-danger: #DC3545;  --bs-danger-rgb: 220, 53, 69;
+      --bs-secondary: #6C757D; --bs-secondary-rgb: 108, 117, 125;
+      --bs-body-color: #1B2A4A; --bs-body-color-rgb: 27, 42, 74;
+      --bs-primary-bg-subtle: #D5E3F0;   --bs-primary-text-emphasis: #122F49;
+      --bs-success-bg-subtle: #D3ECE1;   --bs-success-text-emphasis: #0E402B;
+      --bs-warning-bg-subtle: #F6E4D5;   --bs-warning-text-emphasis: #553012;
+      --bs-danger-bg-subtle: #F8D7DA;    --bs-danger-text-emphasis: #58151C;
+      --bs-secondary-bg-subtle: #E2E3E5; --bs-secondary-text-emphasis: #2B2F32;
+    }
+    [data-bs-theme="dark"] {
+      --bs-body-color: #DEE2E6; --bs-body-color-rgb: 222, 226, 230;
+      --bs-primary-bg-subtle: #091724;   --bs-primary-text-emphasis: #82ACD3;
+      --bs-success-bg-subtle: #072015;   --bs-success-text-emphasis: #7AC6A6;
+      --bs-warning-bg-subtle: #2A1809;   --bs-warning-text-emphasis: #E5AD80;
+      --bs-danger-bg-subtle: #2C0B0E;    --bs-danger-text-emphasis: #EA868F;
+      --bs-secondary-bg-subtle: #161719; --bs-secondary-text-emphasis: #A7ACB1;
+    }
     body { padding: 32px; background: #F5F7FA; }
     .preview-section { margin-bottom: 40px; }
     .preview-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6C757D; margin-bottom: 8px; }
@@ -40,9 +66,9 @@
             </div>
           </div>
           <div class="d-flex flex-wrap gap-1 mb-3">
-            <span class="tag-pill" style="color:#E8733A; background:#FEF3EC;">Theatrical</span>
-            <span class="tag-pill" style="color:#E8733A; background:#FEF3EC;">Digital</span>
-            <span class="tag-pill" style="color:#2E75B6; background:#EBF3FB;">Acquisitions</span>
+            <span class="tag-pill bg-danger-subtle text-danger-emphasis" >Theatrical</span>
+            <span class="tag-pill bg-danger-subtle text-danger-emphasis" >Digital</span>
+            <span class="tag-pill bg-primary-subtle text-primary-emphasis" >Acquisitions</span>
           </div>
           <div class="d-flex justify-content-between card-meta">
             <span>Last engaged: 2 days ago</span>
@@ -62,7 +88,7 @@
             </div>
           </div>
           <div class="d-flex flex-wrap gap-1 mb-3">
-            <span class="tag-pill" style="color:#E8733A; background:#FEF3EC;">Streaming</span>
+            <span class="tag-pill bg-danger-subtle text-danger-emphasis" >Streaming</span>
           </div>
           <div class="d-flex justify-content-between card-meta">
             <span>Last engaged: 1 week ago</span>
@@ -82,8 +108,8 @@
             </div>
           </div>
           <div class="d-flex flex-wrap gap-1 mb-3">
-            <span class="tag-pill" style="color:#E8733A; background:#FEF3EC;">All Rights</span>
-            <span class="tag-pill" style="color:#2E75B6; background:#EBF3FB;">Programmer</span>
+            <span class="tag-pill bg-danger-subtle text-danger-emphasis" >All Rights</span>
+            <span class="tag-pill bg-primary-subtle text-primary-emphasis" >Programmer</span>
           </div>
           <div class="d-flex justify-content-between card-meta">
             <span>Last engaged: 3 days ago</span>
@@ -103,8 +129,8 @@
             </div>
           </div>
           <div class="d-flex flex-wrap gap-1 mb-3">
-            <span class="tag-pill" style="color:#8B5CF6; background:#F3EFFE;">Sales Agent</span>
-            <span class="tag-pill" style="color:#E8733A; background:#FEF3EC;">Television</span>
+            <span class="tag-pill bg-primary-subtle text-primary-emphasis" >Sales Agent</span>
+            <span class="tag-pill bg-danger-subtle text-danger-emphasis" >Television</span>
           </div>
           <div class="d-flex justify-content-between card-meta">
             <span>Last engaged: 5 days ago</span>
@@ -124,8 +150,8 @@
             </div>
           </div>
           <div class="d-flex flex-wrap gap-1 mb-3">
-            <span class="tag-pill" style="color:#2DA67E; background:#ECF8F4;">Online Critic</span>
-            <span class="tag-pill" style="color:#2DA67E; background:#ECF8F4;">Podcaster</span>
+            <span class="tag-pill bg-success-subtle text-success-emphasis" >Online Critic</span>
+            <span class="tag-pill bg-success-subtle text-success-emphasis" >Podcaster</span>
           </div>
           <div class="d-flex justify-content-between card-meta">
             <span>Last engaged: 2 weeks ago</span>
@@ -145,8 +171,8 @@
             </div>
           </div>
           <div class="d-flex flex-wrap gap-1 mb-3">
-            <span class="tag-pill" style="color:#D97706; background:#FEF9EC;">University</span>
-            <span class="tag-pill" style="color:#6366F1; background:#EEEFFE;">Distributor</span>
+            <span class="tag-pill bg-warning-subtle text-warning-emphasis" >University</span>
+            <span class="tag-pill bg-primary-subtle text-primary-emphasis" >Distributor</span>
           </div>
           <div class="d-flex justify-content-between card-meta">
             <span>Last engaged: 4 days ago</span>
@@ -171,9 +197,9 @@
           </div>
         </div>
         <div class="d-flex flex-wrap gap-1 mb-3">
-          <span class="tag-pill" style="color:#E8733A; background:#FEF3EC;">Theatrical</span>
-          <span class="tag-pill" style="color:#E8733A; background:#FEF3EC;">Digital</span>
-          <span class="tag-pill" style="color:#2E75B6; background:#EBF3FB;">Acquisitions</span>
+          <span class="tag-pill bg-danger-subtle text-danger-emphasis" >Theatrical</span>
+          <span class="tag-pill bg-danger-subtle text-danger-emphasis" >Digital</span>
+          <span class="tag-pill bg-primary-subtle text-primary-emphasis" >Acquisitions</span>
         </div>
         <div class="d-flex justify-content-between card-meta">
           <span>Last engaged: 2 days ago</span>

--- a/catalog/previews/contact-list-row.html
+++ b/catalog/previews/contact-list-row.html
@@ -7,6 +7,32 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <style>
+    /* MPI tokens. These mockups load STOCK Bootstrap from a CDN, whose --bs-primary is
+       #0d6efd. Without this block every semantic utility below would paint Bootstrap's
+       indigo/cyan/grey instead of MPI's palette — looking converted while contradicting
+       the component it documents. Values are the compiled engine bundle's, verified in a
+       browser. (#168, see .claude/rules/frontend.md) */
+    :root, [data-bs-theme="light"] {
+      --bs-primary: #2E75B6; --bs-primary-rgb: 46, 117, 182;
+      --bs-success: #22A06B; --bs-success-rgb: 34, 160, 107;
+      --bs-warning: #D4772C; --bs-warning-rgb: 212, 119, 44;
+      --bs-danger: #DC3545;  --bs-danger-rgb: 220, 53, 69;
+      --bs-secondary: #6C757D; --bs-secondary-rgb: 108, 117, 125;
+      --bs-body-color: #1B2A4A; --bs-body-color-rgb: 27, 42, 74;
+      --bs-primary-bg-subtle: #D5E3F0;   --bs-primary-text-emphasis: #122F49;
+      --bs-success-bg-subtle: #D3ECE1;   --bs-success-text-emphasis: #0E402B;
+      --bs-warning-bg-subtle: #F6E4D5;   --bs-warning-text-emphasis: #553012;
+      --bs-danger-bg-subtle: #F8D7DA;    --bs-danger-text-emphasis: #58151C;
+      --bs-secondary-bg-subtle: #E2E3E5; --bs-secondary-text-emphasis: #2B2F32;
+    }
+    [data-bs-theme="dark"] {
+      --bs-body-color: #DEE2E6; --bs-body-color-rgb: 222, 226, 230;
+      --bs-primary-bg-subtle: #091724;   --bs-primary-text-emphasis: #82ACD3;
+      --bs-success-bg-subtle: #072015;   --bs-success-text-emphasis: #7AC6A6;
+      --bs-warning-bg-subtle: #2A1809;   --bs-warning-text-emphasis: #E5AD80;
+      --bs-danger-bg-subtle: #2C0B0E;    --bs-danger-text-emphasis: #EA868F;
+      --bs-secondary-bg-subtle: #161719; --bs-secondary-text-emphasis: #A7ACB1;
+    }
     body { padding: 32px; background: #fff; }
     .preview-section { margin-bottom: 40px; }
     .preview-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6C757D; margin-bottom: 8px; }
@@ -51,9 +77,9 @@
           </td>
           <td class="align-middle">
             <div class="d-flex flex-wrap gap-2">
-              <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Acquisitions</span>
-              <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Streaming</span>
-              <span class="tag"><span class="tag-dot" style="background:#2E75B6;"></span>Festival</span>
+              <span class="tag"><span class="tag-dot bg-danger"></span>Acquisitions</span>
+              <span class="tag"><span class="tag-dot bg-danger"></span>Streaming</span>
+              <span class="tag"><span class="tag-dot bg-primary"></span>Festival</span>
             </div>
           </td>
           <td class="align-middle meta-text">2 days ago</td>
@@ -87,7 +113,7 @@
             </div>
           </td>
           <td class="align-middle">
-            <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Streaming</span>
+            <span class="tag"><span class="tag-dot bg-danger"></span>Streaming</span>
           </td>
           <td class="align-middle meta-text">1 week ago</td>
           <td class="align-middle"><a class="account-link" href="#">MUBI</a></td>
@@ -104,8 +130,8 @@
           </td>
           <td class="align-middle">
             <div class="d-flex flex-wrap gap-2">
-              <span class="tag"><span class="tag-dot" style="background:#8B5CF6;"></span>Seller — Sales Agent</span>
-              <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Buyer — Television</span>
+              <span class="tag"><span class="tag-dot bg-primary"></span>Seller — Sales Agent</span>
+              <span class="tag"><span class="tag-dot bg-danger"></span>Buyer — Television</span>
             </div>
           </td>
           <td class="align-middle meta-text">5 days ago</td>
@@ -123,8 +149,8 @@
           </td>
           <td class="align-middle">
             <div class="d-flex flex-wrap gap-2">
-              <span class="tag"><span class="tag-dot" style="background:#2DA67E;"></span>Press — Online Critic</span>
-              <span class="tag"><span class="tag-dot" style="background:#2DA67E;"></span>Press — Podcaster</span>
+              <span class="tag"><span class="tag-dot bg-success"></span>Press — Online Critic</span>
+              <span class="tag"><span class="tag-dot bg-success"></span>Press — Podcaster</span>
             </div>
           </td>
           <td class="align-middle meta-text">2 weeks ago</td>
@@ -160,8 +186,8 @@
           </td>
           <td class="align-middle">
             <div class="d-flex flex-wrap gap-2">
-              <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Buyer — All Rights</span>
-              <span class="tag"><span class="tag-dot" style="background:#E8733A;"></span>Acquisitions</span>
+              <span class="tag"><span class="tag-dot bg-danger"></span>Buyer — All Rights</span>
+              <span class="tag"><span class="tag-dot bg-danger"></span>Acquisitions</span>
             </div>
           </td>
           <td class="align-middle meta-text">Title: <strong>Investor</strong> Relations</td>

--- a/catalog/previews/detail-view.html
+++ b/catalog/previews/detail-view.html
@@ -114,14 +114,14 @@
                 <div class="card-body">
                   <div class="info-label">Tags</div>
                   <div class="d-flex flex-wrap gap-1 mb-2">
-                    <span class="tag-chip bg-danger-subtle text-danger-emphasis" style="border-color:#E8733A;">
-                      <span class="bg-danger" style="width:5px; height:5px; border-radius:50%; margin-right:4px; display:inline-block;"></span>Acquisitions
+                    <span class="tag-chip bg-danger-subtle text-danger-emphasis">
+                      <span style="width:5px; height:5px; border-radius:50%; margin-right:4px; display:inline-block; background-color: currentColor;"></span>Acquisitions
                     </span>
-                    <span class="tag-chip bg-danger-subtle text-danger-emphasis" style="border-color:#E8733A;">
-                      <span class="bg-danger" style="width:5px; height:5px; border-radius:50%; margin-right:4px; display:inline-block;"></span>Streaming
+                    <span class="tag-chip bg-danger-subtle text-danger-emphasis">
+                      <span style="width:5px; height:5px; border-radius:50%; margin-right:4px; display:inline-block; background-color: currentColor;"></span>Streaming
                     </span>
-                    <span class="tag-chip bg-primary-subtle text-primary-emphasis" style="border-color:#2E75B6;">
-                      <span class="bg-primary" style="width:5px; height:5px; border-radius:50%; margin-right:4px; display:inline-block;"></span>Festival — Acquisitions
+                    <span class="tag-chip bg-primary-subtle text-primary-emphasis">
+                      <span style="width:5px; height:5px; border-radius:50%; margin-right:4px; display:inline-block; background-color: currentColor;"></span>Festival — Acquisitions
                     </span>
                   </div>
                   <a href="#" style="font-size:12px; color:#2E75B6; text-decoration:none;">+ Add tag</a>

--- a/catalog/previews/detail-view.html
+++ b/catalog/previews/detail-view.html
@@ -7,6 +7,32 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <style>
+    /* MPI tokens. These mockups load STOCK Bootstrap from a CDN, whose --bs-primary is
+       #0d6efd. Without this block every semantic utility below would paint Bootstrap's
+       indigo/cyan/grey instead of MPI's palette — looking converted while contradicting
+       the component it documents. Values are the compiled engine bundle's, verified in a
+       browser. (#168, see .claude/rules/frontend.md) */
+    :root, [data-bs-theme="light"] {
+      --bs-primary: #2E75B6; --bs-primary-rgb: 46, 117, 182;
+      --bs-success: #22A06B; --bs-success-rgb: 34, 160, 107;
+      --bs-warning: #D4772C; --bs-warning-rgb: 212, 119, 44;
+      --bs-danger: #DC3545;  --bs-danger-rgb: 220, 53, 69;
+      --bs-secondary: #6C757D; --bs-secondary-rgb: 108, 117, 125;
+      --bs-body-color: #1B2A4A; --bs-body-color-rgb: 27, 42, 74;
+      --bs-primary-bg-subtle: #D5E3F0;   --bs-primary-text-emphasis: #122F49;
+      --bs-success-bg-subtle: #D3ECE1;   --bs-success-text-emphasis: #0E402B;
+      --bs-warning-bg-subtle: #F6E4D5;   --bs-warning-text-emphasis: #553012;
+      --bs-danger-bg-subtle: #F8D7DA;    --bs-danger-text-emphasis: #58151C;
+      --bs-secondary-bg-subtle: #E2E3E5; --bs-secondary-text-emphasis: #2B2F32;
+    }
+    [data-bs-theme="dark"] {
+      --bs-body-color: #DEE2E6; --bs-body-color-rgb: 222, 226, 230;
+      --bs-primary-bg-subtle: #091724;   --bs-primary-text-emphasis: #82ACD3;
+      --bs-success-bg-subtle: #072015;   --bs-success-text-emphasis: #7AC6A6;
+      --bs-warning-bg-subtle: #2A1809;   --bs-warning-text-emphasis: #E5AD80;
+      --bs-danger-bg-subtle: #2C0B0E;    --bs-danger-text-emphasis: #EA868F;
+      --bs-secondary-bg-subtle: #161719; --bs-secondary-text-emphasis: #A7ACB1;
+    }
     body { padding: 0; background: #F5F7FA; margin: 0; }
     .preview-wrapper { padding: 32px; }
     .preview-section { margin-bottom: 32px; }
@@ -88,14 +114,14 @@
                 <div class="card-body">
                   <div class="info-label">Tags</div>
                   <div class="d-flex flex-wrap gap-1 mb-2">
-                    <span class="tag-chip" style="color:#E8733A; border-color:#E8733A; background:#FEF3EC;">
-                      <span style="width:5px;height:5px;border-radius:50%;background:#E8733A;margin-right:4px;display:inline-block;"></span>Acquisitions
+                    <span class="tag-chip bg-danger-subtle text-danger-emphasis" style="border-color:#E8733A;">
+                      <span class="bg-danger" style="width:5px; height:5px; border-radius:50%; margin-right:4px; display:inline-block;"></span>Acquisitions
                     </span>
-                    <span class="tag-chip" style="color:#E8733A; border-color:#E8733A; background:#FEF3EC;">
-                      <span style="width:5px;height:5px;border-radius:50%;background:#E8733A;margin-right:4px;display:inline-block;"></span>Streaming
+                    <span class="tag-chip bg-danger-subtle text-danger-emphasis" style="border-color:#E8733A;">
+                      <span class="bg-danger" style="width:5px; height:5px; border-radius:50%; margin-right:4px; display:inline-block;"></span>Streaming
                     </span>
-                    <span class="tag-chip" style="color:#2E75B6; border-color:#2E75B6; background:#EBF3FB;">
-                      <span style="width:5px;height:5px;border-radius:50%;background:#2E75B6;margin-right:4px;display:inline-block;"></span>Festival — Acquisitions
+                    <span class="tag-chip bg-primary-subtle text-primary-emphasis" style="border-color:#2E75B6;">
+                      <span class="bg-primary" style="width:5px; height:5px; border-radius:50%; margin-right:4px; display:inline-block;"></span>Festival — Acquisitions
                     </span>
                   </div>
                   <a href="#" style="font-size:12px; color:#2E75B6; text-decoration:none;">+ Add tag</a>
@@ -128,8 +154,8 @@
                 <div class="card-body">
                   <div class="info-label">Groups (Auto)</div>
                   <div class="d-flex gap-1 mt-1">
-                    <span class="group-auto-chip" style="background:#FEF3EC; color:#E8733A;">Buyers</span>
-                    <span class="group-auto-chip" style="background:#EBF3FB; color:#2E75B6;">Festivals</span>
+                    <span class="group-auto-chip bg-danger-subtle text-danger-emphasis" >Distribution</span>
+                    <span class="group-auto-chip bg-primary-subtle text-primary-emphasis" >Press/Festival</span>
                   </div>
                 </div>
               </div>

--- a/catalog/previews/engagement-card.html
+++ b/catalog/previews/engagement-card.html
@@ -7,6 +7,32 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <style>
+    /* MPI tokens. These mockups load STOCK Bootstrap from a CDN, whose --bs-primary is
+       #0d6efd. Without this block every semantic utility below would paint Bootstrap's
+       indigo/cyan/grey instead of MPI's palette — looking converted while contradicting
+       the component it documents. Values are the compiled engine bundle's, verified in a
+       browser. (#168, see .claude/rules/frontend.md) */
+    :root, [data-bs-theme="light"] {
+      --bs-primary: #2E75B6; --bs-primary-rgb: 46, 117, 182;
+      --bs-success: #22A06B; --bs-success-rgb: 34, 160, 107;
+      --bs-warning: #D4772C; --bs-warning-rgb: 212, 119, 44;
+      --bs-danger: #DC3545;  --bs-danger-rgb: 220, 53, 69;
+      --bs-secondary: #6C757D; --bs-secondary-rgb: 108, 117, 125;
+      --bs-body-color: #1B2A4A; --bs-body-color-rgb: 27, 42, 74;
+      --bs-primary-bg-subtle: #D5E3F0;   --bs-primary-text-emphasis: #122F49;
+      --bs-success-bg-subtle: #D3ECE1;   --bs-success-text-emphasis: #0E402B;
+      --bs-warning-bg-subtle: #F6E4D5;   --bs-warning-text-emphasis: #553012;
+      --bs-danger-bg-subtle: #F8D7DA;    --bs-danger-text-emphasis: #58151C;
+      --bs-secondary-bg-subtle: #E2E3E5; --bs-secondary-text-emphasis: #2B2F32;
+    }
+    [data-bs-theme="dark"] {
+      --bs-body-color: #DEE2E6; --bs-body-color-rgb: 222, 226, 230;
+      --bs-primary-bg-subtle: #091724;   --bs-primary-text-emphasis: #82ACD3;
+      --bs-success-bg-subtle: #072015;   --bs-success-text-emphasis: #7AC6A6;
+      --bs-warning-bg-subtle: #2A1809;   --bs-warning-text-emphasis: #E5AD80;
+      --bs-danger-bg-subtle: #2C0B0E;    --bs-danger-text-emphasis: #EA868F;
+      --bs-secondary-bg-subtle: #161719; --bs-secondary-text-emphasis: #A7ACB1;
+    }
     body { padding: 32px; background: #F5F7FA; }
     .preview-section { margin-bottom: 40px; }
     .preview-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6C757D; margin-bottom: 8px; }
@@ -54,7 +80,7 @@
         </div>
         <div class="right-meta ms-4" style="min-width:140px;">
           <div><a class="account-link" href="#">Magnolia Pictures</a></div>
-          <div class="mt-1"><span class="tag-sm"><span class="tag-dot-sm" style="background:#E8733A;"></span>Acquisitions</span></div>
+          <div class="mt-1"><span class="tag-sm"><span class="tag-dot-sm bg-danger"></span>Acquisitions</span></div>
           <div class="mt-2">
             <div class="title-link"><i class="bi bi-film"></i> The Orchard</div>
             <div class="title-link"><i class="bi bi-film"></i> Below the Surface</div>
@@ -84,7 +110,7 @@
         </div>
         <div class="right-meta ms-4" style="min-width:140px;">
           <div><a class="account-link" href="#">MUBI</a></div>
-          <div class="mt-1"><span class="tag-sm"><span class="tag-dot-sm" style="background:#E8733A;"></span>Streaming</span></div>
+          <div class="mt-1"><span class="tag-sm"><span class="tag-dot-sm bg-danger"></span>Streaming</span></div>
         </div>
       </div>
     </div>
@@ -109,7 +135,7 @@
         </div>
         <div class="right-meta ms-4" style="min-width:140px;">
           <div><a class="account-link" href="#">Bleecker Street Capital</a></div>
-          <div class="mt-1"><span class="tag-sm"><span class="tag-dot-sm" style="background:#E8733A;"></span>Acquisitions</span></div>
+          <div class="mt-1"><span class="tag-sm"><span class="tag-dot-sm bg-danger"></span>Acquisitions</span></div>
           <div class="mt-2">
             <div class="title-link"><i class="bi bi-film"></i> The Orchard</div>
           </div>
@@ -138,10 +164,10 @@
         <div class="right-meta ms-4" style="min-width:140px;">
           <div><a class="account-link" href="#">Kino Lorber</a></div>
           <div class="mt-1">
-            <span class="tag-sm"><span class="tag-dot-sm" style="background:#E8733A;"></span>Buyer — All Rights</span>
+            <span class="tag-sm"><span class="tag-dot-sm bg-danger"></span>Buyer — All Rights</span>
           </div>
           <div class="mt-1">
-            <span class="tag-sm"><span class="tag-dot-sm" style="background:#2E75B6;"></span>Fest — Programmer</span>
+            <span class="tag-sm"><span class="tag-dot-sm bg-primary"></span>Fest — Programmer</span>
           </div>
         </div>
       </div>

--- a/catalog/previews/filter-chip-bar.html
+++ b/catalog/previews/filter-chip-bar.html
@@ -39,10 +39,27 @@
       --bs-body-color-rgb: 27, 42, 74;
       --bs-secondary-color: rgba(27, 42, 74, 0.75);
     }
+    /* Dark mode. This block previously declared only three EMPHASIS colours and no
+       `*-bg-subtle` at all, so a dark subtle chip kept its LIGHT surface — and its
+       success emphasis (#A7D9C4) disagreed with what the compiled bundle paints
+       (#7AC6A6). The defect was invisible here because the only dark example on the page
+       uses solid `text-bg-primary` pills, not a subtle group chip. Values below are
+       browser-measured against the compiled engine bundle. (#168) */
     [data-bs-theme="dark"] {
+      --bs-body-color: #DEE2E6;
+      --bs-body-color-rgb: 222, 226, 230;
       --bs-primary-text-emphasis: #82ACD3;
-      --bs-success-text-emphasis: #A7D9C4;
+      --bs-primary-bg-subtle: #091724;
+      --bs-success-text-emphasis: #7AC6A6;
+      --bs-success-bg-subtle: #072015;
       --bs-warning-text-emphasis: #E5AD80;
+      --bs-warning-bg-subtle: #2A1809;
+      --bs-danger-text-emphasis: #EA868F;
+      --bs-danger-bg-subtle: #2C0B0E;
+      --bs-secondary-text-emphasis: #A7ACB1;
+      --bs-secondary-bg-subtle: #161719;
+      --bs-link-color: #82ACD3;
+      --bs-link-color-rgb: 130, 172, 211;
     }
 
     body { padding: 32px; }

--- a/catalog/previews/list-view.html
+++ b/catalog/previews/list-view.html
@@ -65,7 +65,10 @@
     .subgroup-bar { display: flex; align-items: center; gap: 6px; margin-bottom: 16px; padding: 8px 12px; background: #fff; border: 1px solid #DEE2E6; border-radius: 6px; }
     .subgroup-label { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: #6C757D; margin-right: 4px; }
     .subgroup-pill { display: inline-flex; align-items: center; padding: 3px 10px; border-radius: 999px; border: 1px solid #DEE2E6; background: #fff; font-size: 11px; font-weight: 500; color: #6C757D; text-decoration: none; }
-    .subgroup-pill.selected { border-color: #E8733A; background: #FEF3EC; color: #E8733A; font-weight: 600; }
+    /* Selected subgroup pill renders the distribution category, so it resolves from the
+     same semantic mapping as every other tag surface. (#168) */
+    .subgroup-pill.selected { border-color: var(--bs-danger-border-subtle, var(--bs-danger-bg-subtle));
+      background: var(--bs-danger-bg-subtle); color: var(--bs-danger-text-emphasis); font-weight: 600; }
 
     /* Toggle */
     .toggle-group { display: inline-flex; border: 1px solid #DEE2E6; border-radius: 5px; overflow: hidden; }

--- a/catalog/previews/search-bar.html
+++ b/catalog/previews/search-bar.html
@@ -7,6 +7,32 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <style>
+    /* MPI tokens. These mockups load STOCK Bootstrap from a CDN, whose --bs-primary is
+       #0d6efd. Without this block every semantic utility below would paint Bootstrap's
+       indigo/cyan/grey instead of MPI's palette — looking converted while contradicting
+       the component it documents. Values are the compiled engine bundle's, verified in a
+       browser. (#168, see .claude/rules/frontend.md) */
+    :root, [data-bs-theme="light"] {
+      --bs-primary: #2E75B6; --bs-primary-rgb: 46, 117, 182;
+      --bs-success: #22A06B; --bs-success-rgb: 34, 160, 107;
+      --bs-warning: #D4772C; --bs-warning-rgb: 212, 119, 44;
+      --bs-danger: #DC3545;  --bs-danger-rgb: 220, 53, 69;
+      --bs-secondary: #6C757D; --bs-secondary-rgb: 108, 117, 125;
+      --bs-body-color: #1B2A4A; --bs-body-color-rgb: 27, 42, 74;
+      --bs-primary-bg-subtle: #D5E3F0;   --bs-primary-text-emphasis: #122F49;
+      --bs-success-bg-subtle: #D3ECE1;   --bs-success-text-emphasis: #0E402B;
+      --bs-warning-bg-subtle: #F6E4D5;   --bs-warning-text-emphasis: #553012;
+      --bs-danger-bg-subtle: #F8D7DA;    --bs-danger-text-emphasis: #58151C;
+      --bs-secondary-bg-subtle: #E2E3E5; --bs-secondary-text-emphasis: #2B2F32;
+    }
+    [data-bs-theme="dark"] {
+      --bs-body-color: #DEE2E6; --bs-body-color-rgb: 222, 226, 230;
+      --bs-primary-bg-subtle: #091724;   --bs-primary-text-emphasis: #82ACD3;
+      --bs-success-bg-subtle: #072015;   --bs-success-text-emphasis: #7AC6A6;
+      --bs-warning-bg-subtle: #2A1809;   --bs-warning-text-emphasis: #E5AD80;
+      --bs-danger-bg-subtle: #2C0B0E;    --bs-danger-text-emphasis: #EA868F;
+      --bs-secondary-bg-subtle: #161719; --bs-secondary-text-emphasis: #A7ACB1;
+    }
     body { padding: 32px; background: #fff; }
     .preview-section { margin-bottom: 32px; }
     .preview-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6C757D; margin-bottom: 8px; }
@@ -72,8 +98,8 @@
         <button class="btn btn-outline-primary btn-sm"><i class="bi bi-funnel me-1"></i>Filter</button>
       </div>
       <div class="d-flex gap-1 mt-2">
-        <span class="tag-chip" style="color: #E8733A; background: #FEF3EC;">Buyers <span style="cursor:pointer;opacity:0.6;">&times;</span></span>
-        <span class="tag-chip" style="color: #2E75B6; background: #EBF3FB;">Festivals <span style="cursor:pointer;opacity:0.6;">&times;</span></span>
+        <span class="tag-chip bg-danger-subtle text-danger-emphasis" >Distribution <span class="text-reset" style="cursor:pointer;">&times;</span></span>
+        <span class="tag-chip bg-primary-subtle text-primary-emphasis" >Press/Festival <span class="text-reset" style="cursor:pointer;">&times;</span></span>
       </div>
     </div>
   </div>

--- a/catalog/previews/tag-chip.html
+++ b/catalog/previews/tag-chip.html
@@ -71,12 +71,15 @@
     <div class="preview-label">With Remove Button</div>
     <div class="preview-row">
       <span class="tag-chip tag-chip-removable bg-danger-subtle text-danger-emphasis" >
+        <span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>
         Distribution <button class="btn-remove text-reset"  aria-label="Remove Distribution">&times;</button>
       </span>
       <span class="tag-chip tag-chip-removable bg-success-subtle text-success-emphasis" >
+        <span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>
         Outreach <button class="btn-remove text-reset"  aria-label="Remove Outreach">&times;</button>
       </span>
       <span class="tag-chip tag-chip-removable bg-primary-subtle text-primary-emphasis" >
+        <span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>
         Press/Festival <button class="btn-remove text-reset"  aria-label="Remove Press/Festival">&times;</button>
       </span>
     </div>

--- a/catalog/previews/tag-chip.html
+++ b/catalog/previews/tag-chip.html
@@ -6,6 +6,32 @@
   <title>TagChip — MPI Design System</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
+    /* MPI tokens. These mockups load STOCK Bootstrap from a CDN, whose --bs-primary is
+       #0d6efd. Without this block every semantic utility below would paint Bootstrap's
+       indigo/cyan/grey instead of MPI's palette — looking converted while contradicting
+       the component it documents. Values are the compiled engine bundle's, verified in a
+       browser. (#168, see .claude/rules/frontend.md) */
+    :root, [data-bs-theme="light"] {
+      --bs-primary: #2E75B6; --bs-primary-rgb: 46, 117, 182;
+      --bs-success: #22A06B; --bs-success-rgb: 34, 160, 107;
+      --bs-warning: #D4772C; --bs-warning-rgb: 212, 119, 44;
+      --bs-danger: #DC3545;  --bs-danger-rgb: 220, 53, 69;
+      --bs-secondary: #6C757D; --bs-secondary-rgb: 108, 117, 125;
+      --bs-body-color: #1B2A4A; --bs-body-color-rgb: 27, 42, 74;
+      --bs-primary-bg-subtle: #D5E3F0;   --bs-primary-text-emphasis: #122F49;
+      --bs-success-bg-subtle: #D3ECE1;   --bs-success-text-emphasis: #0E402B;
+      --bs-warning-bg-subtle: #F6E4D5;   --bs-warning-text-emphasis: #553012;
+      --bs-danger-bg-subtle: #F8D7DA;    --bs-danger-text-emphasis: #58151C;
+      --bs-secondary-bg-subtle: #E2E3E5; --bs-secondary-text-emphasis: #2B2F32;
+    }
+    [data-bs-theme="dark"] {
+      --bs-body-color: #DEE2E6; --bs-body-color-rgb: 222, 226, 230;
+      --bs-primary-bg-subtle: #091724;   --bs-primary-text-emphasis: #82ACD3;
+      --bs-success-bg-subtle: #072015;   --bs-success-text-emphasis: #7AC6A6;
+      --bs-warning-bg-subtle: #2A1809;   --bs-warning-text-emphasis: #E5AD80;
+      --bs-danger-bg-subtle: #2C0B0E;    --bs-danger-text-emphasis: #EA868F;
+      --bs-secondary-bg-subtle: #161719; --bs-secondary-text-emphasis: #A7ACB1;
+    }
     body { padding: 32px; background: #fff; }
     .preview-section { margin-bottom: 32px; }
     .preview-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6C757D; margin-bottom: 8px; }
@@ -18,10 +44,10 @@
     .tag-chip .btn-remove {
       display: inline-flex; align-items: center; justify-content: center;
       width: 18px; height: 18px; border-radius: 50%; border: none;
-      font-size: 12px; line-height: 1; cursor: pointer; opacity: 0.6;
+      font-size: 12px; line-height: 1; cursor: pointer;
       background: transparent; padding: 0;
     }
-    .tag-chip .btn-remove:hover { opacity: 1; }
+    .tag-chip .btn-remove:hover { text-decoration: underline; }
   </style>
 </head>
 <body>
@@ -31,27 +57,27 @@
   <div class="preview-section">
     <div class="preview-label">All Tag Groups</div>
     <div class="preview-row">
-      <span class="tag-chip" style="color: #E8733A; background: #FEF3EC;">Buyers</span>
-      <span class="tag-chip" style="color: #2DA67E; background: #ECF8F4;">Press</span>
-      <span class="tag-chip" style="color: #2E75B6; background: #EBF3FB;">Festivals</span>
-      <span class="tag-chip" style="color: #8B5CF6; background: #F3EFFE;">Sellers</span>
-      <span class="tag-chip" style="color: #D97706; background: #FEF9EC;">Institutional</span>
-      <span class="tag-chip" style="color: #6366F1; background: #EEEFFE;">Organizations</span>
-      <span class="tag-chip" style="color: #64748B; background: #F1F5F9;">Internal</span>
+      <span class="tag-chip bg-danger-subtle text-danger-emphasis" >Distribution</span>
+      <span class="tag-chip bg-success-subtle text-success-emphasis" >Outreach</span>
+      <span class="tag-chip bg-primary-subtle text-primary-emphasis" >Press/Festival</span>
+      <span class="tag-chip bg-primary-subtle text-primary-emphasis" >Vendors</span>
+      <span class="tag-chip bg-warning-subtle text-warning-emphasis" >Finance</span>
+      <span class="tag-chip bg-primary-subtle text-primary-emphasis" >Production</span>
+      <span class="tag-chip bg-secondary-subtle text-secondary-emphasis" >Internal</span>
     </div>
   </div>
 
   <div class="preview-section">
     <div class="preview-label">With Remove Button</div>
     <div class="preview-row">
-      <span class="tag-chip tag-chip-removable" style="color: #E8733A; background: #FEF3EC;">
-        Buyers <button class="btn-remove" style="color: #E8733A;" aria-label="Remove Buyers">&times;</button>
+      <span class="tag-chip tag-chip-removable bg-danger-subtle text-danger-emphasis" >
+        Distribution <button class="btn-remove text-reset"  aria-label="Remove Distribution">&times;</button>
       </span>
-      <span class="tag-chip tag-chip-removable" style="color: #2DA67E; background: #ECF8F4;">
-        Press <button class="btn-remove" style="color: #2DA67E;" aria-label="Remove Press">&times;</button>
+      <span class="tag-chip tag-chip-removable bg-success-subtle text-success-emphasis" >
+        Outreach <button class="btn-remove text-reset"  aria-label="Remove Outreach">&times;</button>
       </span>
-      <span class="tag-chip tag-chip-removable" style="color: #2E75B6; background: #EBF3FB;">
-        Festivals <button class="btn-remove" style="color: #2E75B6;" aria-label="Remove Festivals">&times;</button>
+      <span class="tag-chip tag-chip-removable bg-primary-subtle text-primary-emphasis" >
+        Press/Festival <button class="btn-remove text-reset"  aria-label="Remove Press/Festival">&times;</button>
       </span>
     </div>
   </div>
@@ -59,10 +85,10 @@
   <div class="preview-section">
     <div class="preview-label">With Specific Tags</div>
     <div class="preview-row">
-      <span class="tag-chip" style="color: #E8733A; background: #FEF3EC;">MIPCOM 2025</span>
-      <span class="tag-chip" style="color: #2DA67E; background: #ECF8F4;">Variety</span>
-      <span class="tag-chip" style="color: #2E75B6; background: #EBF3FB;">Cannes 2025</span>
-      <span class="tag-chip" style="color: #8B5CF6; background: #F3EFFE;">Netflix</span>
+      <span class="tag-chip bg-danger-subtle text-danger-emphasis" >MIPCOM 2025</span>
+      <span class="tag-chip bg-success-subtle text-success-emphasis" >Variety</span>
+      <span class="tag-chip bg-primary-subtle text-primary-emphasis" >Cannes 2025</span>
+      <span class="tag-chip bg-primary-subtle text-primary-emphasis" >Netflix</span>
     </div>
   </div>
 
@@ -78,9 +104,9 @@
           </div>
         </div>
         <div class="preview-row mt-2">
-          <span class="tag-chip" style="color: #E8733A; background: #FEF3EC; font-size: 12px;">Buyers</span>
-          <span class="tag-chip" style="color: #2E75B6; background: #EBF3FB; font-size: 12px;">MIPCOM 2025</span>
-          <span class="tag-chip" style="color: #8B5CF6; background: #F3EFFE; font-size: 12px;">Priority</span>
+          <span class="tag-chip bg-danger-subtle text-danger-emphasis" style="font-size: 12px;">Distribution</span>
+          <span class="tag-chip bg-primary-subtle text-primary-emphasis" style="font-size: 12px;">MIPCOM 2025</span>
+          <span class="tag-chip bg-primary-subtle text-primary-emphasis" style="font-size: 12px;">Priority</span>
         </div>
       </div>
     </div>

--- a/catalog/previews/tag-chip.html
+++ b/catalog/previews/tag-chip.html
@@ -52,18 +52,18 @@
 </head>
 <body>
   <h4 class="mb-1">TagChip</h4>
-  <p class="text-muted small mb-4">Color-coded tag chips for CRM contact/account classification. Each group has a designated primary + background color pair.</p>
+  <p class="text-muted small mb-4">Category tag chips for CRM contact/account classification. Colour resolves from <code>TagChip::Component::GROUP_VARIANTS</code> as a Bootstrap <code>-subtle</code>/<code>-emphasis</code> pair, so it follows <code>data-bs-theme</code>. The leading dot paints <code>currentColor</code> — inheriting the chip's emphasis foreground — rather than a solid <code>bg-{semantic}</code>, which on a subtle surface would measure only ~2.6:1. Seven categories collapse onto five hues because MPI maps <code>$info → $primary</code>; the text label carries the identity.</p>
 
   <div class="preview-section">
     <div class="preview-label">All Tag Groups</div>
     <div class="preview-row">
-      <span class="tag-chip bg-danger-subtle text-danger-emphasis" >Distribution</span>
-      <span class="tag-chip bg-success-subtle text-success-emphasis" >Outreach</span>
-      <span class="tag-chip bg-primary-subtle text-primary-emphasis" >Press/Festival</span>
-      <span class="tag-chip bg-primary-subtle text-primary-emphasis" >Vendors</span>
-      <span class="tag-chip bg-warning-subtle text-warning-emphasis" >Finance</span>
-      <span class="tag-chip bg-primary-subtle text-primary-emphasis" >Production</span>
-      <span class="tag-chip bg-secondary-subtle text-secondary-emphasis" >Internal</span>
+      <span class="tag-chip bg-danger-subtle text-danger-emphasis" ><span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>Distribution</span>
+      <span class="tag-chip bg-success-subtle text-success-emphasis" ><span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>Outreach</span>
+      <span class="tag-chip bg-primary-subtle text-primary-emphasis" ><span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>Press/Festival</span>
+      <span class="tag-chip bg-primary-subtle text-primary-emphasis" ><span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>Vendors</span>
+      <span class="tag-chip bg-warning-subtle text-warning-emphasis" ><span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>Finance</span>
+      <span class="tag-chip bg-primary-subtle text-primary-emphasis" ><span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>Production</span>
+      <span class="tag-chip bg-secondary-subtle text-secondary-emphasis" ><span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>Internal</span>
     </div>
   </div>
 
@@ -85,10 +85,10 @@
   <div class="preview-section">
     <div class="preview-label">With Specific Tags</div>
     <div class="preview-row">
-      <span class="tag-chip bg-danger-subtle text-danger-emphasis" >MIPCOM 2025</span>
-      <span class="tag-chip bg-success-subtle text-success-emphasis" >Variety</span>
-      <span class="tag-chip bg-primary-subtle text-primary-emphasis" >Cannes 2025</span>
-      <span class="tag-chip bg-primary-subtle text-primary-emphasis" >Netflix</span>
+      <span class="tag-chip bg-danger-subtle text-danger-emphasis" ><span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>MIPCOM 2025</span>
+      <span class="tag-chip bg-success-subtle text-success-emphasis" ><span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>Variety</span>
+      <span class="tag-chip bg-primary-subtle text-primary-emphasis" ><span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>Cannes 2025</span>
+      <span class="tag-chip bg-primary-subtle text-primary-emphasis" ><span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>Netflix</span>
     </div>
   </div>
 
@@ -104,9 +104,9 @@
           </div>
         </div>
         <div class="preview-row mt-2">
-          <span class="tag-chip bg-danger-subtle text-danger-emphasis" style="font-size: 12px;">Distribution</span>
-          <span class="tag-chip bg-primary-subtle text-primary-emphasis" style="font-size: 12px;">MIPCOM 2025</span>
-          <span class="tag-chip bg-primary-subtle text-primary-emphasis" style="font-size: 12px;">Priority</span>
+          <span class="tag-chip bg-danger-subtle text-danger-emphasis" style="font-size: 12px;"><span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>Distribution</span>
+          <span class="tag-chip bg-primary-subtle text-primary-emphasis" style="font-size: 12px;"><span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>MIPCOM 2025</span>
+          <span class="tag-chip bg-primary-subtle text-primary-emphasis" style="font-size: 12px;"><span style="width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0;"></span>Priority</span>
         </div>
       </div>
     </div>

--- a/spec/components/mpi_design_system/admin/account_detail_panel/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/account_detail_panel/component_spec.rb
@@ -161,9 +161,56 @@ RSpec.describe MpiDesignSystem::Admin::AccountDetailPanel::Component, type: :com
     render_inline(described_class.new(**default_params))
 
     expect(page).to have_css("div[style*='text-transform: uppercase']", text: "Tag Groups Represented")
-    expect(page).to have_css("span[style*='color: #E8733A']", text: /Distribution/)
+    expect(page).to have_css("span.bg-danger-subtle.text-danger-emphasis", text: /Distribution/)
     expect(page).to have_text("Distribution (5)")
     expect(page).to have_text("Press/Festival (2)")
+  end
+
+  describe "tag group chips (#168)" do
+    let(:chip_style) { "padding: 3px 10px; font-size: 12px; font-weight: 500" }
+
+    MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS.each do |group, variant|
+      it "renders the #{group} chip as the #{variant} subtle/emphasis pair" do
+        render_inline(described_class.new(
+          **default_params.merge(tag_groups: [ { label: group.to_s, count: 1, group: group } ])
+        ))
+
+        expect(page).to have_css(
+          "span.rounded-pill.bg-#{variant}-subtle.text-#{variant}-emphasis[style='#{chip_style}']",
+          text: /#{group}/
+        )
+      end
+    end
+
+    # Replaces the frozen #64748B/#F1F5F9 literal fallback, which ISS#142 measured at
+    # 4.34:1 — below the AA floor.
+    it "falls back to the adaptive secondary pair for an unknown group" do
+      render_inline(described_class.new(
+        **default_params.merge(tag_groups: [ { label: "Mystery", count: 2, group: :not_a_group } ])
+      ))
+
+      expect(page).to have_css(
+        "span.rounded-pill.bg-secondary-subtle.text-secondary-emphasis", text: /Mystery/
+      )
+      expect(page.native.to_html).not_to include("#64748B")
+      expect(page.native.to_html).not_to include("#F1F5F9")
+    end
+
+    it "renders the section not at all when there are no tag groups" do
+      render_inline(described_class.new(**default_params.merge(tag_groups: [])))
+
+      expect(page).to have_text("Sony Pictures")
+      expect(page).not_to have_text("Tag Groups Represented")
+    end
+
+    it "leaves no frozen-colour declaration on a chip" do
+      render_inline(described_class.new(
+        **default_params.merge(tag_groups: [ { label: "Distribution", count: 5, group: :distribution } ])
+      ))
+
+      expect(page).to have_css("span.bg-danger-subtle", text: /Distribution/)
+      inline_styles("span.rounded-pill").each { |style| expect(style).to be_free_of_frozen_colour }
+    end
   end
 
   it "renders linked titles section" do

--- a/spec/components/mpi_design_system/admin/account_list_row/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/account_list_row/component_spec.rb
@@ -54,11 +54,66 @@ RSpec.describe MpiDesignSystem::Admin::AccountListRow::Component, type: :compone
     expect(page).to have_css("span.rounded-circle", text: "ML")
   end
 
-  it "renders tag dots with group colors" do
-    render_inline(described_class.new(**default_params))
+  describe "tag dots (#168)" do
+    # A decorative identity dot on the row/card surface — not inside a `-subtle` chip —
+    # so it keeps the solid `bg-#{variant}` treatment whose >=3:1 on both resting
+    # backdrops DataTable's browser spec already proves. Geometry survives inline and is
+    # pinned by exact equality so a dropped declaration reddens (#152).
+    let(:dot_style) { "width: 6px; height: 6px; border-radius: 50%;" }
 
-    expect(page).to have_css("span[style*='background: #E8733A']")
-    expect(page).to have_text("Acquisitions")
+    MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS.each do |group, variant|
+      it "renders the #{group} dot as a solid bg-#{variant}" do
+        render_inline(described_class.new(**default_params.merge(tags: [ { group: group, role: group.to_s } ])))
+
+        expect(page).to have_css(
+          "span.d-inline-block.bg-#{variant}[aria-hidden='true'][style='#{dot_style}']", count: 1
+        )
+      end
+    end
+
+    it "falls back to secondary for an unknown group" do
+      render_inline(described_class.new(**default_params.merge(tags: [ { group: :not_a_group, role: "Mystery" } ])))
+
+      expect(page).to have_css("span.d-inline-block.bg-secondary[aria-hidden='true']", count: 1)
+      expect(page).to have_text("Mystery")
+    end
+
+    it "renders one dot per tag" do
+      tags = [ { group: :distribution, role: "Acquisitions" }, { group: :outreach, role: "Press" } ]
+      render_inline(described_class.new(**default_params.merge(tags: tags)))
+
+      expect(page).to have_css("span.d-inline-block.bg-danger[aria-hidden='true']", count: 1)
+      expect(page).to have_css("span.d-inline-block.bg-success[aria-hidden='true']", count: 1)
+      expect(page).to have_text("Acquisitions")
+      expect(page).to have_text("Press")
+    end
+
+    # The label beside the dot is what actually carries the category for a screen
+    # reader (the dot is aria-hidden), so it must stay legible in BOTH colour modes.
+    # The frozen #1B2A4A navy it used to paint measures 1.09:1 on Bootstrap's dark
+    # surface — which would have quietly invalidated the decorative-dot rationale.
+    it "renders the accompanying label in adaptive text-body" do
+      render_inline(described_class.new(**default_params.merge(tags: [ { group: :distribution, role: "Acquisitions" } ])))
+
+      expect(page).to have_css("span.text-body", text: "Acquisitions")
+      expect(inline_style("span.text-body")).to be_free_of_frozen_colour
+    end
+
+    it "renders no dots when there are no tags" do
+      render_inline(described_class.new(**default_params.merge(tags: [])))
+
+      expect(page).to have_css("span, div")
+      expect(page).not_to have_css("span[aria-hidden='true'][class*='bg-']")
+    end
+
+    it "leaves no frozen-colour declaration on the dot" do
+      render_inline(described_class.new(**default_params.merge(tags: [ { group: :distribution, role: "Acquisitions" } ])))
+
+      expect(page).to have_css("span.bg-danger[aria-hidden='true']")
+      inline_styles("span[aria-hidden='true'][class*='bg-']").each do |style|
+        expect(style).to be_free_of_frozen_colour
+      end
+    end
   end
 
   it "renders health status with colored dot" do
@@ -90,16 +145,6 @@ RSpec.describe MpiDesignSystem::Admin::AccountListRow::Component, type: :compone
     expect(page).not_to have_text("Cold")
   end
 
-  it "renders multiple tags" do
-    tags = [
-      { group: :distribution, role: "Acquisitions" },
-      { group: :outreach, role: "Press — Publicist" }
-    ]
-    render_inline(described_class.new(**default_params.merge(tags: tags)))
-
-    expect(page).to have_css("span[style*='background: #E8733A']")
-    expect(page).to have_css("span[style*='background: #2DA67E']")
-  end
 
   it "renders without optional fields" do
     render_inline(described_class.new(name: "Minimal Corp"))

--- a/spec/components/mpi_design_system/admin/account_list_row/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/account_list_row/component_spec.rb
@@ -103,6 +103,10 @@ RSpec.describe MpiDesignSystem::Admin::AccountListRow::Component, type: :compone
       render_inline(described_class.new(**default_params.merge(tags: [])))
 
       expect(page).to have_css("span, div")
+      # Reject ANY tag dot, not merely one carrying `bg-*`: a dot that lost its semantic
+      # class is exactly the regression this should catch, and a `bg-*`-scoped absence
+      # assertion would pass right through it (Codex PR review, P1-8).
+      expect(page).not_to have_css("span[aria-hidden='true'][style*='border-radius: 50%']:not([style*='width: 8px'])")
       expect(page).not_to have_css("span[aria-hidden='true'][class*='bg-']")
     end
 

--- a/spec/components/mpi_design_system/admin/badge/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/badge/component_spec.rb
@@ -63,10 +63,77 @@ RSpec.describe MpiDesignSystem::Admin::Badge::Component, type: :component do
     expect(page).to have_css("span.badge.border.border-secondary.text-secondary")
   end
 
-  it "renders a tag group variant with inline styles" do
-    render_inline(described_class.new(label: "Distribution", variant: :tag_group, tag_group: :distribution))
+  describe "the tag_group variant (#168)" do
+    # Plumbing for every group. The mapping itself is pinned once, in the TagChip spec.
+    described_class::GROUP_VARIANTS.each do |group, variant|
+      it "renders #{group} as the #{variant} subtle/emphasis pair with no inline style" do
+        render_inline(described_class.new(label: group.to_s, variant: :tag_group, tag_group: group))
 
-    expect(page).to have_css("span.badge[style*='#E8733A']", text: "Distribution")
+        expect(page).to have_css(
+          "span.badge.rounded-pill.bg-#{variant}-subtle.text-#{variant}-emphasis", text: group.to_s
+        )
+        # The retired `tag_group_styles` was this component's only inline style, so
+        # after the conversion the badge emits none at all.
+        expect(page).not_to have_css("span.badge[style]")
+      end
+    end
+
+    # Preserves the retired helper's exact behaviour: it returned nil for an unknown
+    # group and the template then omitted the `style` attribute, leaving an unstyled
+    # badge. `secondary` would have been a behaviour change, not a colour-source change.
+    it "renders an unstyled badge for an unknown tag group" do
+      render_inline(described_class.new(label: "Mystery", variant: :tag_group, tag_group: :not_a_group))
+
+      expect(page).to have_css("span.badge.rounded-pill", text: "Mystery")
+      expect(page).not_to have_css("span.badge[class*='-subtle']")
+      expect(page).not_to have_css("span.badge[class*='-emphasis']")
+      expect(page).not_to have_css("span.badge[style]")
+    end
+
+    it "renders an unstyled badge when the variant is tag_group but no group is given" do
+      render_inline(described_class.new(label: "Plain", variant: :tag_group))
+
+      expect(page).to have_css("span.badge.rounded-pill", text: "Plain")
+      expect(page).not_to have_css("span.badge[class*='-subtle']")
+    end
+
+    # A tag_group passed to a non-tag_group variant must not leak into the output —
+    # `variant_classes` only consults it on the :tag_group branch.
+    it "ignores tag_group on the filled variant" do
+      render_inline(described_class.new(label: "Active", variant: :filled, color: :success, tag_group: :distribution))
+
+      expect(page).to have_css("span.badge.text-bg-success", text: "Active")
+      expect(page).not_to have_css("span.badge[class*='-subtle']")
+    end
+
+    it "emits no hex literal for any group" do
+      described_class::GROUP_VARIANTS.each_key do |group|
+        render_inline(described_class.new(label: group.to_s, variant: :tag_group, tag_group: group))
+
+        expect(page).to have_css("span.badge", text: group.to_s)
+        expect(page.native.to_html).not_to match(/#[0-9A-Fa-f]{6}\b/)
+      end
+    end
+  end
+
+  # The fold-in removed Badge's own TAG_GROUPS duplicate; the other two variants must
+  # be untouched by it. Looping the constants means a typo in either ships red.
+  describe "the other variants are unaffected by the fold-in" do
+    described_class::COLORS.each do |color|
+      it "still renders the filled #{color} variant via text-bg-*" do
+        render_inline(described_class.new(label: color.to_s, variant: :filled, color: color))
+
+        expect(page).to have_css("span.badge.text-bg-#{color}", text: color.to_s)
+      end
+
+      it "still renders the outline #{color} variant" do
+        render_inline(described_class.new(label: color.to_s, variant: :outline, color: color))
+
+        expect(page).to have_css(
+          "span.badge.border.border-#{color}.text-#{color}.bg-transparent", text: color.to_s
+        )
+      end
+    end
   end
 
   it "renders with a count" do

--- a/spec/components/mpi_design_system/admin/contact_card/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/contact_card/component_spec.rb
@@ -137,6 +137,19 @@ RSpec.describe MpiDesignSystem::Admin::ContactCard::Component, type: :component 
         )
       end
 
+      # Codex PR review flagged this as the one place the conversion is NOT byte-identical
+      # to the retired helpers, and it is an intentional improvement: `"" || default`
+      # returned `""` (empty strings are truthy in Ruby), so the old code emitted the
+      # invalid declaration `color: ;`. Pinned so the choice is visible rather than latent.
+      it "treats a blank custom colour as absent rather than emitting an empty declaration" do
+        render_inline(described_class.new(name: "Test", tags: [ { label: "Blank", color: "" } ]))
+
+        expect(page).to have_css(
+          "span.rounded-pill.bg-secondary-subtle.text-secondary-emphasis", text: "Blank"
+        )
+        expect(page).not_to have_css("span[style*='color: ;']")
+      end
+
       it "keeps a custom background while defaulting the foreground" do
         render_inline(described_class.new(name: "Test", tags: [ { label: "BgOnly", bg_color: "#654321" } ]))
 
@@ -190,7 +203,12 @@ RSpec.describe MpiDesignSystem::Admin::ContactCard::Component, type: :component 
   it "renders without tags" do
     render_inline(described_class.new(name: "Test User", tags: [], path: "/contacts/2"))
 
-    expect(page).not_to have_css("span[style*='border-radius: 999px']")
+    # Positive anchor first, then the absence. The old form asserted no inline
+    # `border-radius: 999px` — which the conversion moved to `.rounded-pill`, so it
+    # became vacuous and passed even if a pill DID render (Codex PR review, P1-8).
+    expect(page).to have_css("a[href='/contacts/2']", text: "Test User")
+    expect(page).not_to have_css("span.rounded-pill")
+    expect(page).not_to have_css("span[aria-hidden='true']")
   end
 
   it "hides owner when not provided" do

--- a/spec/components/mpi_design_system/admin/contact_card/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/contact_card/component_spec.rb
@@ -150,6 +150,29 @@ RSpec.describe MpiDesignSystem::Admin::ContactCard::Component, type: :component 
         expect(page).not_to have_css("span[style*='color: ;']")
       end
 
+      # Codex round 2, P1: the blank-value example above avoids the MIXED path, where
+      # the other field is present so the custom branch is taken and the blank half is
+      # still interpolated. Both directions asserted.
+      it "defaults a blank foreground when a custom background is supplied" do
+        render_inline(described_class.new(name: "Test", tags: [ { label: "Mixed", color: "", bg_color: "#654321" } ]))
+
+        expect(page).to have_css(
+          "span.rounded-pill[style='#{semantic_pill_style}; color: #64748B; background-color: #654321']",
+          text: "Mixed"
+        )
+        expect(page).not_to have_css("span[style*='color: ;']")
+      end
+
+      it "defaults a blank background when a custom foreground is supplied" do
+        render_inline(described_class.new(name: "Test", tags: [ { label: "Mixed2", color: "#123456", bg_color: "" } ]))
+
+        expect(page).to have_css(
+          "span.rounded-pill[style='#{semantic_pill_style}; color: #123456; background-color: #F1F5F9']",
+          text: "Mixed2"
+        )
+        expect(page).not_to have_css("span[style*='background-color: ;']")
+      end
+
       it "keeps a custom background while defaulting the foreground" do
         render_inline(described_class.new(name: "Test", tags: [ { label: "BgOnly", bg_color: "#654321" } ]))
 

--- a/spec/components/mpi_design_system/admin/contact_card/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/contact_card/component_spec.rb
@@ -55,24 +55,106 @@ RSpec.describe MpiDesignSystem::Admin::ContactCard::Component, type: :component 
     expect(page).to have_text("Acquisitions")
   end
 
-  it "renders tag pills from group symbol" do
-    tags = [ { label: "Acquisitions", group: :distribution } ]
-    render_inline(described_class.new(name: "Test", tags: tags))
+  describe "tag pills (#168)" do
+    # The complete surviving inline style for a semantic pill — exact equality, so any
+    # dropped or added declaration reddens rather than silently passing (#152).
+    let(:semantic_pill_style) { "padding: 2px 8px; font-size: 11px; font-weight: 500" }
+    let(:pill_dot_style) { "width: 6px; height: 6px; border-radius: 50%; background-color: currentColor; flex-shrink: 0" }
 
-    expect(page).to have_css("span[style*='color: #E8733A']", text: "Acquisitions")
-  end
+    MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS.each do |group, variant|
+      it "renders a #{group} tag as the #{variant} subtle/emphasis pair" do
+        render_inline(described_class.new(name: "Test", tags: [ { label: group.to_s, group: group } ]))
 
-  it "renders tag pills from raw colors" do
-    tags = [ { label: "Custom", color: "#2DA67E", bg_color: "#ECF8F4" } ]
-    render_inline(described_class.new(name: "Test", tags: tags))
+        expect(page).to have_css(
+          "span.rounded-pill.bg-#{variant}-subtle.text-#{variant}-emphasis[style='#{semantic_pill_style}']",
+          text: group.to_s
+        )
+      end
+    end
 
-    expect(page).to have_css("span[style*='color: #2DA67E']", text: "Custom")
-  end
+    # The dot is a direct child of the pill, so `currentColor` resolves to whatever the
+    # pill paints — the `-emphasis` foreground here, the caller's own colour below.
+    # Child combinator, not descendant: the latter would pass with the semantic class
+    # on any ancestor wrapper (#152).
+    it "nests a currentColor dot directly inside the pill" do
+      render_inline(described_class.new(name: "Test", tags: [ { label: "Acquisitions", group: :distribution } ]))
 
-  it "renders tag pills as rounded pills" do
-    render_inline(described_class.new(**default_params))
+      expect(page).to have_css(
+        "span.bg-danger-subtle.text-danger-emphasis > span[aria-hidden='true'][style='#{pill_dot_style}']"
+      )
+    end
 
-    expect(page).to have_css("span[style*='border-radius: 999px']", minimum: 1)
+    # #168 replaced the old no-group default — a frozen #64748B on #F1F5F9 that ISS#142
+    # measured at 4.34:1, below the AA floor — with the adaptive secondary pair. Only
+    # genuinely caller-supplied colour stays inline (the ISS#172 passthrough principle).
+    it "falls back to the adaptive secondary pair when neither group nor custom colour is given" do
+      render_inline(described_class.new(name: "Test", tags: [ { label: "Plain" } ]))
+
+      expect(page).to have_css(
+        "span.rounded-pill.bg-secondary-subtle.text-secondary-emphasis[style='#{semantic_pill_style}']",
+        text: "Plain"
+      )
+      expect(page.native.to_html).not_to include("#64748B")
+      expect(page.native.to_html).not_to include("#F1F5F9")
+    end
+
+    describe "the caller-supplied colour passthrough" do
+      it "keeps both custom values inline when no group is given" do
+        tags = [ { label: "Custom", color: "#2DA67E", bg_color: "#ECF8F4" } ]
+        render_inline(described_class.new(name: "Test", tags: tags))
+
+        expect(page).to have_css(
+          "span.rounded-pill[style='#{semantic_pill_style}; color: #2DA67E; background-color: #ECF8F4']",
+          text: "Custom"
+        )
+        expect(page).not_to have_css("span[class*='-subtle']")
+      end
+
+      # Precedence. The custom values here are ones the semantic path can NEVER emit,
+      # so this fails if custom ever overrides a known group — which asserting a
+      # reachable-by-both value could not distinguish (False Green #1).
+      it "ignores custom colours when the group is known" do
+        tags = [ { label: "Acquisitions", group: :distribution, color: "#123456", bg_color: "#654321" } ]
+        render_inline(described_class.new(name: "Test", tags: tags))
+
+        expect(page).to have_css(
+          "span.rounded-pill.bg-danger-subtle.text-danger-emphasis[style='#{semantic_pill_style}']",
+          text: "Acquisitions"
+        )
+        expect(page.native.to_html).not_to include("#123456")
+        expect(page.native.to_html).not_to include("#654321")
+      end
+
+      # The two halves fall back independently, exactly as resolve_color/resolve_bg did.
+      # Requiring BOTH to be present would pass the two-value example above and still
+      # break these callers.
+      it "keeps a custom foreground while defaulting the background" do
+        render_inline(described_class.new(name: "Test", tags: [ { label: "FgOnly", color: "#123456" } ]))
+
+        expect(page).to have_css(
+          "span.rounded-pill[style='#{semantic_pill_style}; color: #123456; background-color: #F1F5F9']",
+          text: "FgOnly"
+        )
+      end
+
+      it "keeps a custom background while defaulting the foreground" do
+        render_inline(described_class.new(name: "Test", tags: [ { label: "BgOnly", bg_color: "#654321" } ]))
+
+        expect(page).to have_css(
+          "span.rounded-pill[style='#{semantic_pill_style}; color: #64748B; background-color: #654321']",
+          text: "BgOnly"
+        )
+      end
+    end
+
+    it "leaves no frozen-colour declaration on a semantic pill or its dot" do
+      render_inline(described_class.new(name: "Test", tags: [ { label: "Acquisitions", group: :distribution } ]))
+
+      expect(page).to have_css("span.bg-danger-subtle", text: "Acquisitions")
+      inline_styles("span.rounded-pill, span.rounded-pill > span").each do |style|
+        expect(style).to be_free_of_frozen_colour
+      end
+    end
   end
 
   it "renders last engaged time with prefix" do

--- a/spec/components/mpi_design_system/admin/contact_detail_panel/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/contact_detail_panel/component_spec.rb
@@ -135,11 +135,66 @@ RSpec.describe MpiDesignSystem::Admin::ContactDetailPanel::Component, type: :com
     expect(page).to have_css("div[style*='text-transform: uppercase']", text: /Groups/)
   end
 
-  it "renders auto-group pills with correct colors" do
-    render_inline(described_class.new(**default_params))
+  # This panel has TWO tag-rendering paths — delegated `TagChip` components for @tags,
+  # and its own auto-group pills. A bare `span.bg-danger-subtle` would pass if only the
+  # delegated chip were correct, so every assertion here is scoped to the auto-group
+  # pill by its own class (`d-inline-block`, which TagChip's `d-inline-flex` chip never
+  # carries).
+  describe "auto-group pills (#168)" do
+    let(:pill) { "span.rounded-pill.d-inline-block" }
+    let(:pill_style) { "padding: 2px 8px; font-size: 11px; font-weight: 500" }
 
-    expect(page).to have_css("span[style*='color: #E8733A']", text: "Distribution")
-    expect(page).to have_css("span[style*='color: #2E75B6']", text: "Press/Festival")
+    it "renders each auto-group as its semantic subtle/emphasis pair" do
+      render_inline(described_class.new(**default_params))
+
+      expect(page).to have_css("#{pill}.bg-danger-subtle.text-danger-emphasis", text: "Distribution")
+      expect(page).to have_css("#{pill}.bg-primary-subtle.text-primary-emphasis", text: "Press/Festival")
+    end
+
+    MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS.each do |group, variant|
+      it "renders the #{group} pill as the #{variant} pair with its complete geometry" do
+        render_inline(described_class.new(
+          **default_params.merge(auto_groups: [ { label: group.to_s, group: group } ])
+        ))
+
+        expect(page).to have_css(
+          "#{pill}.bg-#{variant}-subtle.text-#{variant}-emphasis[style='#{pill_style}']", text: group.to_s
+        )
+      end
+    end
+
+    it "falls back to the adaptive secondary pair for an unknown group" do
+      render_inline(described_class.new(
+        **default_params.merge(auto_groups: [ { label: "Mystery", group: :not_a_group } ])
+      ))
+
+      expect(page).to have_css("#{pill}.bg-secondary-subtle.text-secondary-emphasis", text: "Mystery")
+    end
+
+    it "renders no auto-group section when the list is empty" do
+      render_inline(described_class.new(**default_params.merge(auto_groups: [])))
+
+      expect(page).to have_text("Jane Doe")
+      expect(page).not_to have_css(pill)
+    end
+
+    it "leaves no frozen-colour declaration on a pill" do
+      render_inline(described_class.new(**default_params))
+
+      expect(page).to have_css("#{pill}.bg-danger-subtle", text: "Distribution")
+      inline_styles(pill).each { |style| expect(style).to be_free_of_frozen_colour }
+    end
+
+    # The delegated TagChip path carries its own conversion; this proves the panel
+    # actually renders it, so the two paths above are genuinely distinct.
+    it "renders @tags through the delegated TagChip, not the auto-group pill" do
+      render_inline(described_class.new(
+        **default_params.merge(tags: [ { label: "VIP", group: :outreach } ], auto_groups: [])
+      ))
+
+      expect(page).to have_css("span.d-inline-flex.bg-success-subtle", text: "VIP")
+      expect(page).not_to have_css(pill)
+    end
   end
 
   it "renders hr dividers between sections" do

--- a/spec/components/mpi_design_system/admin/contact_list_row/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/contact_list_row/component_spec.rb
@@ -32,11 +32,66 @@ RSpec.describe MpiDesignSystem::Admin::ContactListRow::Component, type: :compone
     expect(page).to have_css("div[style*='font-size: 12px'][style*='color: #6C757D']", text: "Theatrical Buyer")
   end
 
-  it "renders tag dot with group color" do
-    render_inline(described_class.new(**default_params))
+  describe "tag dots (#168)" do
+    # A decorative identity dot on the row/card surface — not inside a `-subtle` chip —
+    # so it keeps the solid `bg-#{variant}` treatment whose >=3:1 on both resting
+    # backdrops DataTable's browser spec already proves. Geometry survives inline and is
+    # pinned by exact equality so a dropped declaration reddens (#152).
+    let(:dot_style) { "width: 6px; height: 6px; border-radius: 50%;" }
 
-    expect(page).to have_css("span[style*='background: #E8733A']")
-    expect(page).to have_text("Acquisitions")
+    MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS.each do |group, variant|
+      it "renders the #{group} dot as a solid bg-#{variant}" do
+        render_inline(described_class.new(**default_params.merge(tags: [ { group: group, role: group.to_s } ])))
+
+        expect(page).to have_css(
+          "span.d-inline-block.bg-#{variant}[aria-hidden='true'][style='#{dot_style}']", count: 1
+        )
+      end
+    end
+
+    it "falls back to secondary for an unknown group" do
+      render_inline(described_class.new(**default_params.merge(tags: [ { group: :not_a_group, role: "Mystery" } ])))
+
+      expect(page).to have_css("span.d-inline-block.bg-secondary[aria-hidden='true']", count: 1)
+      expect(page).to have_text("Mystery")
+    end
+
+    it "renders one dot per tag" do
+      tags = [ { group: :distribution, role: "Acquisitions" }, { group: :outreach, role: "Press" } ]
+      render_inline(described_class.new(**default_params.merge(tags: tags)))
+
+      expect(page).to have_css("span.d-inline-block.bg-danger[aria-hidden='true']", count: 1)
+      expect(page).to have_css("span.d-inline-block.bg-success[aria-hidden='true']", count: 1)
+      expect(page).to have_text("Acquisitions")
+      expect(page).to have_text("Press")
+    end
+
+    # The label beside the dot is what actually carries the category for a screen
+    # reader (the dot is aria-hidden), so it must stay legible in BOTH colour modes.
+    # The frozen #1B2A4A navy it used to paint measures 1.09:1 on Bootstrap's dark
+    # surface — which would have quietly invalidated the decorative-dot rationale.
+    it "renders the accompanying label in adaptive text-body" do
+      render_inline(described_class.new(**default_params.merge(tags: [ { group: :distribution, role: "Acquisitions" } ])))
+
+      expect(page).to have_css("span.text-body", text: "Acquisitions")
+      expect(inline_style("span.text-body")).to be_free_of_frozen_colour
+    end
+
+    it "renders no dots when there are no tags" do
+      render_inline(described_class.new(**default_params.merge(tags: [])))
+
+      expect(page).to have_css("span, div")
+      expect(page).not_to have_css("span[aria-hidden='true'][class*='bg-']")
+    end
+
+    it "leaves no frozen-colour declaration on the dot" do
+      render_inline(described_class.new(**default_params.merge(tags: [ { group: :distribution, role: "Acquisitions" } ])))
+
+      expect(page).to have_css("span.bg-danger[aria-hidden='true']")
+      inline_styles("span[aria-hidden='true'][class*='bg-']").each do |style|
+        expect(style).to be_free_of_frozen_colour
+      end
+    end
   end
 
   it "renders last engagement in muted text" do
@@ -58,16 +113,6 @@ RSpec.describe MpiDesignSystem::Admin::ContactListRow::Component, type: :compone
     expect(page).not_to have_css("a", text: "Sony Pictures")
   end
 
-  it "renders multiple tags" do
-    tags = [
-      { group: :distribution, role: "Acquisitions" },
-      { group: :outreach, role: "Journalist" }
-    ]
-    render_inline(described_class.new(**default_params.merge(tags: tags)))
-
-    expect(page).to have_css("span[style*='background: #E8733A']")
-    expect(page).to have_css("span[style*='background: #2DA67E']")
-  end
 
   it "hides title when not provided" do
     render_inline(described_class.new(name: "John Smith"))

--- a/spec/components/mpi_design_system/admin/contact_list_row/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/contact_list_row/component_spec.rb
@@ -81,6 +81,10 @@ RSpec.describe MpiDesignSystem::Admin::ContactListRow::Component, type: :compone
       render_inline(described_class.new(**default_params.merge(tags: [])))
 
       expect(page).to have_css("span, div")
+      # Reject ANY tag dot, not merely one carrying `bg-*`: a dot that lost its semantic
+      # class is exactly the regression this should catch, and a `bg-*`-scoped absence
+      # assertion would pass right through it (Codex PR review, P1-8).
+      expect(page).not_to have_css("span[aria-hidden='true'][style*='border-radius: 50%']:not([style*='width: 8px'])")
       expect(page).not_to have_css("span[aria-hidden='true'][class*='bg-']")
     end
 

--- a/spec/components/mpi_design_system/admin/engagement_card/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/engagement_card/component_spec.rb
@@ -124,21 +124,34 @@ RSpec.describe MpiDesignSystem::Admin::EngagementCard::Component, type: :compone
       expect(page).to have_text("Press")
     end
 
-    # The label beside the dot is what actually carries the category for a screen
-    # reader (the dot is aria-hidden), so it must stay legible in BOTH colour modes.
-    # The frozen #1B2A4A navy it used to paint measures 1.09:1 on Bootstrap's dark
-    # surface — which would have quietly invalidated the decorative-dot rationale.
-    it "renders the accompanying label in adaptive text-body" do
+    # DELIBERATELY the opposite of the list rows' equivalent example. This card paints
+    # its own hardcoded `background: #fff`, so the label sits on a fixed white surface in
+    # both colour modes: the navy measures 14.22:1 there, whereas an adaptive `text-body`
+    # would resolve to #DEE2E6 in dark mode and paint 1.30:1 on that same white card.
+    # `text-body` is correct only where the surface adapts too. Pinning the navy here
+    # stops a well-meaning "make it adaptive" edit from reintroducing that regression.
+    it "keeps the frozen navy label, because the card surface is fixed white" do
       render_inline(described_class.new(**default_params.merge(tags: [ { group: :distribution, role: "Acquisitions" } ])))
 
-      expect(page).to have_css("span.text-body", text: "Acquisitions")
-      expect(inline_style("span.text-body")).to be_free_of_frozen_colour
+      expect(page).to have_css("span[style='font-size: 12px; color: #1B2A4A;']", text: "Acquisitions")
+      expect(page).not_to have_css("span.text-body", text: "Acquisitions")
+    end
+
+    it "still paints that label against a white card, so the pair stays AA in both modes" do
+      render_inline(described_class.new(**default_params.merge(tags: [ { group: :distribution, role: "Acquisitions" } ])))
+
+      expect(page).to have_css("article[style*='background: #fff']")
+      expect(MpiDesignSystem::ColorContrast.ratio("#1B2A4A", "#FFFFFF")).to be >= 4.5
     end
 
     it "renders no dots when there are no tags" do
       render_inline(described_class.new(**default_params.merge(tags: [])))
 
       expect(page).to have_css("span, div")
+      # Reject ANY tag dot, not merely one carrying `bg-*`: a dot that lost its semantic
+      # class is exactly the regression this should catch, and a `bg-*`-scoped absence
+      # assertion would pass right through it (Codex PR review, P1-8).
+      expect(page).not_to have_css("span[aria-hidden='true'][style*='border-radius: 50%']:not([style*='width: 8px'])")
       expect(page).not_to have_css("span[aria-hidden='true'][class*='bg-']")
     end
 

--- a/spec/components/mpi_design_system/admin/engagement_card/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/engagement_card/component_spec.rb
@@ -90,11 +90,66 @@ RSpec.describe MpiDesignSystem::Admin::EngagementCard::Component, type: :compone
     expect(page).to have_css("a[href='/accounts/1'][style*='color: #2E75B6']", text: "Sony Pictures")
   end
 
-  it "renders tags with colored dots in right meta" do
-    render_inline(described_class.new(**default_params))
+  describe "tag dots (#168)" do
+    # A decorative identity dot on the row/card surface — not inside a `-subtle` chip —
+    # so it keeps the solid `bg-#{variant}` treatment whose >=3:1 on both resting
+    # backdrops DataTable's browser spec already proves. Geometry survives inline and is
+    # pinned by exact equality so a dropped declaration reddens (#152).
+    let(:dot_style) { "width: 6px; height: 6px; border-radius: 50%;" }
 
-    expect(page).to have_css("span[style*='background: #E8733A']")
-    expect(page).to have_text("Acquisitions")
+    MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS.each do |group, variant|
+      it "renders the #{group} dot as a solid bg-#{variant}" do
+        render_inline(described_class.new(**default_params.merge(tags: [ { group: group, role: group.to_s } ])))
+
+        expect(page).to have_css(
+          "span.d-inline-block.bg-#{variant}[aria-hidden='true'][style='#{dot_style}']", count: 1
+        )
+      end
+    end
+
+    it "falls back to secondary for an unknown group" do
+      render_inline(described_class.new(**default_params.merge(tags: [ { group: :not_a_group, role: "Mystery" } ])))
+
+      expect(page).to have_css("span.d-inline-block.bg-secondary[aria-hidden='true']", count: 1)
+      expect(page).to have_text("Mystery")
+    end
+
+    it "renders one dot per tag" do
+      tags = [ { group: :distribution, role: "Acquisitions" }, { group: :outreach, role: "Press" } ]
+      render_inline(described_class.new(**default_params.merge(tags: tags)))
+
+      expect(page).to have_css("span.d-inline-block.bg-danger[aria-hidden='true']", count: 1)
+      expect(page).to have_css("span.d-inline-block.bg-success[aria-hidden='true']", count: 1)
+      expect(page).to have_text("Acquisitions")
+      expect(page).to have_text("Press")
+    end
+
+    # The label beside the dot is what actually carries the category for a screen
+    # reader (the dot is aria-hidden), so it must stay legible in BOTH colour modes.
+    # The frozen #1B2A4A navy it used to paint measures 1.09:1 on Bootstrap's dark
+    # surface — which would have quietly invalidated the decorative-dot rationale.
+    it "renders the accompanying label in adaptive text-body" do
+      render_inline(described_class.new(**default_params.merge(tags: [ { group: :distribution, role: "Acquisitions" } ])))
+
+      expect(page).to have_css("span.text-body", text: "Acquisitions")
+      expect(inline_style("span.text-body")).to be_free_of_frozen_colour
+    end
+
+    it "renders no dots when there are no tags" do
+      render_inline(described_class.new(**default_params.merge(tags: [])))
+
+      expect(page).to have_css("span, div")
+      expect(page).not_to have_css("span[aria-hidden='true'][class*='bg-']")
+    end
+
+    it "leaves no frozen-colour declaration on the dot" do
+      render_inline(described_class.new(**default_params.merge(tags: [ { group: :distribution, role: "Acquisitions" } ])))
+
+      expect(page).to have_css("span.bg-danger[aria-hidden='true']")
+      inline_styles("span[aria-hidden='true'][class*='bg-']").each do |style|
+        expect(style).to be_free_of_frozen_colour
+      end
+    end
   end
 
   it "renders creator name" do

--- a/spec/components/mpi_design_system/admin/tag_chip/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/tag_chip/component_spec.rb
@@ -3,82 +3,162 @@
 require "spec_helper"
 
 RSpec.describe MpiDesignSystem::Admin::TagChip::Component, type: :component do
-  it "renders a tag chip with group color" do
+  # The chip's complete surviving inline style. Pinned by EXACT equality rather than
+  # `[style*=…]` fragments: a substring pin polices only the declarations it names, so
+  # every unnamed survivor stays deletable-green (#152). Any dropped, added or reordered
+  # declaration reddens this, which is the intent — a deliberate geometry change updates
+  # the constant on purpose.
+  let(:chip_style_md) { "font-size: 13px; padding: 0.25em 0.75em; line-height: 1.4" }
+  let(:chip_style_sm) { "font-size: 12px; padding: 0.25em 0.75em; line-height: 1.4" }
+  let(:dot_style) { "width: 8px; height: 8px; border-radius: 50%; background-color: currentColor; flex-shrink: 0" }
+  let(:remove_style) { "padding: 0; font-size: inherit; line-height: 1; cursor: pointer" }
+
+  it "renders the label inside a pill carrying its group's semantic pair" do
     render_inline(described_class.new(label: "Distribution", group: :distribution))
 
-    expect(page).to have_css("span[style*='#E8733A']", text: "Distribution")
-    expect(page).to have_css("span[style*='#FEF3EC']")
+    expect(page).to have_css(
+      "span.rounded-pill.bg-danger-subtle.text-danger-emphasis", text: "Distribution"
+    )
   end
 
-  it "renders different colors for different groups" do
-    render_inline(described_class.new(label: "Outreach", group: :outreach))
+  # Plumbing: every group reaches the utilities its mapping specifies. This does NOT
+  # prove the mapping itself — both sides read the same constant, so a remap would move
+  # them together and stay green. The exact-mapping example below is what pins that.
+  described_class::GROUP_VARIANTS.each do |group, variant|
+    it "renders the #{group} chip as the #{variant} subtle/emphasis pair" do
+      render_inline(described_class.new(label: group.to_s, group: group))
 
-    expect(page).to have_css("span[style*='#2DA67E']", text: "Outreach")
+      expect(page).to have_css("span.bg-#{variant}-subtle.text-#{variant}-emphasis", text: group.to_s)
+    end
   end
 
-  it "renders a colored dot indicator before the label" do
-    render_inline(described_class.new(label: "Distribution", group: :distribution))
+  describe "the decorative dot" do
+    # Child combinator, not a descendant selector: `span.bg-danger-subtle span[…]` would
+    # also pass if the semantic class landed on some ancestor wrapper rather than the
+    # chip itself — the exact regression this asserts against (#152).
+    it "nests directly inside the chip so it inherits the chip's foreground" do
+      render_inline(described_class.new(label: "Distribution", group: :distribution))
 
-    expect(page).to have_css("span[style*='background-color: #E8733A'][style*='border-radius: 50%']")
+      expect(page).to have_css(
+        "span.bg-danger-subtle.text-danger-emphasis > span[aria-hidden='true'][style='#{dot_style}']"
+      )
+    end
+
+    # currentColor is load-bearing, not incidental. A solid `bg-#{variant}` fill inside a
+    # `-subtle` chip measures 2.67:1 (success) / 2.62:1 (warning) — under the 3:1 floor
+    # `.claude/rules/frontend.md` sets for a decorative semantic dot. Inheriting the
+    # `-emphasis` foreground instead measures 9.43:1 / 9.34:1.
+    it "paints currentColor rather than a solid semantic fill" do
+      render_inline(described_class.new(label: "Outreach", group: :outreach))
+
+      expect(page).to have_css("span[aria-hidden='true'][style*='background-color: currentColor']")
+      expect(page).not_to have_css("span[aria-hidden='true'][class*='bg-']")
+    end
   end
 
-  it "renders dot with correct color for each group" do
-    render_inline(described_class.new(label: "Press/Festival", group: :press_festival))
+  describe "the remove control" do
+    it "renders a button that pins no colour and no opacity of its own" do
+      render_inline(described_class.new(label: "MIPCOM 2025", group: :distribution, removable: true))
 
-    expect(page).to have_css("span[style*='background-color: #2E75B6'][style*='border-radius: 50%']")
+      # Positive pin FIRST — an unpaired `not_to` would also pass if nothing rendered.
+      expect(page).to have_css(
+        "button.text-reset.bg-transparent.border-0[aria-label='Remove MIPCOM 2025'][style='#{remove_style}']"
+      )
+      expect(page).to have_css("i.bi.bi-x-lg")
+      # The retired `opacity: 0.6` faded an already-sub-AA foreground further (#130).
+      expect(page).not_to have_css("button[style*='opacity']")
+      expect(page).not_to have_css("button[style*='color']")
+    end
+
+    it "renders a turbo link with the same treatment when remove_url is given" do
+      render_inline(described_class.new(label: "MIPCOM 2025", group: :distribution, removable: true, remove_url: "/tags/1"))
+
+      expect(page).to have_css(
+        "a.text-reset.bg-transparent.border-0[href='/tags/1'][aria-label='Remove MIPCOM 2025'][style='#{remove_style}']"
+      )
+      expect(page).to have_css("a[data-turbo-method='delete']")
+      expect(page).not_to have_css("a[style*='opacity']")
+    end
+
+    it "does not show a remove control by default" do
+      render_inline(described_class.new(label: "Press/Festival", group: :press_festival))
+
+      expect(page).to have_css("span.rounded-pill", text: "Press/Festival")
+      expect(page).not_to have_css("button")
+      expect(page).not_to have_css("a")
+    end
   end
 
-  it "renders a removable chip with close button (no URL)" do
-    render_inline(described_class.new(label: "MIPCOM 2025", group: :distribution, removable: true))
+  describe "sizes" do
+    it "renders the default size with its complete geometry" do
+      render_inline(described_class.new(label: "Test", group: :internal))
 
-    expect(page).to have_css("button[aria-label='Remove MIPCOM 2025']")
-    expect(page).to have_css("i.bi.bi-x-lg")
+      expect(page).to have_css("span.rounded-pill[style='#{chip_style_md}']", text: "Test")
+    end
+
+    it "renders the small size with its complete geometry" do
+      render_inline(described_class.new(label: "Test", group: :internal, size: :sm))
+
+      expect(page).to have_css("span.rounded-pill[style='#{chip_style_sm}']", text: "Test")
+    end
+
+    it "falls back to the default size for an unknown size" do
+      render_inline(described_class.new(label: "Test", group: :internal, size: :enormous))
+
+      expect(page).to have_css("span.rounded-pill[style='#{chip_style_md}']", text: "Test")
+    end
   end
 
-  it "renders a removable chip as turbo link when remove_url provided" do
-    render_inline(described_class.new(label: "MIPCOM 2025", group: :distribution, removable: true, remove_url: "/tags/1"))
+  describe "edge cases" do
+    # :internal maps to :secondary, so this also proves the initializer's group
+    # coercion still runs after the conversion.
+    it "coerces an unknown group to internal" do
+      render_inline(described_class.new(label: "Mystery", group: :not_a_group))
 
-    expect(page).to have_css("a[href='/tags/1'][aria-label='Remove MIPCOM 2025']")
-    expect(page).to have_css("a[data-turbo-method='delete']")
+      expect(page).to have_css("span.bg-secondary-subtle.text-secondary-emphasis", text: "Mystery")
+    end
+
+    it "renders an empty label without raising" do
+      render_inline(described_class.new(label: "", group: :finance))
+
+      expect(page).to have_css("span.rounded-pill.bg-warning-subtle.text-warning-emphasis")
+    end
   end
 
-  it "does not show remove button by default" do
-    render_inline(described_class.new(label: "Press/Festival", group: :press_festival))
+  # #168's conversion guard. `.claude/rules/testing.md` requires this be watched RED
+  # against a real mutation — reintroducing `color: #{'#'}E8733A` into `chip_styles`
+  # reddens it, as does `opacity: 0.6` on the remove button.
+  describe "theme adaptivity (#168)" do
+    described_class::GROUP_VARIANTS.each_key do |group|
+      it "leaves no frozen-colour declaration on the #{group} chip, dot or remove button" do
+        render_inline(described_class.new(label: group.to_s, group: group, removable: true))
 
-    expect(page).not_to have_css("button")
+        expect(page).to have_css("span.rounded-pill", text: group.to_s)
+        inline_styles("span, button, a").each do |style|
+          expect(style).to be_free_of_frozen_colour
+        end
+      end
+    end
+
+    it "emits no hex literal anywhere in the rendered chip" do
+      render_inline(described_class.new(label: "Distribution", group: :distribution, removable: true))
+
+      expect(page).to have_css("span.bg-danger-subtle", text: "Distribution")
+      expect(page.native.to_html).not_to match(/#[0-9A-Fa-f]{6}\b/)
+    end
   end
 
-  it "renders at small size" do
-    render_inline(described_class.new(label: "Test", group: :internal, size: :sm))
-
-    expect(page).to have_css("span[style*='font-size: 12px']")
-  end
-
-  it "renders at default size" do
-    render_inline(described_class.new(label: "Test", group: :internal))
-
-    expect(page).to have_css("span[style*='font-size: 13px']")
-  end
-
-  it "has pill shape" do
-    render_inline(described_class.new(label: "Test", group: :vendors))
-
-    expect(page).to have_css("span[style*='border-radius: 999px']")
-  end
-
-  # GROUP_VARIANTS is the shared tag-group -> Bootstrap-semantic mapping that
-  # FilterChipBar and DataTable consume (#151). Every GROUPS key must have a mapping,
-  # or a converted consumer would hit `nil` and silently fall back to `secondary`.
-  describe "GROUP_VARIANTS mapping (#151)" do
+  # GROUP_VARIANTS is the shared tag-group -> Bootstrap-semantic mapping. Since #168
+  # every engine renderer of tag-group colour reads it, so a defect here is systemic.
+  describe "GROUP_VARIANTS mapping" do
     it "maps every GROUPS key to a semantic variant" do
       expect(described_class::GROUP_VARIANTS.keys).to match_array(described_class::GROUPS.keys)
     end
 
-    # The consumer loops (FilterChipBar/DataTable) read this same constant, so a
-    # semantic REMAP (e.g. distribution: :danger -> :success) would render and assert
-    # the new value identically and ship green there. Pinning the exact mapping makes
-    # any category recolour a deliberate, test-updating change — the crux design
-    # decision of #151 (info==primary collapses the three cool categories onto blue).
+    # The consumer loops throughout the suite read this same constant, so a semantic
+    # REMAP (e.g. distribution: :danger -> :success) would render and assert the new
+    # value identically and ship green everywhere. Pinning the exact mapping is the only
+    # assertion in the suite that catches it — it must not be replaced by a loop.
     it "maps each category to its issue-specified semantic" do
       expect(described_class::GROUP_VARIANTS).to eq(
         press_festival: :primary,
@@ -95,15 +175,28 @@ RSpec.describe MpiDesignSystem::Admin::TagChip::Component, type: :component do
       valid = %i[primary secondary success warning danger info light dark]
       expect(described_class::GROUP_VARIANTS.values.uniq - valid).to be_empty
     end
+  end
 
-    # TagChip's OWN rendering stays hex this phase — the conversion is limited to the
-    # two list-view consumers. This pins that scope: the chip still emits its frozen
-    # colour pair, so a future TagChip conversion is a deliberate, tested change rather
-    # than an accident. (#151 follow-up)
-    it "leaves TagChip's own rendering on the frozen hex palette" do
-      render_inline(described_class.new(label: "Distribution", group: :distribution))
+  # GROUPS is retained post-#168 as the canonical key set and the brand-hex reference,
+  # but nothing may render from it. #167 pinned the opposite ("leaves TagChip's own
+  # rendering on the frozen hex palette") so that converting TagChip could not happen by
+  # accident; #168 IS that deliberate change, so the guard is inverted rather than
+  # deleted — it now holds the chip to the semantics.
+  describe "GROUPS (retained, deprecated for rendering)" do
+    it "still defines the canonical group key set" do
+      expect(described_class::GROUPS.keys).to match_array(
+        %i[production distribution finance press_festival internal vendors outreach]
+      )
+    end
 
-      expect(page).to have_css("span[style*='color: #E8733A'][style*='background-color: #FEF3EC']", text: "Distribution")
+    it "no longer supplies any rendered colour" do
+      described_class::GROUPS.each do |group, pair|
+        render_inline(described_class.new(label: group.to_s, group: group))
+
+        expect(page).to have_css("span.rounded-pill", text: group.to_s)
+        expect(page.native.to_html).not_to include(pair[:color])
+        expect(page.native.to_html).not_to include(pair[:bg])
+      end
     end
   end
 end

--- a/spec/components/mpi_design_system/admin/tag_input/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/tag_input/component_spec.rb
@@ -171,6 +171,30 @@ RSpec.describe MpiDesignSystem::Admin::TagInput::Component, type: :component do
       expect(page).to have_css("#{derived}.bg-success-subtle.text-success-emphasis", text: "Outreach", count: 1)
     end
 
+    # Complete surviving inline style, exact equality. Without this, deleting
+    # `derived_group_styles` outright or dropping one declaration both ship green — the
+    # #152 "guards police what LEFT, not what stayed" lesson.
+    MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS.each do |group, variant|
+      it "renders the #{group} derived pill as the #{variant} pair with its complete geometry" do
+        render_inline(described_class.new(
+          available_tags: available_tags, selected_tags: [ { label: "X", group: group } ]
+        ))
+
+        expect(page).to have_css(
+          "#{derived}.bg-#{variant}-subtle.text-#{variant}-emphasis[style='padding: 2px 8px; font-size: 11px; font-weight: 500']"
+        )
+      end
+    end
+
+    it "leaves no frozen-colour declaration on a derived pill" do
+      render_inline(described_class.new(
+        available_tags: available_tags, selected_tags: [ { label: "X", group: :distribution } ]
+      ))
+
+      expect(page).to have_css("#{derived}.bg-danger-subtle")
+      inline_styles(derived).each { |style| expect(style).to be_free_of_frozen_colour }
+    end
+
     it "renders no derived section when nothing is selected" do
       render_inline(described_class.new(available_tags: available_tags))
 

--- a/spec/components/mpi_design_system/admin/tag_input/component_spec.rb
+++ b/spec/components/mpi_design_system/admin/tag_input/component_spec.rb
@@ -98,13 +98,85 @@ RSpec.describe MpiDesignSystem::Admin::TagInput::Component, type: :component do
     expect(page).to have_css("div[data-mpi--tag-input-target='dropdown'][style*='margin-top: 4px; display: none']", visible: :hidden)
   end
 
-  it "renders selected tag chips with correct colors" do
-    render_inline(described_class.new(
-      available_tags: available_tags,
-      selected_tags: [ { label: "VIP", group: :distribution } ]
-    ))
+  # Three separate colour-emitting paths live in this template — the selected chip, its
+  # remove button, and the derived-group pills — and before #168 only ONE had any
+  # coverage. Each is asserted by a selector unique to it, so a defect in one cannot be
+  # masked by another being right.
+  describe "selected tag chips (#168)" do
+    let(:chip) { "span[data-mpi--tag-input-target='tag']" }
+    let(:chip_style) { "font-size: 13px; padding: 0.25em 0.75em; line-height: 1.4" }
+    let(:remove_style) { "padding: 0; font-size: inherit; line-height: 1; cursor: pointer" }
 
-    expect(page).to have_css("span[style*='color: #E8733A']", text: "VIP")
+    MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS.each do |group, variant|
+      it "renders a #{group} chip as the #{variant} subtle/emphasis pair" do
+        render_inline(described_class.new(
+          available_tags: available_tags, selected_tags: [ { label: "VIP", group: group } ]
+        ))
+
+        expect(page).to have_css(
+          "#{chip}.rounded-pill.bg-#{variant}-subtle.text-#{variant}-emphasis[style='#{chip_style}']",
+          text: "VIP"
+        )
+      end
+    end
+
+    it "falls back to the adaptive secondary pair for an unknown group" do
+      render_inline(described_class.new(
+        available_tags: available_tags, selected_tags: [ { label: "VIP", group: :not_a_group } ]
+      ))
+
+      expect(page).to have_css("#{chip}.bg-secondary-subtle.text-secondary-emphasis", text: "VIP")
+    end
+
+    it "renders a remove button that pins no colour and no opacity" do
+      render_inline(described_class.new(
+        available_tags: available_tags, selected_tags: [ { label: "VIP", group: :distribution } ]
+      ))
+
+      expect(page).to have_css(
+        "#{chip} > button.text-reset.bg-transparent.border-0[aria-label='Remove VIP'][style='#{remove_style}']"
+      )
+      expect(page).not_to have_css("#{chip} > button[style*='opacity']")
+      expect(page).not_to have_css("#{chip} > button[style*='color']")
+    end
+
+    it "leaves no frozen-colour declaration on the chip or its button" do
+      render_inline(described_class.new(
+        available_tags: available_tags, selected_tags: [ { label: "VIP", group: :distribution } ]
+      ))
+
+      expect(page).to have_css("#{chip}.bg-danger-subtle", text: "VIP")
+      inline_styles("#{chip}, #{chip} > button").each do |style|
+        expect(style).to be_free_of_frozen_colour
+      end
+    end
+  end
+
+  describe "derived group pills (#168)" do
+    # `d-inline-block` distinguishes the derived pill from the `d-inline-flex` chip, so
+    # these assertions cannot be satisfied by the chips being correct.
+    let(:derived) { "span.rounded-pill.d-inline-block" }
+
+    it "renders one pill per distinct group of the selected tags" do
+      render_inline(described_class.new(
+        available_tags: available_tags,
+        selected_tags: [
+          { label: "VIP", group: :distribution },
+          { label: "Press", group: :outreach },
+          { label: "Also VIP", group: :distribution }
+        ]
+      ))
+
+      expect(page).to have_css("#{derived}.bg-danger-subtle.text-danger-emphasis", text: "Distribution", count: 1)
+      expect(page).to have_css("#{derived}.bg-success-subtle.text-success-emphasis", text: "Outreach", count: 1)
+    end
+
+    it "renders no derived section when nothing is selected" do
+      render_inline(described_class.new(available_tags: available_tags))
+
+      expect(page).to have_css("div[data-controller='mpi--tag-input']")
+      expect(page).not_to have_css(derived)
+    end
   end
 
   it "renders Stimulus action bindings on input" do

--- a/spec/components/previews/mpi_design_system/admin/tag_chip/component_preview.rb
+++ b/spec/components/previews/mpi_design_system/admin/tag_chip/component_preview.rb
@@ -33,6 +33,16 @@ class MpiDesignSystem::Admin::TagChip::ComponentPreview < ApplicationComponentPr
     )
   end
 
+  # The chip is one of the few converted components whose surrounding markup is the chip
+  # itself, so a colour-mode preview here shows the real thing rather than an adaptive tag
+  # sitting inside a still-fixed light shell. The card, list-row and detail-panel previews
+  # deliberately do NOT get a dark example for that reason — see the #168 PR notes.
+  #
+  # @label Colour Modes
+  def colour_modes
+    render_with_template
+  end
+
   # @label Small Size
   def small
     render_with_template(

--- a/spec/components/previews/mpi_design_system/admin/tag_chip/component_preview/colour_modes.html.erb
+++ b/spec/components/previews/mpi_design_system/admin/tag_chip/component_preview/colour_modes.html.erb
@@ -1,0 +1,35 @@
+<%# Light and dark side by side. Each wrapper sets `data-bs-theme` and `bg-body`, so the
+    surface and the chips inside it resolve from the same colour mode — which is the whole
+    claim of the #168 conversion.
+
+    One chip per DISTINCT hue: the seven CRM categories collapse to five, because MPI maps
+    $info -> $primary, so press_festival / production / vendors all render blue. The text
+    label is what carries the category identity; the hue is reinforcement.
+
+    Each chip is removable, so the remove control's inherited `-emphasis` foreground (via
+    `text-reset`, with no `opacity`) is visible in both modes too. The dot paints
+    `currentColor`, tracking whatever the chip's foreground resolves to. %>
+<% samples = [
+     { label: "Distribution", group: :distribution },
+     { label: "Outreach", group: :outreach },
+     { label: "Finance", group: :finance },
+     { label: "Press/Festival", group: :press_festival },
+     { label: "Internal", group: :internal }
+   ] %>
+
+<div class="d-flex flex-column gap-3">
+  <% { "light" => "Light", "dark" => "Dark" }.each do |mode, heading| %>
+    <div data-bs-theme="<%= mode %>" class="bg-body p-3 rounded-3 border">
+      <div class="text-body-secondary mb-2" style="font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em;">
+        <%= heading %>
+      </div>
+      <div class="d-flex flex-wrap gap-2">
+        <% samples.each do |sample| %>
+          <%= render MpiDesignSystem::Admin::TagChip::Component.new(
+                label: sample[:label], group: sample[:group], removable: true, remove_url: "#"
+              ) %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/spec/dummy/app/views/contrast_demo/show.html.erb
+++ b/spec/dummy/app/views/contrast_demo/show.html.erb
@@ -124,6 +124,25 @@
         ) %>
   </section>
 
+  <%# #168: one TagChip per DISTINCT GROUP_VARIANTS hue (the 7 categories collapse to 5,
+      since MPI maps $info -> $primary), shared by the light (#tag-chip) and dark
+      (#dark-tag-chip) renders so contrast_spec can loop every semantic in both modes.
+      Each chip is `removable` so the remove control's inherited foreground — and the
+      absence of the retired `opacity: 0.6` — are measurable too. %>
+  <% tag_chip_samples = MpiDesignSystem::Admin::TagChip::Component::GROUP_VARIANTS
+       .group_by { |_group, variant| variant }
+       .map { |variant, pairs| [ variant, pairs.first.first ] } %>
+
+  <section id="tag-chip" class="mb-4">
+    <% tag_chip_samples.each do |variant, group| %>
+      <span data-variant="<%= variant %>" class="me-1">
+        <%= render MpiDesignSystem::Admin::TagChip::Component.new(
+              label: group.to_s.titleize, group: group, removable: true
+            ) %>
+      </span>
+    <% end %>
+  </section>
+
   <section id="filter-chip-bar" class="mb-4">
     <%= render MpiDesignSystem::Admin::FilterChipBar::Component.new(
           groups: [
@@ -189,6 +208,19 @@
             clear_all_url: "#"
           ) %>
     </div>
+    <%# #168: the same five hues under dark mode. The `-subtle`/`-emphasis` pair must
+        re-resolve to its dark values, and the dot — which paints `currentColor` rather
+        than a solid `bg-#{variant}` — must follow the chip's dark foreground. %>
+    <div id="dark-tag-chip" class="mb-3">
+      <% tag_chip_samples.each do |variant, group| %>
+        <span data-variant="<%= variant %>" class="me-1">
+          <%= render MpiDesignSystem::Admin::TagChip::Component.new(
+                label: group.to_s.titleize, group: group, removable: true
+              ) %>
+        </span>
+      <% end %>
+    </div>
+
     <div id="dark-filter-chip-bar" class="mb-3">
       <%= render MpiDesignSystem::Admin::FilterChipBar::Component.new(
             groups: [

--- a/spec/dummy/app/views/tag_input_demo/show.html.erb
+++ b/spec/dummy/app/views/tag_input_demo/show.html.erb
@@ -1,14 +1,26 @@
 <% content_for :title, "Tag Input Demo" %>
 
+<%# Groups use the CRM vocabulary the component actually validates against
+    (`TagChip::Component::GROUP_VARIANTS`). This fixture previously used the LEGACY
+    names — buyers / sellers / festivals — which existed only in the Stimulus
+    controller's own stale colour map. That is why the tag_input_controller.js
+    key mismatch went unnoticed for so long: the one fixture anyone would look at was
+    written against the controller's vocabulary, so the JS path looked correct here
+    while every real component group fell through to grey. (#168)
+
+    One tag per distinct GROUP_VARIANTS hue, so the feature spec can prove the
+    interactively-added chip picks up the right semantic for more than one category. %>
 <main class="container py-4">
   <h1 class="h4 mb-3">Tag Input Demo</h1>
 
   <%= render MpiDesignSystem::Admin::TagInput::Component.new(
         available_tags: [
-          { label: "VIP", group: :buyers },
-          { label: "Priority", group: :sellers },
-          { label: "TIFF 2026", group: :festivals },
-          { label: "Cannes", group: :festivals }
+          { label: "VIP", group: :distribution },
+          { label: "Priority", group: :outreach },
+          { label: "TIFF 2026", group: :press_festival },
+          { label: "Cannes", group: :press_festival },
+          { label: "Budget", group: :finance },
+          { label: "Ops", group: :internal }
         ],
         name: "contact[tags][]"
       ) %>

--- a/spec/dummy/app/views/tag_input_demo/show.html.erb
+++ b/spec/dummy/app/views/tag_input_demo/show.html.erb
@@ -8,8 +8,11 @@
     written against the controller's vocabulary, so the JS path looked correct here
     while every real component group fell through to grey. (#168)
 
-    One tag per distinct GROUP_VARIANTS hue, so the feature spec can prove the
-    interactively-added chip picks up the right semantic for more than one category. %>
+    ALL SEVEN groups are present, not one per distinct hue: the Stimulus controller
+    duplicates the mapping in JavaScript (it cannot read the Ruby constant), so the
+    feature spec has to exercise every KEY to prove the duplicate is complete. Covering
+    only the five hues would let a missing `production` or `vendors` key fall through to
+    the secondary fallback unnoticed. %>
 <main class="container py-4">
   <h1 class="h4 mb-3">Tag Input Demo</h1>
 
@@ -20,7 +23,9 @@
           { label: "TIFF 2026", group: :press_festival },
           { label: "Cannes", group: :press_festival },
           { label: "Budget", group: :finance },
-          { label: "Ops", group: :internal }
+          { label: "Ops", group: :internal },
+          { label: "Studio", group: :production },
+          { label: "Agency", group: :vendors }
         ],
         name: "contact[tags][]"
       ) %>

--- a/spec/features/contrast_spec.rb
+++ b/spec/features/contrast_spec.rb
@@ -23,85 +23,6 @@ require "spec_helper"
 # browser actually painted — following the computed-style precedent set by the
 # `mpi--tag-input` spec (see `.claude/rules/testing.md`).
 RSpec.describe "Derived foreground contrast", type: :feature, js: true do
-  # Resolves what a user actually SEES, which is not the same as the declared
-  # value in three ways this suite has to account for:
-  #
-  #   1. A colour may carry alpha. `.text-body-secondary` is
-  #      `rgba(<body-color>, .75)`, so reading the RGB channels and discarding
-  #      the alpha overstates contrast. Alpha is composited over the backdrop.
-  #   2. A background may be transparent, in which case the visible backdrop is
-  #      an ancestor's — so we walk up until we find an opaque one.
-  #   3. `opacity` on any ancestor fades the whole subtree. It is invisible to
-  #      the element's own computed `color`, which is how the retired
-  #      `opacity: 0.8` hid a 3.71:1 failure behind an AA-clean declaration.
-  RESOLVE_JS = <<~JS
-    (() => {
-      const parse = (value) => {
-        const parts = (value.match(/[\\d.]+/g) || []).map(Number);
-        return { r: parts[0], g: parts[1], b: parts[2], a: parts.length > 3 ? parts[3] : 1 };
-      };
-      const opaqueBackdrop = (node) => {
-        for (let el = node; el; el = el.parentElement) {
-          const bg = parse(getComputedStyle(el).backgroundColor);
-          if (bg.a === 1) return bg;
-        }
-        return { r: 255, g: 255, b: 255, a: 1 };
-      };
-      const over = (fg, bg) => ({
-        r: fg.r * fg.a + bg.r * (1 - fg.a),
-        g: fg.g * fg.a + bg.g * (1 - fg.a),
-        b: fg.b * fg.a + bg.b * (1 - fg.a),
-      });
-      const hex = (c) => '#' + [c.r, c.g, c.b]
-        .map((v) => Math.round(v).toString(16).padStart(2, '0')).join('').toUpperCase();
-
-      const el = document.querySelector(SELECTOR);
-      if (!el) return null;
-
-      let cumulativeOpacity = 1;
-      for (let n = el; n; n = n.parentElement) {
-        cumulativeOpacity *= parseFloat(getComputedStyle(n).opacity);
-      }
-
-      const backdrop = opaqueBackdrop(el);
-      const foreground = over(parse(getComputedStyle(el).color), backdrop);
-
-      return {
-        foreground: hex(foreground),
-        background: hex(backdrop),
-        cumulativeOpacity: cumulativeOpacity,
-      };
-    })()
-  JS
-
-  def resolve(selector)
-    result = page.evaluate_script(RESOLVE_JS.sub("SELECTOR", selector.to_json))
-    raise "no element matched #{selector}" if result.nil?
-
-    result.transform_keys(&:to_sym)
-  end
-
-  def ratio_for(selector)
-    resolved = resolve(selector)
-    measured = MpiDesignSystem::ColorContrast.ratio(resolved[:foreground], resolved[:background])
-
-    [ measured, resolved[:foreground], resolved[:background] ]
-  end
-
-  def border_color_of(selector)
-    page.evaluate_script(
-      "(() => { const e = document.querySelector(#{selector.to_json}); " \
-      "if (!e) throw new Error('no element matched'); " \
-      "return getComputedStyle(e).borderTopColor; })()"
-    )
-  end
-
-  def computed(selector, property)
-    key = property == "color" ? :foreground : :background
-
-    resolve(selector).fetch(key)
-  end
-
   before { visit "/contrast_demo" }
 
   # The avatar palette parsed from its source map (_tokens_values.scss), so this browser
@@ -814,6 +735,83 @@ RSpec.describe "Derived foreground contrast", type: :feature, js: true do
             expect(backdrop).to eq(expected[:surface])
             expect(measured).to be >= 3.0,
               "#{mode} #{variant} status dot #{fill} on resting #{backdrop} = #{measured.round(2)}:1"
+          end
+        end
+      end
+    end
+  end
+
+  # TagChip (#168). The conversion moved every tag renderer in the engine onto the shared
+  # group -> semantic mapping, and TagChip is the canonical one. Three claims a render
+  # spec cannot reach, proven here for EVERY distinct hue in BOTH colour modes:
+  #
+  #   * the `-subtle`/`-emphasis` pair actually clears AA once Bootstrap derives it —
+  #     the plan asserted this, and `bin/verify-contrast-oracle` is avatar-only, so
+  #     without these pins the AA claim would rest on nothing;
+  #   * the dot paints `currentColor`, i.e. the chip's own emphasis foreground. This is
+  #     the whole reason it is not a solid `bg-#{variant}` like DataTable's dots: a solid
+  #     semantic fill on its own `-subtle` surface measures 2.62:1-2.67:1, under the 3:1
+  #     floor for a decorative dot. Asserting the dot equals the chip foreground is what
+  #     proves the substitution, since a wrong fill would still be "some colour";
+  #   * the remove control inherits that same foreground through `text-reset` and is not
+  #     faded — the retired `opacity: 0.6` is asserted gone via cumulativeOpacity.
+  #
+  # Foreground/background are pinned as VALUES, not just ratios: inherited body text also
+  # clears AA on these surfaces, so a ratio-only assertion would stay green if the
+  # semantic classes stopped applying entirely (#149/#150).
+  describe "TagChip (#168)" do
+    def rgb_of(hex)
+      "rgb(#{hex[1..2].hex}, #{hex[3..4].hex}, #{hex[5..6].hex})"
+    end
+
+    {
+      "light" => {
+        root: "#tag-chip",
+        pairs: {
+          primary: %w[#122F49 #D5E3F0], success: %w[#0E402B #D3ECE1],
+          warning: %w[#553012 #F6E4D5], danger: %w[#58151C #F8D7DA],
+          secondary: %w[#2B2F32 #E2E3E5]
+        }
+      },
+      "dark" => {
+        root: "#dark-tag-chip",
+        pairs: {
+          primary: %w[#82ACD3 #091724], success: %w[#7AC6A6 #072015],
+          warning: %w[#E5AD80 #2A1809], danger: %w[#EA868F #2C0B0E],
+          secondary: %w[#A7ACB1 #161719]
+        }
+      }
+    }.each do |mode, expected|
+      context "in #{mode} mode" do
+        expected[:pairs].each do |variant, (foreground, background)|
+          # A plain local, NOT `let`: `let` is resolved when the example RUNS, so a
+          # definition inside this loop would be overwritten on every iteration and
+          # every example would silently measure the last variant.
+          chip = "#{expected[:root]} [data-variant='#{variant}'] span.rounded-pill"
+
+          it "paints the #{variant} chip's emphasis-on-subtle above the AA floor" do
+            measured, painted_fg, painted_bg = ratio_for(chip)
+
+            expect(painted_fg).to eq(foreground)
+            expect(painted_bg).to eq(background)
+            expect(measured).to be >= 4.5,
+              "#{mode} #{variant} chip #{painted_fg} on #{painted_bg} = #{measured.round(2)}:1"
+          end
+
+          it "paints the #{variant} dot in the chip's own foreground via currentColor" do
+            painted = page.evaluate_script(
+              "getComputedStyle(document.querySelector(#{"#{chip} > span[aria-hidden=\'true\']".to_json})).backgroundColor"
+            )
+
+            expect(painted).to eq(rgb_of(foreground))
+          end
+
+          it "leaves the #{variant} remove control inheriting an unfaded foreground" do
+            measured, painted_fg, = ratio_for("#{chip} button")
+
+            expect(painted_fg).to eq(foreground)
+            expect(measured).to be >= 4.5
+            expect(resolve("#{chip} button")[:cumulativeOpacity]).to eq(1.0)
           end
         end
       end

--- a/spec/features/tag_input_stimulus_spec.rb
+++ b/spec/features/tag_input_stimulus_spec.rb
@@ -72,6 +72,95 @@ RSpec.describe "TagInput Stimulus controller", type: :feature, js: true do
     end
   end
 
+  # Before #168 this spec proved a chip EXISTED but never inspected its styling, and
+  # the controller carried its own frozen palette keyed on a stale vocabulary
+  # (buyers/press/festivals/…) that the server never sends. Only `internal` overlapped,
+  # so six of seven groups silently painted grey — a live defect that shipped green
+  # precisely because nothing here read a colour. These examples close that hole.
+  describe "the colour of an interactively-added chip (#168)" do
+    # Group -> the semantic Bootstrap paints for `bg-{sem}-subtle`, measured against the
+    # compiled engine bundle in light mode. Pinning the PAINTED value (not merely the
+    # class) is what proves the controller resolved the right variant: an unstyled or
+    # wrongly-keyed chip would inherit its parent's background instead.
+    {
+      "VIP" => { group: "distribution", variant: "danger", surface: "#F8D7DA", foreground: "#58151C" },
+      "Priority" => { group: "outreach", variant: "success", surface: "#D3ECE1", foreground: "#0E402B" },
+      "Budget" => { group: "finance", variant: "warning", surface: "#F6E4D5", foreground: "#553012" },
+      "Ops" => { group: "internal", variant: "secondary", surface: "#E2E3E5", foreground: "#2B2F32" }
+    }.each do |label, expected|
+      it "paints a #{expected[:group]} chip with the #{expected[:variant]} subtle/emphasis pair" do
+        visit "/tag_input_demo"
+
+        fill_tag_input(label)
+        find("[role='option']", text: label).click
+        expect(page).to have_css(chip, text: label)
+
+        # The classes the controller must emit — identical to the server-rendered chip.
+        expect(page).to have_css(
+          "#{chip}.rounded-pill.bg-#{expected[:variant]}-subtle.text-#{expected[:variant]}-emphasis",
+          text: label
+        )
+
+        measured, foreground, background = ratio_for("#{chip}[data-tag-label='#{label}']")
+
+        expect(foreground).to eq(expected[:foreground])
+        expect(background).to eq(expected[:surface])
+        expect(measured).to be >= 4.5,
+          "#{expected[:group]} chip #{foreground} on #{background} = #{measured.round(2)}:1"
+      end
+    end
+
+    # The retired `opacity: 0.6` faded the chip's foreground; RESOLVE_JS multiplies
+    # cumulative ancestor opacity, so this measures what a user actually sees rather
+    # than the declared pair (#130's lesson — audit opacity, not just `color:`).
+    it "keeps the remove button's effective foreground above the AA floor" do
+      visit "/tag_input_demo"
+
+      fill_tag_input("VIP")
+      find("[role='option']", text: "VIP").click
+      expect(page).to have_css(chip, text: "VIP")
+
+      measured, foreground, background = ratio_for("#{chip} button")
+
+      expect(foreground).to eq("#58151C")
+      expect(background).to eq("#F8D7DA")
+      expect(measured).to be >= 4.5,
+        "remove button #{foreground} on #{background} = #{measured.round(2)}:1"
+      # The declared pair above can be AA-clean and still fail once faded, so assert
+      # nothing in the ancestor chain reintroduces an opacity multiplier.
+      expect(resolve("#{chip} button")[:cumulativeOpacity]).to eq(1.0)
+    end
+
+    # A chip added after load must be indistinguishable from one rendered by the server.
+    # This is the assertion the old vocabulary mismatch would have failed outright.
+    it "matches the server-rendered chip's classes exactly" do
+      visit "/tag_input_demo"
+
+      fill_tag_input("VIP")
+      find("[role='option']", text: "VIP").click
+      expect(page).to have_css(chip, text: "VIP")
+
+      added = page.evaluate_script(
+        "document.querySelector(\"#{chip}[data-tag-label='VIP']\").className.split(/\\s+/).sort().join(' ')"
+      )
+      expect(added).to eq(
+        %w[
+          align-items-center bg-danger-subtle d-inline-flex fw-semibold gap-1
+          rounded-pill text-danger-emphasis
+        ].join(" ")
+      )
+    end
+
+    it "gives the dropdown suggestion dot its group's semantic fill" do
+      visit "/tag_input_demo"
+
+      fill_tag_input("VIP")
+
+      expect(page).to have_css("[role='option'] span.d-inline-block.bg-danger")
+      expect(page).to have_css("[role='option'].text-body", text: "VIP")
+    end
+  end
+
   describe "removing a tag" do
     it "removes the chip and its hidden input when the remove button is clicked" do
       visit "/tag_input_demo"

--- a/spec/features/tag_input_stimulus_spec.rb
+++ b/spec/features/tag_input_stimulus_spec.rb
@@ -82,11 +82,18 @@ RSpec.describe "TagInput Stimulus controller", type: :feature, js: true do
     # compiled engine bundle in light mode. Pinning the PAINTED value (not merely the
     # class) is what proves the controller resolved the right variant: an unstyled or
     # wrongly-keyed chip would inherit its parent's background instead.
+    # Every one of the seven GROUP_VARIANTS keys, not one per distinct hue. The
+    # controller duplicates the mapping in JavaScript, so a missing or mistyped KEY is
+    # the failure mode — and `production`/`vendors`/`press_festival` all resolve to the
+    # same `primary` hue, meaning a per-hue loop would leave two of them unproven.
     {
       "VIP" => { group: "distribution", variant: "danger", surface: "#F8D7DA", foreground: "#58151C" },
       "Priority" => { group: "outreach", variant: "success", surface: "#D3ECE1", foreground: "#0E402B" },
       "Budget" => { group: "finance", variant: "warning", surface: "#F6E4D5", foreground: "#553012" },
-      "Ops" => { group: "internal", variant: "secondary", surface: "#E2E3E5", foreground: "#2B2F32" }
+      "Ops" => { group: "internal", variant: "secondary", surface: "#E2E3E5", foreground: "#2B2F32" },
+      "TIFF 2026" => { group: "press_festival", variant: "primary", surface: "#D5E3F0", foreground: "#122F49" },
+      "Studio" => { group: "production", variant: "primary", surface: "#D5E3F0", foreground: "#122F49" },
+      "Agency" => { group: "vendors", variant: "primary", surface: "#D5E3F0", foreground: "#122F49" }
     }.each do |label, expected|
       it "paints a #{expected[:group]} chip with the #{expected[:variant]} subtle/emphasis pair" do
         visit "/tag_input_demo"
@@ -132,23 +139,39 @@ RSpec.describe "TagInput Stimulus controller", type: :feature, js: true do
     end
 
     # A chip added after load must be indistinguishable from one rendered by the server.
-    # This is the assertion the old vocabulary mismatch would have failed outright.
-    it "matches the server-rendered chip's classes exactly" do
-      visit "/tag_input_demo"
+    # Comparing against a second hardcoded list would only restate the JS; this renders
+    # the REAL server markup and diffs against it, so future server/JS drift reddens.
+    it "matches the server-rendered chip's classes and inline style exactly" do
+      server = ActionController::Base.render(
+        MpiDesignSystem::Admin::TagInput::Component.new(
+          available_tags: [ { label: "VIP", group: :distribution } ],
+          selected_tags: [ { label: "VIP", group: :distribution } ],
+          name: "contact[tags][]"
+        )
+      )
+      server_node = Nokogiri::HTML.fragment(server).at_css("span[data-mpi--tag-input-target='tag']")
+      server_button = server_node.at_css("button")
 
+      visit "/tag_input_demo"
       fill_tag_input("VIP")
       find("[role='option']", text: "VIP").click
       expect(page).to have_css(chip, text: "VIP")
 
       added = page.evaluate_script(
-        "document.querySelector(\"#{chip}[data-tag-label='VIP']\").className.split(/\\s+/).sort().join(' ')"
+        "(() => { const c = document.querySelector(\"#{chip}[data-tag-label='VIP']\");" \
+        "const b = c.querySelector('button');" \
+        "return { cls: c.className, style: c.getAttribute('style')," \
+        "         btnCls: b.className, btnStyle: b.getAttribute('style') }; })()"
       )
-      expect(added).to eq(
-        %w[
-          align-items-center bg-danger-subtle d-inline-flex fw-semibold gap-1
-          rounded-pill text-danger-emphasis
-        ].join(" ")
-      )
+
+      norm = ->(value) { value.to_s.split(/\s+/).reject(&:empty?).sort.join(" ") }
+      expect(norm.call(added["cls"])).to eq(norm.call(server_node["class"]))
+      expect(norm.call(added["btnCls"])).to eq(norm.call(server_button["class"]))
+      # Declaration sets, order-insensitive — the server joins with "; " and the JS
+      # writes a cssText string, so a literal string compare would be brittle noise.
+      decls = ->(style) { style.to_s.split(";").map { |d| d.strip.chomp(";") }.reject(&:empty?).sort }
+      expect(decls.call(added["style"])).to eq(decls.call(server_node["style"]))
+      expect(decls.call(added["btnStyle"])).to eq(decls.call(server_button["style"]))
     end
 
     it "gives the dropdown suggestion dot its group's semantic fill" do
@@ -157,7 +180,12 @@ RSpec.describe "TagInput Stimulus controller", type: :feature, js: true do
       fill_tag_input("VIP")
 
       expect(page).to have_css("[role='option'] span.d-inline-block.bg-danger")
-      expect(page).to have_css("[role='option'].text-body", text: "VIP")
+      # The option TEXT deliberately keeps the frozen navy: the dropdown panel paints a
+      # hardcoded white background, so an adaptive `text-body` would render #DEE2E6 on
+      # white (1.30:1) in dark mode. The dot's solid semantic fill is a fixed hue and is
+      # safe on that white. Converting the panel is ISS#142 §3.
+      expect(page).to have_css("[role='option'][style*='color: #1B2A4A']", text: "VIP")
+      expect(page).not_to have_css("[role='option'].text-body")
     end
   end
 

--- a/spec/features/tag_input_stimulus_spec.rb
+++ b/spec/features/tag_input_stimulus_spec.rb
@@ -187,6 +187,39 @@ RSpec.describe "TagInput Stimulus controller", type: :feature, js: true do
       expect(page).to have_css("[role='option'][style*='color: #1B2A4A']", text: "VIP")
       expect(page).not_to have_css("[role='option'].text-body")
     end
+
+    # The RESTING option is not the whole story. A previous revision fixed the resting
+    # state and left the hover/keyboard-active surface adaptive, so navy text sat on
+    # ~#2B3035 in dark mode at 1.07:1 — a fix that introduced an inaccessible
+    # interactive state, which a resting-only assertion could never catch.
+    it "keeps a hovered option readable, not just a resting one" do
+      visit "/tag_input_demo"
+      fill_tag_input("VIP")
+      expect(page).to have_css("[role='option']", text: "VIP")
+
+      find("[role='option']", text: "VIP").hover
+
+      measured, foreground, background = ratio_for("[role='option']")
+      expect(foreground).to eq("#1B2A4A")
+      expect(background).to eq("#F5F7FA")
+      expect(measured).to be >= 4.5,
+        "hovered option #{foreground} on #{background} = #{measured.round(2)}:1"
+    end
+
+    # Keyboard navigation paints the same surface by a different code path
+    # (`highlightItem`), so it needs its own proof.
+    it "keeps a keyboard-highlighted option readable" do
+      visit "/tag_input_demo"
+      fill_tag_input("VIP")
+      expect(page).to have_css("[role='option']", text: "VIP")
+
+      find("#{root} [data-mpi--tag-input-target='input']").send_keys(:arrow_down)
+
+      measured, foreground, background = ratio_for("[role='option']")
+      expect(foreground).to eq("#1B2A4A")
+      expect(background).to eq("#F5F7FA")
+      expect(measured).to be >= 4.5
+    end
   end
 
   describe "removing a tag" do

--- a/spec/lib/theme_adaptivity_spec.rb
+++ b/spec/lib/theme_adaptivity_spec.rb
@@ -61,11 +61,67 @@ RSpec.describe ThemeAdaptivity do
       # Modern colour spaces a narrow rgb()/hsl() regex misses entirely.
       "an oklch() value" => "caret-color: oklch(0.7 0.1 200)",
       "a color() value" => "caret-color: color(display-p3 1 0 0)",
-      "a color-mix() value" => "background: color-mix(in srgb, red, blue)"
+      "a color-mix() value" => "background: color-mix(in srgb, red, blue)",
+      # Codex round 2, P1. A custom property can hold anything and nothing downstream
+      # constrains it. `papayawhip` is deliberately absent from NAMED_COLOURS and is not a
+      # literal, so ONLY the custom-property rule can reject this — which is what makes
+      # the example isolating. With a value the blacklist knows (e.g. `red`), deleting
+      # that rule would leave the test green.
+      "a colour in a custom property" => "--tag-fill: papayawhip",
+      "an unparseable var() fallback (must fail closed)" => "color: var(--bs-body-color, chartreuse) !important"
     }.each do |label, style|
       it "rejects #{label}" do
         expect(offences(style)).not_to be_empty
       end
+    end
+  end
+
+  # Codex round 2, P1: the earlier examples for these two fixes were NOT isolating. A
+  # frozen fallback was caught by the literal scan too, so removing the recursion left
+  # them green; and the "independent scans" example was caught by the property rule too,
+  # so restoring the `elsif` left IT green. Either fix could be deleted individually
+  # without a red test — which is the mutation requirement, not merely a passing suite.
+  # These target each mechanism directly.
+  describe "the var() fallback recursion, in isolation" do
+    it "accepts a bare adaptive token" do
+      expect(described_class.adaptive_value?("var(--bs-body-color)")).to be true
+    end
+
+    it "rejects a token whose fallback is frozen" do
+      expect(described_class.adaptive_value?("var(--bs-body-color, #fff)")).to be false
+    end
+
+    it "accepts a token whose fallback is itself adaptive" do
+      expect(described_class.adaptive_value?("var(--bs-body-color, currentColor)")).to be true
+    end
+
+    it "recurses through a nested fallback" do
+      expect(described_class.adaptive_value?("var(--bs-a, var(--bs-b, #fff))")).to be false
+      expect(described_class.adaptive_value?("var(--bs-a, var(--bs-b, inherit))")).to be true
+    end
+
+    # Fail CLOSED: "did not parse" must not be answered the same way as "no fallback".
+    # This is what let `var(--bs-body-color, chartreuse) !important` through.
+    it "rejects a token it cannot parse confidently" do
+      expect(described_class.adaptive_value?("var(--bs-body-color, chartreuse) !important")).to be false
+      expect(described_class.adaptive_value?("var(--bs-body-color,)")).to be false
+    end
+  end
+
+  describe "the two scans, in isolation" do
+    # A value the PROPERTY rule accepts must still be examined by the literal scan.
+    # Under the old `elsif` this returned zero offences.
+    it "runs the literal scan even when the property rule accepts the value" do
+      offending = offences("background-color: var(--bs-tertiary-bg, #F5F7FA)")
+
+      expect(offending.any? { |o| o.include?("colour literal") }).to be true
+    end
+
+    # And a value the literal scan cannot see must still be caught by the property rule.
+    it "runs the property rule even when the value carries no literal" do
+      offending = offences("background-color: linear-gradient(in oklab, currentColor, currentColor)")
+
+      expect(offending.any? { |o| o.include?("re-resolve per colour mode") }).to be true
     end
   end
 

--- a/spec/lib/theme_adaptivity_spec.rb
+++ b/spec/lib/theme_adaptivity_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# The guard in `spec/support/theme_adaptivity.rb` is itself a check, and an untested check
+# is the shape `.claude/rules/testing.md` warns about hardest — one that cannot fail. Nine
+# component specs lean on it, so a hole here is a hole in all of them at once.
+#
+# Every rejection case below corresponds to a real defect this repo has shipped:
+# #130's `opacity`, #150's `outline`, #151's guard that rejected colour VALUES but not
+# colour PROPERTIES (so `border: 1px solid red` and `border: none` sailed through).
+RSpec.describe ThemeAdaptivity do
+  def offences(style)
+    described_class.frozen_colour_offences(style)
+  end
+
+  describe "styles it must ALLOW" do
+    {
+      "pure geometry" => "padding: 2px 8px; font-size: 11px; font-weight: 500",
+      "currentColor, which the in-chip dot depends on" => "background-color: currentColor",
+      "the documented geometry exceptions" => "border-radius: 50%; --bs-border-width: 2px",
+      "an adaptive Bootstrap token" => "color: var(--bs-body-color)",
+      "inherit" => "color: inherit",
+      "transparent" => "background: transparent",
+      "an empty style" => ""
+    }.each do |label, style|
+      it "allows #{label}" do
+        expect(offences(style)).to be_empty
+      end
+    end
+  end
+
+  describe "styles it must REJECT" do
+    {
+      "a hex foreground" => "color: #E8733A",
+      "a hex background" => "background-color: #FEF3EC",
+      "an rgb() value" => "background: rgb(1, 2, 3)",
+      "an hsl() value" => "background: hsl(1, 2%, 3%)",
+      # The #151 hole: a guard scanning only for hex/rgb/hsl VALUES lets these through.
+      "a NAMED colour on a border" => "border: 1px solid red",
+      "border: none, which overrides a utility border" => "border: none",
+      "a named colour in a box-shadow" => "box-shadow: 0 0 2px black",
+      "an svg fill" => "fill: red",
+      # #130 / #150: a declared pair can be AA-clean and still fail once faded or outlined.
+      "opacity" => "opacity: 0.6",
+      "an outline colour" => "outline: 1px solid #64748B",
+      # Caught by the value scan rather than the property list, which is why both exist.
+      "a colour in a property the list does not name" => "caret-color: #fff",
+      "a hex inside a shorthand function" => "background: linear-gradient(#fff, #000)",
+      # A non-Bootstrap custom property may not resolve at all, so its hex fallback is
+      # what actually paints — a frozen colour by another name.
+      "a non-Bootstrap var() with a hex fallback" => "background-color: var(--mds-avatar-0, #64748B)"
+    }.each do |label, style|
+      it "rejects #{label}" do
+        expect(offences(style)).not_to be_empty
+      end
+    end
+  end
+
+  it "names the offending declaration and the reason, so a failure is actionable" do
+    message = offences("padding: 0; border: 1px solid red").first
+
+    expect(message).to include("border: 1px solid red")
+    expect(message).to include("does not re-resolve per colour mode")
+  end
+
+  it "reports every offence in a style, not merely the first" do
+    expect(offences("color: #fff; opacity: 0.5; padding: 0").size).to eq(2)
+  end
+
+  # A known, deliberate limitation rather than a defect: the `var(--mds-*, <hex>)` pattern
+  # #169 introduced for AvatarCircle is rejected here. No component this guard is applied
+  # to uses it, and for a TAG surface a frozen fallback really would be wrong — but anyone
+  # reusing this guard for the avatar palette must widen the allowlist first.
+  it "rejects the #169 avatar token pattern, which is out of scope for tag surfaces" do
+    expect(offences("background-color: var(--mds-avatar-3, #4EA8DE)")).not_to be_empty
+  end
+end

--- a/spec/lib/theme_adaptivity_spec.rb
+++ b/spec/lib/theme_adaptivity_spec.rb
@@ -49,7 +49,19 @@ RSpec.describe ThemeAdaptivity do
       "a hex inside a shorthand function" => "background: linear-gradient(#fff, #000)",
       # A non-Bootstrap custom property may not resolve at all, so its hex fallback is
       # what actually paints — a frozen colour by another name.
-      "a non-Bootstrap var() with a hex fallback" => "background-color: var(--mds-avatar-0, #64748B)"
+      "a non-Bootstrap var() with a hex fallback" => "background-color: var(--mds-avatar-0, #64748B)",
+      # Codex PR review, P1-3. The prefix check alone accepted this, and the literal scan
+      # was an `elsif`, so the frozen fallback was never examined. An absent token makes
+      # that fallback the colour that actually paints (the #155 un-imported-partial case).
+      "a var(--bs-*) whose FALLBACK is a frozen hex" => "background-color: var(--bs-body-bg, #fff)",
+      "a var(--bs-*) whose fallback is a named colour" => "color: var(--bs-body-color, black)",
+      # Same review: a named colour on a property the list does not name.
+      "a named colour on an unlisted property" => "caret-color: red",
+      "a named colour in a text-shadow" => "text-shadow: 0 0 2px black",
+      # Modern colour spaces a narrow rgb()/hsl() regex misses entirely.
+      "an oklch() value" => "caret-color: oklch(0.7 0.1 200)",
+      "a color() value" => "caret-color: color(display-p3 1 0 0)",
+      "a color-mix() value" => "background: color-mix(in srgb, red, blue)"
     }.each do |label, style|
       it "rejects #{label}" do
         expect(offences(style)).not_to be_empty
@@ -64,8 +76,24 @@ RSpec.describe ThemeAdaptivity do
     expect(message).to include("does not re-resolve per colour mode")
   end
 
-  it "reports every offence in a style, not merely the first" do
-    expect(offences("color: #fff; opacity: 0.5; padding: 0").size).to eq(2)
+  it "reports every offending declaration in a style, not merely the first" do
+    reported = offences("color: #fff; opacity: 0.5; padding: 0")
+
+    # One declaration can trip both scans (a hex on a paint property trips the property
+    # rule AND the literal rule), so assert on which DECLARATIONS were named.
+    expect(reported.select { |o| o.include?("color: #fff") }).not_to be_empty
+    expect(reported.select { |o| o.include?("opacity: 0.5") }).not_to be_empty
+    expect(reported.select { |o| o.include?("padding: 0") }).to be_empty
+  end
+
+  # The property scan and the literal scan must both run on the same declaration; when
+  # they were an if/elsif, a value the property rule accepted skipped the literal scan.
+  it "reports a nested literal even when the property rule accepts the value shape" do
+    expect(offences("background-color: var(--bs-body-bg, #fff)")).not_to be_empty
+  end
+
+  it "still allows a var(--bs-*) whose fallback is itself adaptive" do
+    expect(offences("color: var(--bs-body-color, currentColor)")).to be_empty
   end
 
   # A known, deliberate limitation rather than a defect: the `var(--mds-*, <hex>)` pattern

--- a/spec/support/contrast_helpers.rb
+++ b/spec/support/contrast_helpers.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# Computed-style contrast helpers shared by the browser feature specs.
+#
+# Extracted from `contrast_spec.rb` in #168 so the `mpi--tag-input` Stimulus spec can
+# measure an interactively-added chip with the SAME machinery, rather than a second
+# hand-rolled copy that could drift from it. Behaviour is unchanged.
+module ContrastHelpers
+  # Resolves what a user actually SEES, which is not the same as the declared
+  # value in three ways this suite has to account for:
+  #
+  #   1. A colour may carry alpha. `.text-body-secondary` is
+  #      `rgba(<body-color>, .75)`, so reading the RGB channels and discarding
+  #      the alpha overstates contrast. Alpha is composited over the backdrop.
+  #   2. A background may be transparent, in which case the visible backdrop is
+  #      an ancestor's — so we walk up until we find an opaque one.
+  #   3. `opacity` on any ancestor fades the whole subtree. It is invisible to
+  #      the element's own computed `color`, which is how the retired
+  #      `opacity: 0.8` hid a 3.71:1 failure behind an AA-clean declaration.
+  RESOLVE_JS = <<~JS
+    (() => {
+      const parse = (value) => {
+        const parts = (value.match(/[\\d.]+/g) || []).map(Number);
+        return { r: parts[0], g: parts[1], b: parts[2], a: parts.length > 3 ? parts[3] : 1 };
+      };
+      const opaqueBackdrop = (node) => {
+        for (let el = node; el; el = el.parentElement) {
+          const bg = parse(getComputedStyle(el).backgroundColor);
+          if (bg.a === 1) return bg;
+        }
+        return { r: 255, g: 255, b: 255, a: 1 };
+      };
+      const over = (fg, bg) => ({
+        r: fg.r * fg.a + bg.r * (1 - fg.a),
+        g: fg.g * fg.a + bg.g * (1 - fg.a),
+        b: fg.b * fg.a + bg.b * (1 - fg.a),
+      });
+      const hex = (c) => '#' + [c.r, c.g, c.b]
+        .map((v) => Math.round(v).toString(16).padStart(2, '0')).join('').toUpperCase();
+
+      const el = document.querySelector(SELECTOR);
+      if (!el) return null;
+
+      let cumulativeOpacity = 1;
+      for (let n = el; n; n = n.parentElement) {
+        cumulativeOpacity *= parseFloat(getComputedStyle(n).opacity);
+      }
+
+      const backdrop = opaqueBackdrop(el);
+      const foreground = over(parse(getComputedStyle(el).color), backdrop);
+
+      return {
+        foreground: hex(foreground),
+        background: hex(backdrop),
+        cumulativeOpacity: cumulativeOpacity,
+      };
+    })()
+  JS
+
+  def resolve(selector)
+    result = page.evaluate_script(RESOLVE_JS.sub("SELECTOR", selector.to_json))
+    raise "no element matched #{selector}" if result.nil?
+
+    result.transform_keys(&:to_sym)
+  end
+
+  def ratio_for(selector)
+    resolved = resolve(selector)
+    measured = MpiDesignSystem::ColorContrast.ratio(resolved[:foreground], resolved[:background])
+
+    [ measured, resolved[:foreground], resolved[:background] ]
+  end
+
+  def border_color_of(selector)
+    page.evaluate_script(
+      "(() => { const e = document.querySelector(#{selector.to_json}); " \
+      "if (!e) throw new Error('no element matched'); " \
+      "return getComputedStyle(e).borderTopColor; })()"
+    )
+  end
+
+  def computed(selector, property)
+    key = property == "color" ? :foreground : :background
+
+    resolve(selector).fetch(key)
+  end
+end
+
+RSpec.configure do |config|
+  config.include ContrastHelpers, type: :feature
+end

--- a/spec/support/theme_adaptivity.rb
+++ b/spec/support/theme_adaptivity.rb
@@ -34,8 +34,26 @@ module ThemeAdaptivity
   # Values that re-resolve per colour mode, so they survive a `data-bs-theme` flip.
   ADAPTIVE_VALUES = %w[currentcolor transparent inherit].freeze
 
-  # A hex literal, or an rgb()/rgba()/hsl()/hsla() function call.
-  COLOUR_LITERAL = /#[0-9a-f]{3,8}\b|\brgba?\(|\bhsla?\(/i
+  # A hex literal, or any CSS colour function. The function list is deliberately broad —
+  # a guard that knows only rgb()/hsl() lets a modern colour space through silently.
+  COLOUR_LITERAL = /
+    \#[0-9a-f]{3,8}\b
+    | \b(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color|color-mix|device-cmyk)\(
+  /xi
+
+  # CSS named colours. Not exhaustive by intent — it covers the ones a human would
+  # actually reach for, and the property whitelist above is what catches the rest on a
+  # colour-bearing property. Its job is the residual case: a named colour on a property
+  # COLOUR_PROPERTIES does not list (e.g. `caret-color: red`).
+  NAMED_COLOURS = %w[
+    black white red green blue yellow orange purple pink brown grey gray silver gold
+    navy teal aqua cyan magenta maroon olive lime indigo violet crimson salmon coral
+    tomato khaki plum orchid tan beige ivory azure lavender turquoise chocolate
+    firebrick forestgreen goldenrod hotpink lightblue lightgreen midnightblue
+    rebeccapurple seagreen skyblue slategray slategrey steelblue whitesmoke
+  ].freeze
+
+  NAMED_COLOUR_PATTERN = /\b(?:#{NAMED_COLOURS.join('|')})\b/i
 
   module_function
 
@@ -53,26 +71,43 @@ module ThemeAdaptivity
     declaration.split(":", 2).last.to_s.strip
   end
 
+  # A `var(--bs-*)` reference re-resolves per colour mode — but only if it actually
+  # resolves. `var(--bs-body-bg, #fff)` falls back to a FROZEN colour whenever the token
+  # is absent, which is precisely the situation an un-imported partial creates (#155).
+  # So the token form is adaptive only when its fallback is itself adaptive, or absent.
   def adaptive_value?(value)
     normalised = value.strip.downcase
-    ADAPTIVE_VALUES.include?(normalised) || normalised.start_with?("var(--bs-")
+    return true if ADAPTIVE_VALUES.include?(normalised)
+    return false unless normalised.start_with?("var(--bs-")
+
+    fallback = normalised[/\Avar\(\s*--bs-[a-z0-9-]+\s*,(.*)\)\z/m, 1]
+    fallback.nil? || adaptive_value?(fallback)
   end
 
   # Returns [] when the style makes no frozen-colour decision, else the offending
   # declarations with the reason each was rejected.
+  #
+  # The two scans are INDEPENDENT, not an if/elsif chain: a value accepted by the
+  # property rule must still be checked for an embedded literal, or
+  # `background-color: var(--bs-body-bg, #fff)` passes on the strength of its prefix
+  # while a frozen hex rides along in the fallback.
   def frozen_colour_offences(style)
-    declarations(style).filter_map do |declaration|
+    declarations(style).flat_map do |declaration|
       property = property_of(declaration)
       value = value_of(declaration)
+      next [] if GEOMETRY_EXCEPTIONS.include?(property)
 
-      next if GEOMETRY_EXCEPTIONS.include?(property)
-
+      offences = []
       if COLOUR_PROPERTIES.include?(property) && !adaptive_value?(value)
-        "#{declaration.inspect} — `#{property}` paints, and #{value.inspect} does not " \
+        offences << "#{declaration.inspect} — `#{property}` paints, and #{value.inspect} does not " \
           "re-resolve per colour mode (allowed: currentColor, transparent, inherit, var(--bs-*))"
-      elsif declaration.match?(COLOUR_LITERAL)
-        "#{declaration.inspect} — carries a colour literal"
       end
+      if value.match?(COLOUR_LITERAL)
+        offences << "#{declaration.inspect} — carries a colour literal"
+      elsif value.match?(NAMED_COLOUR_PATTERN)
+        offences << "#{declaration.inspect} — carries a named CSS colour"
+      end
+      offences
     end
   end
 end

--- a/spec/support/theme_adaptivity.rb
+++ b/spec/support/theme_adaptivity.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+# Shared guard for the inline-style -> semantic-utility conversions (#149, #150, #151,
+# #152, #168). It answers one question about a converted element: does its SURVIVING
+# inline style still make a colour decision?
+#
+# The shape matters. `.claude/rules/testing.md` records two ways an earlier version of
+# this guard shipped green while broken:
+#
+#   * rejecting colour VALUES (hex/rgb/hsl) but not colour PROPERTIES, so
+#     `border: 1px solid red` (a named colour) and `border: none` both passed;
+#   * rejecting a blacklist of named colours, which can never be complete.
+#
+# So this is a WHITELIST on both axes. A colour-bearing property may hold only a value
+# that re-resolves at runtime (`currentColor`, `transparent`, `inherit`, or a
+# `var(--bs-*)` token); everything else fails, whether or not the value looks like a
+# colour. Independently, NO property may carry a hex / rgb() / hsl() literal, which
+# catches a colour smuggled into a property this list does not know about.
+module ThemeAdaptivity
+  # Properties that paint. `opacity` is here because a declared pair can be AA-clean and
+  # still fail once faded — #130's ActiveFilterBar composited white at 0.8 to 3.71:1, and
+  # TagChip's remove button did the same at 0.6.
+  COLOUR_PROPERTIES = %w[
+    color background background-color background-image
+    border border-top border-right border-bottom border-left
+    border-color border-style border-width
+    outline outline-color outline-style box-shadow opacity fill stroke
+  ].freeze
+
+  # Geometry that merely shares a `border-*` prefix. `--bs-border-width` is the documented
+  # escape DataTable uses to put a 2px rule on one edge without boxing all four (#151).
+  GEOMETRY_EXCEPTIONS = %w[border-radius --bs-border-width].freeze
+
+  # Values that re-resolve per colour mode, so they survive a `data-bs-theme` flip.
+  ADAPTIVE_VALUES = %w[currentcolor transparent inherit].freeze
+
+  # A hex literal, or an rgb()/rgba()/hsl()/hsla() function call.
+  COLOUR_LITERAL = /#[0-9a-f]{3,8}\b|\brgba?\(|\bhsla?\(/i
+
+  module_function
+
+  # "a: b; c: d" -> ["a: b", "c: d"]. Splits on ";" only — no CSS value in this engine
+  # contains one, and `var(--x, #fff)` fallbacks keep their comma.
+  def declarations(style)
+    style.to_s.split(";").map(&:strip).reject(&:empty?)
+  end
+
+  def property_of(declaration)
+    declaration.split(":", 2).first.to_s.strip.downcase
+  end
+
+  def value_of(declaration)
+    declaration.split(":", 2).last.to_s.strip
+  end
+
+  def adaptive_value?(value)
+    normalised = value.strip.downcase
+    ADAPTIVE_VALUES.include?(normalised) || normalised.start_with?("var(--bs-")
+  end
+
+  # Returns [] when the style makes no frozen-colour decision, else the offending
+  # declarations with the reason each was rejected.
+  def frozen_colour_offences(style)
+    declarations(style).filter_map do |declaration|
+      property = property_of(declaration)
+      value = value_of(declaration)
+
+      next if GEOMETRY_EXCEPTIONS.include?(property)
+
+      if COLOUR_PROPERTIES.include?(property) && !adaptive_value?(value)
+        "#{declaration.inspect} — `#{property}` paints, and #{value.inspect} does not " \
+          "re-resolve per colour mode (allowed: currentColor, transparent, inherit, var(--bs-*))"
+      elsif declaration.match?(COLOUR_LITERAL)
+        "#{declaration.inspect} — carries a colour literal"
+      end
+    end
+  end
+end
+
+RSpec::Matchers.define :be_free_of_frozen_colour do
+  match { |style| ThemeAdaptivity.frozen_colour_offences(style).empty? }
+
+  failure_message do |style|
+    offences = ThemeAdaptivity.frozen_colour_offences(style)
+    "expected the surviving inline style to make no frozen-colour decision, but found " \
+      "#{offences.size} offence(s) in #{style.inspect}:\n  - #{offences.join("\n  - ")}"
+  end
+
+  failure_message_when_negated do |style|
+    "expected #{style.inspect} to carry at least one frozen-colour declaration, but it was clean"
+  end
+end
+
+module ThemeAdaptivityHelpers
+  # The `style` attribute of every node matching `selector`, in document order.
+  def inline_styles(selector)
+    page.all(selector, visible: :all).map { |node| node[:style].to_s }
+  end
+
+  # Convenience for the common single-element case.
+  def inline_style(selector)
+    styles = inline_styles(selector)
+    raise "expected exactly one #{selector.inspect}, found #{styles.size}" unless styles.one?
+
+    styles.first
+  end
+end
+
+RSpec.configure do |config|
+  config.include ThemeAdaptivityHelpers, type: :component
+end

--- a/spec/support/theme_adaptivity.rb
+++ b/spec/support/theme_adaptivity.rb
@@ -11,11 +11,19 @@
 #     `border: 1px solid red` (a named colour) and `border: none` both passed;
 #   * rejecting a blacklist of named colours, which can never be complete.
 #
-# So this is a WHITELIST on both axes. A colour-bearing property may hold only a value
-# that re-resolves at runtime (`currentColor`, `transparent`, `inherit`, or a
-# `var(--bs-*)` token); everything else fails, whether or not the value looks like a
-# colour. Independently, NO property may carry a hex / rgb() / hsl() literal, which
-# catches a colour smuggled into a property this list does not know about.
+# The PROPERTY axis is the authoritative whitelist and is where the real strength lies:
+# any property that can paint — including every un-excepted `--*` custom property — may
+# hold only a value that re-resolves at runtime (`currentColor`, `transparent`,
+# `inherit`, or a `var(--bs-*)` whose fallback is itself adaptive). Everything else
+# fails, whether or not the value looks like a colour, and an unparseable `var()` fails
+# CLOSED.
+#
+# The VALUE axis is a deliberate best-effort BACKSTOP, not a whitelist: it catches hex,
+# colour functions and common named colours smuggled into a property the list does not
+# know about. A named-colour blacklist can never be complete, and claiming otherwise
+# would be the sort of prose-only assurance `.claude/rules/testing.md` warns about — so
+# the honest statement is that a novel named colour on an unlisted property can still
+# slip through. Widen COLOUR_PROPERTIES when that matters.
 module ThemeAdaptivity
   # Properties that paint. `opacity` is here because a declared pair can be AA-clean and
   # still fail once faded — #130's ActiveFilterBar composited white at 0.8 to 3.71:1, and
@@ -24,7 +32,8 @@ module ThemeAdaptivity
     color background background-color background-image
     border border-top border-right border-bottom border-left
     border-color border-style border-width
-    outline outline-color outline-style box-shadow opacity fill stroke
+    outline outline-color outline-style box-shadow text-shadow opacity fill stroke
+    accent-color caret-color column-rule column-rule-color text-decoration-color
   ].freeze
 
   # Geometry that merely shares a `border-*` prefix. `--bs-border-width` is the documented
@@ -38,7 +47,7 @@ module ThemeAdaptivity
   # a guard that knows only rgb()/hsl() lets a modern colour space through silently.
   COLOUR_LITERAL = /
     \#[0-9a-f]{3,8}\b
-    | \b(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color|color-mix|device-cmyk)\(
+    | \b(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch|color|color-mix|device-cmyk|light-dark)\(
   /xi
 
   # CSS named colours. Not exhaustive by intent — it covers the ones a human would
@@ -80,8 +89,17 @@ module ThemeAdaptivity
     return true if ADAPTIVE_VALUES.include?(normalised)
     return false unless normalised.start_with?("var(--bs-")
 
+    # Fail CLOSED. A `var(--bs-*)` with no fallback is adaptive; one WITH a fallback is
+    # adaptive only if the fallback is too. Anything this cannot parse confidently —
+    # a trailing `!important`, nested parens, an empty fallback — is rejected rather
+    # than waved through, because "did not parse" and "no fallback" are different
+    # answers and conflating them is how the guard shipped fail-open.
+    return true if normalised.match?(/\Avar\(\s*--bs-[a-z0-9-]+\s*\)\z/)
+
     fallback = normalised[/\Avar\(\s*--bs-[a-z0-9-]+\s*,(.*)\)\z/m, 1]
-    fallback.nil? || adaptive_value?(fallback)
+    return false if fallback.nil? || fallback.strip.empty?
+
+    adaptive_value?(fallback)
   end
 
   # Returns [] when the style makes no frozen-colour decision, else the offending
@@ -97,8 +115,12 @@ module ThemeAdaptivity
       value = value_of(declaration)
       next [] if GEOMETRY_EXCEPTIONS.include?(property)
 
+      # A custom property can hold anything, including a colour, and nothing downstream
+      # constrains it — so treat every un-excepted `--*` as colour-bearing.
+      paints = COLOUR_PROPERTIES.include?(property) || property.start_with?("--")
+
       offences = []
-      if COLOUR_PROPERTIES.include?(property) && !adaptive_value?(value)
+      if paints && !adaptive_value?(value)
         offences << "#{declaration.inspect} — `#{property}` paints, and #{value.inspect} does not " \
           "re-resolve per colour mode (allowed: currentColor, transparent, inherit, var(--bs-*))"
       end


### PR DESCRIPTION
## Summary

Finishes the convergence [PR#167](https://github.com/mpimedia/mpi-design-system/pull/167) began. #167 moved `FilterChipBar` and `DataTable` onto the shared `TagChip::Component::GROUP_VARIANTS` mapping and deliberately left the other nine consumers on frozen hex — a transient cross-consumer inconsistency, tracked as this issue. All nine now resolve category colour from that one mapping, so a category renders the same theme-adaptive hue everywhere.

It also discharges **[ISS#142](https://github.com/mpimedia/mpi-design-system/issues/142) §1**. The retired hex pairs measured **2.77:1–4.34:1** — every one below the WCAG AA floor. The `-subtle`/`-emphasis` pairs replacing them are browser-measured at **9.34:1–10.52:1** (light) and **7.15:1–8.61:1** (dark), across all five distinct hues in both colour modes.

Plan and its two revisions are on [ISS#168](https://github.com/mpimedia/mpi-design-system/issues/168); Codex reviewed the plan before any code was written and found 4 P0 / 8 P1 / 1 P2, all verified by execution and folded in.

## Changes Made

**Components** — `tag_chip`, `badge`, `contact_card`, `engagement_card`, `account_list_row`, `contact_list_row`, `account_detail_panel`, `contact_detail_panel`, `tag_input` (`.rb` + `.html.erb` each) now read `GROUP_VARIANTS`. Chips/pills render `bg-{sem}-subtle text-{sem}-emphasis`; surviving inline style is geometry only.

**JS** — `tag_input_controller.js`: replaced the frozen `GROUP_COLORS` map with a `GROUP_VARIANTS` mirror keyed on the vocabulary the server actually sends, emitting the same semantic classes as the ERB. Dropped the faded remove button and the frozen dropdown-hover surface.

**Specs** — all nine rewritten; new shared `spec/support/theme_adaptivity.rb` guard; `spec/support/contrast_helpers.rb` extracted from `contrast_spec.rb` so the Stimulus spec measures with the same machinery.

**Browser** — `contrast_demo` gains light + dark TagChip sections (one chip per distinct hue); `contrast_spec.rb` loops all five semantics × both modes; `tag_input_stimulus_spec.rb` gains six examples that finally read colour.

**Catalog** — `tag-chip.md` (mapping + per-surface treatment table rewritten), `badge.md`, `contact-card.md`; nine `previews/*.html` mockups converted with a `:root` MPI token block.

**Removed** — `Badge::TAG_GROUPS`, both `TAG_DOT_COLORS`, `FilterChipBar::GROUPS` (dead alias). No references outside this engine, verified across all four apps. `TagChip::GROUPS` is **retained** as the canonical key set.

## Technical Approach

**A dot's treatment depends on its surface.** The plan promised solid `bg-{semantic}` dots *and* a ≥3:1 test; Codex proved both cannot hold. A solid semantic fill inside a `-subtle` chip measures **2.67:1** (success) / **2.62:1** (warning), because a subtle surface is by construction a tint of the same hue. So dots inside a chip paint `currentColor` — inheriting the `-emphasis` foreground, adaptive by construction — while dots on a plain card/row backdrop keep the solid fill, where DataTable's browser spec already proves ≥3:1. Added to `.claude/rules/frontend.md`.

**`tag_input_controller.js` was painting six of seven groups grey.** Its map was keyed `buyers`/`press`/`festivals`/`sellers`/`institutional`/`organizations`/`internal`; the server sends `distribution`/`outreach`/`press_festival`/…. Only `internal` overlapped, so every other group hit the grey fallback — a tag added interactively rendered grey while the same tag server-rendered its category colour. It shipped green because the Stimulus spec asserted no styling, and the dummy fixture was itself written in the broken map's vocabulary. Nothing used that vocabulary (not the components, not Harvest), so re-keying breaks no consumer. **This was originally scoped out**; the HC reversed that ruling once the evidence showed it was a live bug rather than a naming preference.

**`ContactCard`'s caller passthrough is preserved exactly**, including independent per-property fallbacks. Only the *default* (nothing supplied) moved to semantic `secondary` — it was painting `#64748B` on `#F1F5F9`, 4.34:1, one of ISS#142's own failures.

## Testing

- `bundle exec rubocop` — 161 files, **0 offenses**
- `bundle exec rspec` — **1285 examples, 0 failures** (baseline 1134), including browser feature specs against a real compiled bundle and the 145-scenario preview sweep

**Every load-bearing guard was watched RED against a real mutation, then reverted:** a frozen colour reintroduced; a *named* colour (`red`) in a dot — closing the hole Codex found in #151's guard, which rejected only hex/rgb/hsl; `opacity: 0.6` restored; a geometry survivor deleted; a semantic class moved to a wrapper; the JS re-keyed to the stale vocabulary (reddens exactly the 6 new colour examples); the dot reverted to a solid fill (reddens 10 of 30).

**The mockups' token block was verified in a browser and proven load-bearing by removing it** — MPI `#122F49`/`#D5E3F0` with it, stock Bootstrap indigo `#052C65`/`#CFE2FF` without. Nothing in CI catches this.

## Deliberately not done

- **`bin/verify-contrast-oracle` was not extended.** Codex offered either/or: extend the Sass oracle, or make the browser test exhaustive with exact painted pins. I took the second — all five semantics × both modes are pinned by value in `contrast_spec.rb`. The oracle remains avatar-only, and the PR does not cite it as evidence for the AA claim.
- **Only `TagChip` gained a colour-mode preview.** The card/row/panel shells are still opaque light, so nine "dark mode" previews would claim more dark support than this PR delivers (Codex P1-12). The preview says so explicitly.
- **Non-tag hex left alone** — `#6C757D` meta, `#2E75B6` links, `HEALTH_STATUSES`, engagement *type* colours. That is ISS#142 §3's sweep. Consequence stated honestly: in the list rows the dot adapts while other text does not.
- **`account_list_row` and `tag_input` have no catalog entry at all** (no `.md`, no mockup). Writing two from scratch inside a conversion PR is unrelated work; flagging rather than silently skipping.
- **The legacy `$mpi-tag-*` SCSS tokens are untouched** — public API, 14 declarations, zero readers. Filed as [ISS#181](https://github.com/mpimedia/mpi-design-system/issues/181).

## Honest-claims register

This converges every **`GROUPS`-backed tag renderer**. It does *not* make a category render one hue literally everywhere: the Dashboard group chart and `ListView`'s selected-group pair are deliberate caller-owned passthroughs ([ISS#172](https://github.com/mpimedia/mpi-design-system/issues/172)). The 7→5 hue collapse is unchanged and now visible on the canonical tag element — `press_festival`/`production`/`vendors` all render blue, because MPI maps `$info → $primary`. If per-category hue is load-bearing, that is #151's Option B and a designer decision.

## Reviewer attention

1. The **`currentColor` vs solid-fill split** — the headline design call, driven by measurement.
2. **`ContactCard`'s three-branch precedence** (`tag_pill_classes` / `tag_pill_styles`) — the subtlest behaviour preserved here.
3. `Badge` keeps rendering an **unstyled** badge for an unknown `tag_group:`, matching the retired helper's nil return rather than defaulting to `secondary`.
4. **`TagInput` is the only one of the nine with a consuming-app surface** (Harvest, currently adoption specs). Its chips change appearance — an accessibility improvement, but a visual change worth a heads-up.

## Checklist
- [x] Tests pass
- [x] Linting passes

Closes #168
Part of #147

— Claude Code (Fable 5)
